### PR TITLE
Add report top risk ranking command

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Gait keeps the contract deterministic and offline-first:
 
 - runpack: signed artifact per run (`gait verify`, `gait run replay`, `gait run diff`)
 - regress: convert incidents into CI checks (`gait regress init`, `gait regress run`)
+- report top: rank highest-risk actions from runpacks/traces offline (`gait report top`)
 - optional gate: enforce policy and approvals at tool-call time (`gait gate eval`)
 
 If your agent touched production, attach the runpack.
@@ -126,6 +127,14 @@ Deterministic failure contract:
 
 Template workflow: [`.github/workflows/adoption-regress-template.yml`](.github/workflows/adoption-regress-template.yml)
 Drop-in action: [`.github/actions/gait-regress/README.md`](.github/actions/gait-regress/README.md)
+
+## Triage Top Risks Fast
+
+```bash
+gait report top --runs ./gait-out --traces ./gait-out --limit 5
+```
+
+`gait report top` ranks the highest-risk actions deterministically by tool class and blast radius, then writes `./gait-out/report_top_actions.json`.
 
 ## Optional: Enforce At The Tool Boundary
 
@@ -218,6 +227,7 @@ gait demo
 gait verify <run_id|path>
 gait run inspect --from <run_id|path>
 gait regress bootstrap --from <run_id|path>
+gait report top --runs <csv|run_id|dir> [--traces <csv|dir>]
 gait gate eval --policy <policy.yaml> --intent <intent.json>
 gait policy test <policy.yaml> <intent_fixture.json>
 gait doctor --json

--- a/cmd/gait/adoption_test.go
+++ b/cmd/gait/adoption_test.go
@@ -222,6 +222,7 @@ func TestNormalizeAdoptionCommandVariants(t *testing.T) {
 		{arguments: []string{"gait", "--version"}, expected: "version"},
 		{arguments: []string{"gait", "regress", "run"}, expected: "regress run"},
 		{arguments: []string{"gait", "keys", "verify"}, expected: "keys verify"},
+		{arguments: []string{"gait", "report", "top"}, expected: "report top"},
 		{arguments: []string{"gait", "doctor", "adoption"}, expected: "doctor adoption"},
 		{arguments: []string{"gait", "doctor", "--json"}, expected: "doctor"},
 		{arguments: []string{"gait", "--explain"}, expected: "explain"},

--- a/cmd/gait/main.go
+++ b/cmd/gait/main.go
@@ -82,6 +82,8 @@ func runDispatch(arguments []string) int {
 		return runRegress(arguments[2:])
 	case "run":
 		return runCommand(arguments[2:])
+	case "report":
+		return runReport(arguments[2:])
 	case "scout":
 		return runScout(arguments[2:])
 	case "guard":
@@ -123,7 +125,7 @@ func normalizeAdoptionCommand(arguments []string) string {
 		return "version"
 	case "--explain":
 		return "explain"
-	case "gate", "policy", "keys", "trace", "regress", "run", "scout", "guard", "incident", "registry", "mcp", "doctor", "delegate", "ui":
+	case "gate", "policy", "keys", "trace", "regress", "run", "report", "scout", "guard", "incident", "registry", "mcp", "doctor", "delegate", "ui":
 		if len(arguments) > 2 {
 			subcommand := strings.TrimSpace(arguments[2])
 			if subcommand != "" && !strings.HasPrefix(subcommand, "-") {

--- a/cmd/gait/main_test.go
+++ b/cmd/gait/main_test.go
@@ -100,6 +100,9 @@ func TestRunDispatch(t *testing.T) {
 	if code := run([]string{"gait", "run", "receipt", "--help"}); code != exitOK {
 		t.Fatalf("run receipt help: expected %d got %d", exitOK, code)
 	}
+	if code := run([]string{"gait", "report", "top", "--help"}); code != exitOK {
+		t.Fatalf("run report top help: expected %d got %d", exitOK, code)
+	}
 	if code := run([]string{"gait", "scout", "snapshot", "--help"}); code != exitOK {
 		t.Fatalf("run scout snapshot help: expected %d got %d", exitOK, code)
 	}

--- a/cmd/gait/report.go
+++ b/cmd/gait/report.go
@@ -1,0 +1,302 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/davidahmann/gait/core/scout"
+)
+
+type reportTopOutput struct {
+	OK          bool                    `json:"ok"`
+	OutputPath  string                  `json:"output_path,omitempty"`
+	RunCount    int                     `json:"run_count,omitempty"`
+	TraceCount  int                     `json:"trace_count,omitempty"`
+	ActionCount int                     `json:"action_count,omitempty"`
+	TopActions  int                     `json:"top_actions,omitempty"`
+	Report      *scout.TopActionsReport `json:"report,omitempty"`
+	Error       string                  `json:"error,omitempty"`
+}
+
+func runReport(arguments []string) int {
+	if hasExplainFlag(arguments) {
+		return writeExplain("Rank the highest-risk actions from runpacks/traces and emit a deterministic offline triage report.")
+	}
+	if len(arguments) == 0 {
+		printReportUsage()
+		return exitInvalidInput
+	}
+	switch arguments[0] {
+	case "top":
+		return runReportTop(arguments[1:])
+	default:
+		printReportUsage()
+		return exitInvalidInput
+	}
+}
+
+func runReportTop(arguments []string) int {
+	if hasExplainFlag(arguments) {
+		return writeExplain("Rank top risky actions deterministically by tool class and blast radius from runpack and trace artifacts.")
+	}
+	arguments = reorderInterspersedFlags(arguments, map[string]bool{
+		"runs":   true,
+		"traces": true,
+		"limit":  true,
+		"out":    true,
+	})
+	flagSet := flag.NewFlagSet("report-top", flag.ContinueOnError)
+	flagSet.SetOutput(io.Discard)
+
+	var runsCSV string
+	var tracesCSV string
+	var limit int
+	var outPath string
+	var jsonOutput bool
+	var helpFlag bool
+
+	flagSet.StringVar(&runsCSV, "runs", "", "comma-separated runpack paths, run IDs, or directories")
+	flagSet.StringVar(&tracesCSV, "traces", "", "comma-separated trace paths or directories")
+	flagSet.IntVar(&limit, "limit", 5, "maximum number of top actions to emit (1-20)")
+	flagSet.StringVar(&outPath, "out", "", "path to write top actions report JSON")
+	flagSet.BoolVar(&jsonOutput, "json", false, "emit JSON output")
+	flagSet.BoolVar(&helpFlag, "help", false, "show help")
+
+	if err := flagSet.Parse(arguments); err != nil {
+		return writeReportTopOutput(jsonOutput, reportTopOutput{OK: false, Error: err.Error()}, exitCodeForError(err, exitInvalidInput))
+	}
+	if helpFlag {
+		printReportTopUsage()
+		return exitOK
+	}
+	if limit < 1 {
+		return writeReportTopOutput(jsonOutput, reportTopOutput{OK: false, Error: "--limit must be >= 1"}, exitInvalidInput)
+	}
+
+	runSources := parseCSVList(runsCSV)
+	runSources = append(runSources, flagSet.Args()...)
+	traceSources := parseCSVList(tracesCSV)
+	if len(runSources) == 0 && len(traceSources) == 0 {
+		return writeReportTopOutput(jsonOutput, reportTopOutput{OK: false, Error: "missing --runs and/or --traces sources"}, exitInvalidInput)
+	}
+
+	runpackPaths, err := resolveReportRunpackPaths(runSources)
+	if err != nil {
+		return writeReportTopOutput(jsonOutput, reportTopOutput{OK: false, Error: err.Error()}, exitCodeForError(err, exitInvalidInput))
+	}
+	tracePaths, err := resolveReportTracePaths(traceSources)
+	if err != nil {
+		return writeReportTopOutput(jsonOutput, reportTopOutput{OK: false, Error: err.Error()}, exitCodeForError(err, exitInvalidInput))
+	}
+	if len(runpackPaths) == 0 && len(tracePaths) == 0 {
+		return writeReportTopOutput(jsonOutput, reportTopOutput{OK: false, Error: "no runpack or trace artifacts found in provided sources"}, exitInvalidInput)
+	}
+
+	report, err := scout.BuildTopActionsReport(scout.TopActionsInput{
+		RunpackPaths: runpackPaths,
+		TracePaths:   tracePaths,
+		Limit:        limit,
+	}, scout.TopActionsOptions{
+		ProducerVersion: version,
+	})
+	if err != nil {
+		return writeReportTopOutput(jsonOutput, reportTopOutput{OK: false, Error: err.Error()}, exitCodeForError(err, exitInvalidInput))
+	}
+	if strings.TrimSpace(outPath) == "" {
+		outPath = "./gait-out/report_top_actions.json"
+	}
+	if err := writeJSONFile(outPath, report); err != nil {
+		return writeReportTopOutput(jsonOutput, reportTopOutput{OK: false, Error: err.Error()}, exitCodeForError(err, exitInvalidInput))
+	}
+
+	return writeReportTopOutput(jsonOutput, reportTopOutput{
+		OK:          true,
+		OutputPath:  outPath,
+		RunCount:    report.RunCount,
+		TraceCount:  report.TraceCount,
+		ActionCount: report.ActionCount,
+		TopActions:  len(report.TopActions),
+		Report:      &report,
+	}, exitOK)
+}
+
+func resolveReportRunpackPaths(sources []string) ([]string, error) {
+	resolved := make([]string, 0, len(sources))
+	for _, source := range sources {
+		trimmed := strings.TrimSpace(source)
+		if trimmed == "" {
+			continue
+		}
+		sanitized, err := sanitizeReportInputPath(trimmed)
+		if err != nil {
+			return nil, fmt.Errorf("invalid run source %q: %w", trimmed, err)
+		}
+		info, statErr := os.Stat(sanitized)
+		if statErr == nil {
+			if info.IsDir() {
+				collected, err := collectRunpackPathsFromDir(sanitized)
+				if err != nil {
+					return nil, err
+				}
+				resolved = append(resolved, collected...)
+			} else {
+				resolved = append(resolved, sanitized)
+			}
+			continue
+		}
+		if !os.IsNotExist(statErr) {
+			return nil, fmt.Errorf("inspect run source %s: %w", sanitized, statErr)
+		}
+		if looksLikePath(trimmed) {
+			return nil, fmt.Errorf("run source not found: %s", trimmed)
+		}
+		runpackPath, err := resolveRunpackPath(trimmed)
+		if err != nil {
+			return nil, err
+		}
+		resolved = append(resolved, runpackPath)
+	}
+	return uniqueSortedStrings(resolved), nil
+}
+
+func resolveReportTracePaths(sources []string) ([]string, error) {
+	resolved := make([]string, 0, len(sources))
+	for _, source := range sources {
+		trimmed := strings.TrimSpace(source)
+		if trimmed == "" {
+			continue
+		}
+		sanitized, err := sanitizeReportInputPath(trimmed)
+		if err != nil {
+			return nil, fmt.Errorf("invalid trace source %q: %w", trimmed, err)
+		}
+		info, statErr := os.Stat(sanitized)
+		if statErr != nil {
+			if os.IsNotExist(statErr) {
+				return nil, fmt.Errorf("trace source not found: %s", trimmed)
+			}
+			return nil, fmt.Errorf("inspect trace source %s: %w", sanitized, statErr)
+		}
+		if info.IsDir() {
+			collected, err := collectTracePathsFromDir(sanitized)
+			if err != nil {
+				return nil, err
+			}
+			resolved = append(resolved, collected...)
+			continue
+		}
+		if !strings.HasSuffix(strings.ToLower(sanitized), ".json") {
+			return nil, fmt.Errorf("trace source must be a .json file or directory: %s", sanitized)
+		}
+		resolved = append(resolved, sanitized)
+	}
+	return uniqueSortedStrings(resolved), nil
+}
+
+func collectRunpackPathsFromDir(dir string) ([]string, error) {
+	paths := make([]string, 0, 8)
+	err := filepath.WalkDir(dir, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		base := strings.ToLower(filepath.Base(path))
+		if strings.HasPrefix(base, "runpack_") && strings.HasSuffix(base, ".zip") {
+			paths = append(paths, filepath.Clean(path))
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("walk runpack directory %s: %w", dir, err)
+	}
+	return uniqueSortedStrings(paths), nil
+}
+
+func collectTracePathsFromDir(dir string) ([]string, error) {
+	paths := make([]string, 0, 8)
+	err := filepath.WalkDir(dir, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		base := strings.ToLower(filepath.Base(path))
+		if strings.HasPrefix(base, "trace_") && strings.HasSuffix(base, ".json") {
+			paths = append(paths, filepath.Clean(path))
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("walk trace directory %s: %w", dir, err)
+	}
+	return uniqueSortedStrings(paths), nil
+}
+
+func sanitizeReportInputPath(path string) (string, error) {
+	trimmed := strings.TrimSpace(path)
+	if trimmed == "" {
+		return "", fmt.Errorf("path is required")
+	}
+	cleaned := filepath.Clean(trimmed)
+	if cleaned == "." || cleaned == string(filepath.Separator) {
+		return "", fmt.Errorf("path is required")
+	}
+	if filepath.IsLocal(cleaned) || filepath.IsAbs(cleaned) {
+		return cleaned, nil
+	}
+	if volume := filepath.VolumeName(cleaned); volume != "" && strings.HasPrefix(cleaned, volume+string(filepath.Separator)) {
+		return cleaned, nil
+	}
+	return "", fmt.Errorf("path must be local relative or absolute")
+}
+
+func writeReportTopOutput(jsonOutput bool, output reportTopOutput, exitCode int) int {
+	if jsonOutput {
+		return writeJSONOutput(output, exitCode)
+	}
+	if output.OK {
+		fmt.Printf("report top ok: runs=%d traces=%d actions=%d top=%d\n", output.RunCount, output.TraceCount, output.ActionCount, output.TopActions)
+		fmt.Printf("output: %s\n", output.OutputPath)
+		if output.Report != nil {
+			for _, action := range output.Report.TopActions {
+				verdict := action.Verdict
+				if verdict == "" {
+					verdict = "n/a"
+				}
+				fmt.Printf(
+					"%d. score=%d class=%s blast=%d tool=%s run=%s verdict=%s source=%s\n",
+					action.Rank,
+					action.Score,
+					action.ToolClass,
+					action.BlastRadius,
+					action.ToolName,
+					action.RunID,
+					verdict,
+					action.SourceArtifact,
+				)
+			}
+		}
+		return exitCode
+	}
+	fmt.Printf("report top error: %s\n", output.Error)
+	return exitCode
+}
+
+func printReportUsage() {
+	fmt.Println("Usage:")
+	fmt.Println("  gait report top --runs <csv|run_id|dir> [--traces <csv|dir>] [--limit <n>] [--out <report.json>] [--json] [--explain]")
+}
+
+func printReportTopUsage() {
+	fmt.Println("Usage:")
+	fmt.Println("  gait report top --runs <csv|run_id|dir> [--traces <csv|dir>] [--limit <n>] [--out <report.json>] [--json] [--explain]")
+	fmt.Println("  gait report top <run_id|runpack_path|runpack_dir> [--traces <csv|dir>] [--limit <n>] [--out <report.json>] [--json] [--explain]")
+}

--- a/cmd/gait/report_test.go
+++ b/cmd/gait/report_test.go
@@ -1,0 +1,172 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	schemagate "github.com/davidahmann/gait/core/schema/v1/gate"
+	"github.com/davidahmann/gait/core/scout"
+)
+
+func TestRunReportTopJSONFromRunIDAndTraceDir(t *testing.T) {
+	workDir := t.TempDir()
+	withWorkingDir(t, workDir)
+
+	if code := runDemo([]string{"--json"}); code != exitOK {
+		t.Fatalf("runDemo expected %d got %d", exitOK, code)
+	}
+
+	traceDir := filepath.Join(workDir, "traces")
+	if err := os.MkdirAll(traceDir, 0o750); err != nil {
+		t.Fatalf("mkdir traces dir: %v", err)
+	}
+	tracePath := filepath.Join(traceDir, "trace_run_demo.json")
+	record := schemagate.TraceRecord{
+		SchemaID:        "gait.gate.trace",
+		SchemaVersion:   "1.0.0",
+		CreatedAt:       time.Date(2026, time.February, 13, 0, 0, 0, 0, time.UTC),
+		ProducerVersion: "test",
+		TraceID:         "trace_001",
+		CorrelationID:   "run_demo",
+		ToolName:        "tool.delete_user",
+		ArgsDigest:      "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		IntentDigest:    "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+		PolicyDigest:    "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+		Verdict:         "block",
+		Violations:      []string{"prompt_injection_egress_attempt"},
+	}
+	rawTrace, err := json.Marshal(record)
+	if err != nil {
+		t.Fatalf("marshal trace fixture: %v", err)
+	}
+	if err := os.WriteFile(tracePath, rawTrace, 0o600); err != nil {
+		t.Fatalf("write trace fixture: %v", err)
+	}
+
+	var code int
+	raw := captureStdout(t, func() {
+		code = runReportTop([]string{
+			"--runs", "run_demo",
+			"--traces", traceDir,
+			"--limit", "3",
+			"--json",
+		})
+	})
+	if code != exitOK {
+		t.Fatalf("runReportTop expected %d got %d", exitOK, code)
+	}
+
+	var output reportTopOutput
+	if err := json.Unmarshal([]byte(raw), &output); err != nil {
+		t.Fatalf("unmarshal report top output: %v", err)
+	}
+	if !output.OK {
+		t.Fatalf("expected report top output ok=true, got error=%s", output.Error)
+	}
+	if output.Report == nil {
+		t.Fatalf("expected embedded report payload")
+	}
+	if output.TopActions == 0 || len(output.Report.TopActions) == 0 {
+		t.Fatalf("expected non-empty top actions")
+	}
+	if output.TopActions > 3 {
+		t.Fatalf("expected top actions to honor limit, got %d", output.TopActions)
+	}
+	if _, err := os.Stat(output.OutputPath); err != nil {
+		t.Fatalf("expected output report to be written: %v", err)
+	}
+}
+
+func TestRunReportTopFromRunpackDirectory(t *testing.T) {
+	workDir := t.TempDir()
+	withWorkingDir(t, workDir)
+
+	if code := runDemo([]string{"--json"}); code != exitOK {
+		t.Fatalf("runDemo expected %d got %d", exitOK, code)
+	}
+
+	var code int
+	raw := captureStdout(t, func() {
+		code = runReportTop([]string{
+			"--runs", filepath.Join(workDir, "gait-out"),
+			"--json",
+		})
+	})
+	if code != exitOK {
+		t.Fatalf("runReportTop expected %d got %d", exitOK, code)
+	}
+
+	var output reportTopOutput
+	if err := json.Unmarshal([]byte(raw), &output); err != nil {
+		t.Fatalf("unmarshal report top output: %v", err)
+	}
+	if !output.OK {
+		t.Fatalf("expected report top output ok=true, got error=%s", output.Error)
+	}
+	if output.ActionCount == 0 {
+		t.Fatalf("expected non-zero action count")
+	}
+}
+
+func TestRunReportTopErrors(t *testing.T) {
+	if code := runReportTop([]string{"--json"}); code != exitInvalidInput {
+		t.Fatalf("runReportTop missing inputs expected %d got %d", exitInvalidInput, code)
+	}
+	if code := runReportTop([]string{"--runs", "../missing", "--json"}); code != exitInvalidInput {
+		t.Fatalf("runReportTop invalid path expected %d got %d", exitInvalidInput, code)
+	}
+}
+
+func TestRunReportUsageAndTextOutput(t *testing.T) {
+	if code := runReport([]string{}); code != exitInvalidInput {
+		t.Fatalf("runReport missing subcommand expected %d got %d", exitInvalidInput, code)
+	}
+	if code := runReport([]string{"--explain"}); code != exitOK {
+		t.Fatalf("runReport explain expected %d got %d", exitOK, code)
+	}
+
+	out := captureStdout(t, func() {
+		code := writeReportTopOutput(false, reportTopOutput{
+			OK:          true,
+			OutputPath:  "./gait-out/report_top_actions.json",
+			RunCount:    1,
+			TraceCount:  1,
+			ActionCount: 2,
+			TopActions:  1,
+			Report: &scout.TopActionsReport{
+				TopActions: []scout.TopAction{{
+					Rank:           1,
+					Score:          350,
+					ToolClass:      "destructive",
+					BlastRadius:    3,
+					ToolName:       "tool.delete",
+					RunID:          "run_demo",
+					SourceArtifact: "trace_run_demo.json",
+				}},
+			},
+		}, exitOK)
+		if code != exitOK {
+			t.Fatalf("writeReportTopOutput expected %d got %d", exitOK, code)
+		}
+	})
+	if !strings.Contains(out, "report top ok") {
+		t.Fatalf("expected success text output, got: %s", out)
+	}
+
+	errOut := captureStdout(t, func() {
+		code := writeReportTopOutput(false, reportTopOutput{
+			OK:    false,
+			Error: "boom",
+		}, exitInvalidInput)
+		if code != exitInvalidInput {
+			t.Fatalf("writeReportTopOutput error expected %d got %d", exitInvalidInput, code)
+		}
+	})
+	if !strings.Contains(errOut, "report top error: boom") {
+		t.Fatalf("expected error text output, got: %s", errOut)
+	}
+}

--- a/cmd/gait/verify.go
+++ b/cmd/gait/verify.go
@@ -607,6 +607,7 @@ func printUsage() {
 	fmt.Println("  gait run replay <run_id|path> [--json] [--real-tools --unsafe-real-tools --allow-tools <csv> --unsafe-real-tools-env <VAR>] [--explain]")
 	fmt.Println("  gait run diff <left> <right> [--json] [--explain]")
 	fmt.Println("  gait run reduce --from <run_id|path> [--predicate missing_result|non_ok_status] [--json] [--explain]")
+	fmt.Println("  gait report top --runs <csv|run_id|dir> [--traces <csv|dir>] [--limit <n>] [--json] [--explain]")
 	fmt.Println("  gait scout snapshot [--roots <csv>] [--policy <csv>] [--json] [--explain]")
 	fmt.Println("  gait scout diff <left_snapshot.json> <right_snapshot.json> [--json] [--explain]")
 	fmt.Println("  gait guard pack --run <run_id|path> [--json] [--explain]")

--- a/core/scout/top_actions.go
+++ b/core/scout/top_actions.go
@@ -1,0 +1,314 @@
+package scout
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/davidahmann/gait/core/runpack"
+	schemagate "github.com/davidahmann/gait/core/schema/v1/gate"
+	schemarunpack "github.com/davidahmann/gait/core/schema/v1/runpack"
+)
+
+const (
+	topActionsReportSchemaID      = "gait.report.top_actions"
+	topActionsReportSchemaVersion = "1.0.0"
+	defaultTopActionsLimit        = 5
+	maxTopActionsLimit            = 20
+)
+
+type TopActionsInput struct {
+	RunpackPaths []string
+	TracePaths   []string
+	Limit        int
+}
+
+type TopActionsOptions struct {
+	ProducerVersion string
+	Now             time.Time
+}
+
+type TopAction struct {
+	Rank           int      `json:"rank"`
+	Score          int      `json:"score"`
+	ToolClass      string   `json:"tool_class"`
+	BlastRadius    int      `json:"blast_radius"`
+	RunID          string   `json:"run_id"`
+	IntentID       string   `json:"intent_id,omitempty"`
+	IntentDigest   string   `json:"intent_digest,omitempty"`
+	TraceID        string   `json:"trace_id,omitempty"`
+	ToolName       string   `json:"tool_name"`
+	Verdict        string   `json:"verdict,omitempty"`
+	ReasonCodes    []string `json:"reason_codes,omitempty"`
+	SourceType     string   `json:"source_type"`
+	SourceArtifact string   `json:"source_artifact"`
+}
+
+type TopActionsReport struct {
+	SchemaID        string      `json:"schema_id"`
+	SchemaVersion   string      `json:"schema_version"`
+	CreatedAt       time.Time   `json:"created_at"`
+	ProducerVersion string      `json:"producer_version"`
+	RunCount        int         `json:"run_count"`
+	TraceCount      int         `json:"trace_count"`
+	ActionCount     int         `json:"action_count"`
+	TopActions      []TopAction `json:"top_actions"`
+}
+
+type topActionCandidate struct {
+	Action         TopAction
+	toolClassScore int
+}
+
+func BuildTopActionsReport(input TopActionsInput, opts TopActionsOptions) (TopActionsReport, error) {
+	runpackPaths := uniqueSorted(input.RunpackPaths)
+	tracePaths := uniqueSorted(input.TracePaths)
+	if len(runpackPaths) == 0 && len(tracePaths) == 0 {
+		return TopActionsReport{}, fmt.Errorf("at least one runpack or trace path is required")
+	}
+
+	limit := input.Limit
+	if limit <= 0 {
+		limit = defaultTopActionsLimit
+	}
+	if limit > maxTopActionsLimit {
+		limit = maxTopActionsLimit
+	}
+
+	candidates := make([]topActionCandidate, 0, len(runpackPaths)+len(tracePaths))
+	runIDs := map[string]struct{}{}
+
+	for _, runpackPath := range runpackPaths {
+		loadedRunpack, err := runpack.ReadRunpack(runpackPath)
+		if err != nil {
+			return TopActionsReport{}, fmt.Errorf("read runpack %s: %w", runpackPath, err)
+		}
+		runID := strings.TrimSpace(loadedRunpack.Run.RunID)
+		if runID == "" {
+			return TopActionsReport{}, fmt.Errorf("runpack %s missing run_id", runpackPath)
+		}
+		runIDs[runID] = struct{}{}
+
+		blastRadius := topActionBlastRadiusFromReceipts(loadedRunpack.Refs.Receipts)
+		resultsByIntent := map[string]string{}
+		for _, result := range loadedRunpack.Results {
+			intentID := strings.TrimSpace(result.IntentID)
+			if intentID == "" {
+				continue
+			}
+			resultsByIntent[intentID] = normalizeIdentifier(strings.ToLower(strings.TrimSpace(result.Status)))
+		}
+
+		for _, intent := range loadedRunpack.Intents {
+			toolName := strings.TrimSpace(intent.ToolName)
+			if toolName == "" {
+				continue
+			}
+			intentID := strings.TrimSpace(intent.IntentID)
+			resultStatus := resultsByIntent[intentID]
+			reasonCodes := topActionReasonCodesFromResultStatus(resultStatus)
+			toolClass := classifyToolClass(toolName)
+			toolClassScore := toolClassScore(toolClass)
+			score := topActionScore(toolClassScore, blastRadius, "", reasonCodes)
+			candidates = append(candidates, topActionCandidate{
+				Action: TopAction{
+					Score:          score,
+					ToolClass:      toolClass,
+					BlastRadius:    blastRadius,
+					RunID:          runID,
+					IntentID:       intentID,
+					ToolName:       toolName,
+					ReasonCodes:    reasonCodes,
+					SourceType:     "runpack",
+					SourceArtifact: runpackPath,
+				},
+				toolClassScore: toolClassScore,
+			})
+		}
+	}
+
+	for _, tracePath := range tracePaths {
+		// #nosec G304 -- trace path list is explicit local user input validated by caller.
+		raw, err := os.ReadFile(tracePath)
+		if err != nil {
+			return TopActionsReport{}, fmt.Errorf("read trace %s: %w", tracePath, err)
+		}
+		var trace schemagate.TraceRecord
+		if err := json.Unmarshal(raw, &trace); err != nil {
+			return TopActionsReport{}, fmt.Errorf("parse trace %s: %w", tracePath, err)
+		}
+
+		runID := runIDFromTrace(trace)
+		if runID == "" {
+			runID = "unknown"
+		}
+		runIDs[runID] = struct{}{}
+
+		toolName := strings.TrimSpace(trace.ToolName)
+		if toolName == "" {
+			continue
+		}
+		toolClass := classifyToolClass(toolName)
+		toolClassScore := toolClassScore(toolClass)
+		verdict := normalizeIdentifier(strings.ToLower(strings.TrimSpace(trace.Verdict)))
+		reasonCodes := topActionReasonCodesFromTrace(trace, verdict)
+		blastRadius := topActionBlastRadiusFromTrace(trace)
+		score := topActionScore(toolClassScore, blastRadius, verdict, reasonCodes)
+		candidates = append(candidates, topActionCandidate{
+			Action: TopAction{
+				Score:          score,
+				ToolClass:      toolClass,
+				BlastRadius:    blastRadius,
+				RunID:          runID,
+				IntentDigest:   strings.ToLower(strings.TrimSpace(trace.IntentDigest)),
+				TraceID:        strings.TrimSpace(trace.TraceID),
+				ToolName:       toolName,
+				Verdict:        verdict,
+				ReasonCodes:    reasonCodes,
+				SourceType:     "trace",
+				SourceArtifact: tracePath,
+			},
+			toolClassScore: toolClassScore,
+		})
+	}
+
+	if len(candidates) == 0 {
+		return TopActionsReport{}, fmt.Errorf("no actions found in provided runpack/trace sources")
+	}
+
+	sort.Slice(candidates, func(i, j int) bool {
+		if candidates[i].Action.Score != candidates[j].Action.Score {
+			return candidates[i].Action.Score > candidates[j].Action.Score
+		}
+		if candidates[i].toolClassScore != candidates[j].toolClassScore {
+			return candidates[i].toolClassScore > candidates[j].toolClassScore
+		}
+		if candidates[i].Action.BlastRadius != candidates[j].Action.BlastRadius {
+			return candidates[i].Action.BlastRadius > candidates[j].Action.BlastRadius
+		}
+		if candidates[i].Action.RunID != candidates[j].Action.RunID {
+			return candidates[i].Action.RunID < candidates[j].Action.RunID
+		}
+		if candidates[i].Action.IntentID != candidates[j].Action.IntentID {
+			return candidates[i].Action.IntentID < candidates[j].Action.IntentID
+		}
+		if candidates[i].Action.IntentDigest != candidates[j].Action.IntentDigest {
+			return candidates[i].Action.IntentDigest < candidates[j].Action.IntentDigest
+		}
+		if candidates[i].Action.TraceID != candidates[j].Action.TraceID {
+			return candidates[i].Action.TraceID < candidates[j].Action.TraceID
+		}
+		if candidates[i].Action.ToolName != candidates[j].Action.ToolName {
+			return candidates[i].Action.ToolName < candidates[j].Action.ToolName
+		}
+		if candidates[i].Action.SourceType != candidates[j].Action.SourceType {
+			return candidates[i].Action.SourceType < candidates[j].Action.SourceType
+		}
+		return candidates[i].Action.SourceArtifact < candidates[j].Action.SourceArtifact
+	})
+
+	if limit > len(candidates) {
+		limit = len(candidates)
+	}
+	topActions := make([]TopAction, 0, limit)
+	for index := 0; index < limit; index++ {
+		item := candidates[index].Action
+		item.Rank = index + 1
+		topActions = append(topActions, item)
+	}
+
+	return TopActionsReport{
+		SchemaID:        topActionsReportSchemaID,
+		SchemaVersion:   topActionsReportSchemaVersion,
+		CreatedAt:       normalizeSignalNow(opts.Now),
+		ProducerVersion: normalizeProducerVersion(opts.ProducerVersion),
+		RunCount:        len(runIDs),
+		TraceCount:      len(tracePaths),
+		ActionCount:     len(candidates),
+		TopActions:      topActions,
+	}, nil
+}
+
+func topActionBlastRadiusFromReceipts(receipts []schemarunpack.RefReceipt) int {
+	if len(receipts) == 0 {
+		return 1
+	}
+	targetSystems := make([]string, 0, len(receipts))
+	for _, receipt := range receipts {
+		targetSystems = append(targetSystems, normalizeTargetSystem(receipt.SourceType, receipt.SourceLocator))
+	}
+	return targetSensitivityScore(uniqueSorted(targetSystems))
+}
+
+func topActionBlastRadiusFromTrace(trace schemagate.TraceRecord) int {
+	payload := strings.ToLower(strings.Join(append([]string{trace.ToolName}, trace.Violations...), " "))
+	if strings.Contains(payload, "prod") ||
+		strings.Contains(payload, "payment") ||
+		strings.Contains(payload, "finance") ||
+		strings.Contains(payload, "customer") ||
+		strings.Contains(payload, "pii") ||
+		strings.Contains(payload, "ssn") ||
+		strings.Contains(payload, "delete") ||
+		strings.Contains(payload, "drop") ||
+		strings.Contains(payload, "destroy") {
+		return 3
+	}
+	if strings.Contains(payload, "internal") ||
+		strings.Contains(payload, "staging") ||
+		strings.Contains(payload, "queue") {
+		return 2
+	}
+	return 1
+}
+
+func topActionReasonCodesFromResultStatus(status string) []string {
+	if status == "" || status == "ok" || status == "success" {
+		return nil
+	}
+	return []string{"result_status_" + status}
+}
+
+func topActionReasonCodesFromTrace(trace schemagate.TraceRecord, verdict string) []string {
+	reasonCodes := make([]string, 0, len(trace.Violations)+1)
+	if verdict != "" && verdict != "allow" {
+		reasonCodes = append(reasonCodes, "trace_verdict_"+verdict)
+	}
+	for _, violation := range trace.Violations {
+		normalized := normalizeIdentifier(strings.ToLower(strings.TrimSpace(violation)))
+		if normalized == "" {
+			continue
+		}
+		reasonCodes = append(reasonCodes, "violation_"+normalized)
+	}
+	return uniqueSorted(reasonCodes)
+}
+
+func topActionScore(toolClass int, blastRadius int, verdict string, reasonCodes []string) int {
+	score := toolClass*100 + blastRadius*10
+	switch verdict {
+	case "block":
+		score += 15
+	case "require_approval":
+		score += 12
+	case "error":
+		score += 8
+	}
+	for _, reasonCode := range reasonCodes {
+		lower := strings.ToLower(reasonCode)
+		switch {
+		case strings.Contains(lower, "violation_"),
+			strings.Contains(lower, "blocked"),
+			strings.Contains(lower, "approval"),
+			strings.Contains(lower, "destructive"),
+			strings.Contains(lower, "credential"),
+			strings.Contains(lower, "prompt_injection"):
+			score += 2
+		default:
+			score++
+		}
+	}
+	return score
+}

--- a/core/scout/top_actions_test.go
+++ b/core/scout/top_actions_test.go
@@ -1,0 +1,246 @@
+package scout
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/davidahmann/gait/core/runpack"
+	schemagate "github.com/davidahmann/gait/core/schema/v1/gate"
+	schemarunpack "github.com/davidahmann/gait/core/schema/v1/runpack"
+)
+
+func TestBuildTopActionsReportDeterministic(t *testing.T) {
+	workDir := t.TempDir()
+	runHighPath := writeSignalRunpack(t, workDir, "run_high", "tool.delete_customer", "error")
+	runLowPath := writeSignalRunpack(t, workDir, "run_low", "tool.read_customer", "ok")
+	tracePath := filepath.Join(workDir, "trace_run_high.json")
+	writeTraceFixture(t, tracePath, schemagate.TraceRecord{
+		SchemaID:        "gait.gate.trace",
+		SchemaVersion:   "1.0.0",
+		CreatedAt:       time.Date(2026, time.February, 13, 0, 0, 0, 0, time.UTC),
+		ProducerVersion: "test",
+		TraceID:         "trace_001",
+		CorrelationID:   "run_high",
+		ToolName:        "tool.delete_customer",
+		ArgsDigest:      "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		IntentDigest:    "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+		PolicyDigest:    "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+		Verdict:         "block",
+		Violations:      []string{"prompt_injection_egress_attempt"},
+	})
+
+	options := TopActionsOptions{
+		ProducerVersion: "test",
+		Now:             time.Date(2026, time.February, 13, 0, 0, 0, 0, time.UTC),
+	}
+	first, err := BuildTopActionsReport(TopActionsInput{
+		RunpackPaths: []string{runHighPath, runLowPath},
+		TracePaths:   []string{tracePath},
+		Limit:        5,
+	}, options)
+	if err != nil {
+		t.Fatalf("build top actions report first: %v", err)
+	}
+	second, err := BuildTopActionsReport(TopActionsInput{
+		RunpackPaths: []string{runLowPath, runHighPath},
+		TracePaths:   []string{tracePath},
+		Limit:        5,
+	}, options)
+	if err != nil {
+		t.Fatalf("build top actions report second: %v", err)
+	}
+
+	firstEncoded, err := json.Marshal(first)
+	if err != nil {
+		t.Fatalf("marshal first report: %v", err)
+	}
+	secondEncoded, err := json.Marshal(second)
+	if err != nil {
+		t.Fatalf("marshal second report: %v", err)
+	}
+	if string(firstEncoded) != string(secondEncoded) {
+		t.Fatalf("expected deterministic report output")
+	}
+
+	if first.SchemaID != topActionsReportSchemaID {
+		t.Fatalf("unexpected schema id: %s", first.SchemaID)
+	}
+	if first.ActionCount == 0 {
+		t.Fatalf("expected non-zero action count")
+	}
+	if len(first.TopActions) == 0 {
+		t.Fatalf("expected non-empty top actions")
+	}
+	if first.TopActions[0].ToolClass != "destructive" {
+		t.Fatalf("expected destructive tool class at rank 1, got %s", first.TopActions[0].ToolClass)
+	}
+	if first.TopActions[0].Score < first.TopActions[len(first.TopActions)-1].Score {
+		t.Fatalf("expected descending score order")
+	}
+}
+
+func TestBuildTopActionsReportTraceOnly(t *testing.T) {
+	workDir := t.TempDir()
+	tracePath := filepath.Join(workDir, "trace_only.json")
+	writeTraceFixture(t, tracePath, schemagate.TraceRecord{
+		SchemaID:        "gait.gate.trace",
+		SchemaVersion:   "1.0.0",
+		CreatedAt:       time.Date(2026, time.February, 13, 0, 0, 0, 0, time.UTC),
+		ProducerVersion: "test",
+		TraceID:         "trace_run_trace_only",
+		CorrelationID:   "run_trace_only",
+		ToolName:        "tool.write_customer",
+		ArgsDigest:      "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		IntentDigest:    "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+		PolicyDigest:    "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+		Verdict:         "require_approval",
+		Violations:      []string{"approval_missing"},
+	})
+
+	report, err := BuildTopActionsReport(TopActionsInput{
+		TracePaths: []string{tracePath},
+		Limit:      1,
+	}, TopActionsOptions{
+		ProducerVersion: "test",
+		Now:             time.Date(2026, time.February, 13, 0, 0, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("build top actions report trace-only: %v", err)
+	}
+	if report.RunCount != 1 {
+		t.Fatalf("expected run_count=1 got %d", report.RunCount)
+	}
+	if report.TraceCount != 1 {
+		t.Fatalf("expected trace_count=1 got %d", report.TraceCount)
+	}
+	if len(report.TopActions) != 1 {
+		t.Fatalf("expected one top action got %d", len(report.TopActions))
+	}
+	action := report.TopActions[0]
+	if action.SourceType != "trace" {
+		t.Fatalf("expected trace source type, got %s", action.SourceType)
+	}
+	if action.Verdict != "require_approval" {
+		t.Fatalf("expected require_approval verdict, got %s", action.Verdict)
+	}
+}
+
+func TestBuildTopActionsReportErrors(t *testing.T) {
+	if _, err := BuildTopActionsReport(TopActionsInput{}, TopActionsOptions{}); err == nil {
+		t.Fatalf("expected missing input to fail")
+	}
+	if _, err := BuildTopActionsReport(TopActionsInput{
+		RunpackPaths: []string{"missing.zip"},
+	}, TopActionsOptions{}); err == nil {
+		t.Fatalf("expected missing runpack to fail")
+	}
+
+	workDir := t.TempDir()
+	runpackPath := filepath.Join(workDir, "runpack_empty_tool.zip")
+	createdAt := time.Date(2026, time.February, 13, 0, 0, 0, 0, time.UTC)
+	if _, err := runpack.WriteRunpack(runpackPath, runpack.RecordOptions{
+		Run: schemarunpack.Run{
+			RunID:           "run_empty",
+			CreatedAt:       createdAt,
+			ProducerVersion: "test",
+		},
+		Intents: []schemarunpack.IntentRecord{{
+			IntentID:   "intent_1",
+			RunID:      "run_empty",
+			ToolName:   "",
+			ArgsDigest: strings.Repeat("a", 64),
+		}},
+		Results: []schemarunpack.ResultRecord{{
+			IntentID:     "intent_1",
+			RunID:        "run_empty",
+			Status:       "ok",
+			ResultDigest: strings.Repeat("b", 64),
+		}},
+		Refs: schemarunpack.Refs{
+			RunID:    "run_empty",
+			Receipts: []schemarunpack.RefReceipt{},
+		},
+	}); err != nil {
+		t.Fatalf("write empty-tool runpack: %v", err)
+	}
+	if _, err := BuildTopActionsReport(TopActionsInput{
+		RunpackPaths: []string{runpackPath},
+	}, TopActionsOptions{}); err == nil {
+		t.Fatalf("expected runpack with no actionable intents to fail")
+	}
+}
+
+func TestTopActionHelperBranches(t *testing.T) {
+	highTrace := schemagate.TraceRecord{ToolName: "tool.delete_prod_customer", Violations: []string{"pii_exfiltration"}}
+	if got := topActionBlastRadiusFromTrace(highTrace); got != 3 {
+		t.Fatalf("expected high blast radius 3 got %d", got)
+	}
+	mediumTrace := schemagate.TraceRecord{ToolName: "tool.write_internal_queue"}
+	if got := topActionBlastRadiusFromTrace(mediumTrace); got != 2 {
+		t.Fatalf("expected medium blast radius 2 got %d", got)
+	}
+	lowTrace := schemagate.TraceRecord{ToolName: "tool.read_public"}
+	if got := topActionBlastRadiusFromTrace(lowTrace); got != 1 {
+		t.Fatalf("expected low blast radius 1 got %d", got)
+	}
+
+	base := topActionScore(4, 3, "", nil)
+	requireApproval := topActionScore(4, 3, "require_approval", []string{"violation_policy"})
+	blocked := topActionScore(4, 3, "block", []string{"violation_policy"})
+	errored := topActionScore(4, 3, "error", []string{"result_status_error"})
+	if blocked <= requireApproval {
+		t.Fatalf("expected block score to exceed require_approval score")
+	}
+	if errored <= base {
+		t.Fatalf("expected error score to exceed base score")
+	}
+}
+
+func TestBuildTopActionsReportLimitClampAndTraceOnlyUnknownRun(t *testing.T) {
+	workDir := t.TempDir()
+	tracePath := filepath.Join(workDir, "trace_unknown.json")
+	record := schemagate.TraceRecord{
+		SchemaID:        "gait.gate.trace",
+		SchemaVersion:   "1.0.0",
+		CreatedAt:       time.Date(2026, time.February, 13, 0, 0, 0, 0, time.UTC),
+		ProducerVersion: "test",
+		TraceID:         "trace_xyz",
+		CorrelationID:   "corr_xyz",
+		ToolName:        "tool.write_internal_queue",
+		ArgsDigest:      strings.Repeat("a", 64),
+		IntentDigest:    strings.Repeat("b", 64),
+		PolicyDigest:    strings.Repeat("c", 64),
+		Verdict:         "error",
+	}
+	encoded, err := json.Marshal(record)
+	if err != nil {
+		t.Fatalf("marshal trace record: %v", err)
+	}
+	if err := os.WriteFile(tracePath, encoded, 0o600); err != nil {
+		t.Fatalf("write trace record: %v", err)
+	}
+
+	report, err := BuildTopActionsReport(TopActionsInput{
+		TracePaths: []string{tracePath},
+		Limit:      99,
+	}, TopActionsOptions{
+		ProducerVersion: "test",
+		Now:             time.Date(2026, time.February, 13, 0, 0, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("build top actions report trace-only unknown run: %v", err)
+	}
+	if report.RunCount != 1 {
+		t.Fatalf("expected run_count=1 got %d", report.RunCount)
+	}
+	if len(report.TopActions) != 1 {
+		t.Fatalf("expected clamped top action length 1 got %d", len(report.TopActions))
+	}
+	if report.TopActions[0].RunID != "unknown" {
+		t.Fatalf("expected fallback unknown run id, got %s", report.TopActions[0].RunID)
+	}
+}


### PR DESCRIPTION
## Summary

## Testing

- [ ] `make fmt`
- [ ] `make lint`
- [ ] `make test`

## Hardening Review

- [ ] Failure classification impact reviewed (`error_category`, `error_code`, retryability)
- [ ] Exit code contract impact reviewed (no accidental contract break)
- [ ] Deterministic output impact reviewed (`--json`, artifacts, golden fixtures)
- [ ] Security/privacy impact reviewed (secrets redaction, key handling, fail-closed behavior)

## Operational Notes

- [ ] User-facing docs updated where behavior changed (`README.md`, `docs/hardening/*`, runbooks)
- [ ] If agent behavior touched production-like paths, attached runpack evidence (`If your agent touched prod, attach the runpack.`)
- [ ] Included ticket footer evidence line (`gait run receipt --from <run_id|path>`)
- [ ] For new/expanded official integration lane proposals, attached `gait-out/integration_lane_scorecard.json` evidence and decision outcome
