### PR TITLE
docs(readme): clarify tap-first brew install quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ Install
 
 ```bash
 # macOS
+brew tap davidahmann/tap
 brew install gait
+# or: brew install davidahmann/tap/gait
 
 # Linux / Windows
 # download binary from GitHub Releases:
@@ -42,7 +44,7 @@ gait demo
 Verify
 
 ```bash
-gait verify ./gait-out/runpack_run_demo.zip
+gait verify run_demo
 ```
 
 Install details: [`docs/install.md`](docs/install.md) and [`docs/homebrew.md`](docs/homebrew.md)


### PR DESCRIPTION
## Summary

## Testing

- [ ] `make fmt`
- [ ] `make lint`
- [ ] `make test`

## Hardening Review

- [ ] Failure classification impact reviewed (`error_category`, `error_code`, retryability)
- [ ] Exit code contract impact reviewed (no accidental contract break)
- [ ] Deterministic output impact reviewed (`--json`, artifacts, golden fixtures)
- [ ] Security/privacy impact reviewed (secrets redaction, key handling, fail-closed behavior)

## Operational Notes

- [ ] User-facing docs updated where behavior changed (`README.md`, `docs/hardening/*`, runbooks)
- [ ] If agent behavior touched production-like paths, attached runpack evidence (`If your agent touched prod, attach the runpack.`)
- [ ] Included ticket footer evidence line (`gait run receipt --from <run_id|path>`)
- [ ] For new/expanded official integration lane proposals, attached `gait-out/integration_lane_scorecard.json` evidence and decision outcome
