### PR TITLE
fix: stamp release versions and validate install path versioning

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -6,6 +6,8 @@ builds:
   - id: gait
     main: ./cmd/gait
     binary: gait
+    ldflags:
+      - -s -w -X main.version={{ .Version }}
     goos:
       - linux
       - darwin

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ BENCH_REGEX := Benchmark(EvaluatePolicyTypical|VerifyZipTypical|DiffRunpacksTypi
 BENCH_OUTPUT ?= perf/bench_output.txt
 BENCH_BASELINE ?= perf/bench_baseline.json
 
-.PHONY: fmt lint lint-fast codeql test test-fast prepush prepush-full github-guardrails github-guardrails-strict test-hardening test-hardening-acceptance test-chaos test-e2e test-acceptance test-v1-6-acceptance test-v1-7-acceptance test-v1-8-acceptance test-v2-3-acceptance test-ui-acceptance test-adoption test-adapter-parity test-ecosystem-automation test-release-smoke test-install test-contracts test-intent-receipt-conformance test-ci-regress-template test-live-connectors test-skill-supply-chain test-runtime-slo test-ent-consumer-contract test-uat-local test-openclaw-skill-install test-beads-bridge openclaw-skill-install build bench bench-check bench-budgets skills-validate ecosystem-validate ecosystem-release-notes demo-90s demo-hero-gif homebrew-formula wiki-publish tool-allowlist-policy ui-build ui-sync ui-deps-check
+.PHONY: fmt lint lint-fast codeql test test-fast prepush prepush-full github-guardrails github-guardrails-strict test-hardening test-hardening-acceptance test-chaos test-e2e test-acceptance test-v1-6-acceptance test-v1-7-acceptance test-v1-8-acceptance test-v2-3-acceptance test-ui-acceptance test-adoption test-adapter-parity test-ecosystem-automation test-release-smoke test-install test-install-path-versions test-contracts test-intent-receipt-conformance test-ci-regress-template test-live-connectors test-skill-supply-chain test-runtime-slo test-ent-consumer-contract test-uat-local test-openclaw-skill-install test-beads-bridge openclaw-skill-install build bench bench-check bench-budgets skills-validate ecosystem-validate ecosystem-release-notes demo-90s demo-hero-gif homebrew-formula wiki-publish tool-allowlist-policy ui-build ui-sync ui-deps-check
 .PHONY: hooks
 .PHONY: docs-site-install docs-site-build docs-site-lint
 
@@ -137,6 +137,9 @@ test-release-smoke: build
 
 test-install: build
 	bash scripts/test_install.sh ./gait
+
+test-install-path-versions: build
+	bash scripts/test_cli_version_install_paths.sh ./gait
 
 test-contracts: build
 	bash scripts/test_contracts.sh ./gait

--- a/cmd/gait/main.go
+++ b/cmd/gait/main.go
@@ -12,7 +12,8 @@ import (
 	"github.com/davidahmann/gait/core/scout"
 )
 
-const version = "0.0.0-dev"
+// version is stamped at release time via ldflags; default stays dev for local builds.
+var version = "0.0.0-dev"
 
 type telemetryStreamHealth struct {
 	Attempts int64 `json:"attempts"`

--- a/scripts/test_cli_version_install_paths.sh
+++ b/scripts/test_cli_version_install_paths.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+if [[ $# -gt 1 ]]; then
+  echo "usage: $0 [path-to-gait-binary]" >&2
+  exit 2
+fi
+
+if [[ $# -eq 1 ]]; then
+  if [[ "$1" = /* ]]; then
+    BIN_PATH="$1"
+  else
+    BIN_PATH="$(pwd)/$1"
+  fi
+else
+  BIN_PATH="${REPO_ROOT}/gait"
+  go build -o "${BIN_PATH}" ./cmd/gait
+fi
+
+if [[ ! -x "${BIN_PATH}" ]]; then
+  echo "binary is not executable: ${BIN_PATH}" >&2
+  exit 2
+fi
+
+if ! command -v brew >/dev/null 2>&1; then
+  echo "brew is required for install-path version smoke" >&2
+  exit 2
+fi
+
+detect_os() {
+  case "$(uname -s)" in
+    Linux) echo "linux" ;;
+    Darwin) echo "darwin" ;;
+    *)
+      echo "unsupported OS for install-path version smoke: $(uname -s)" >&2
+      exit 2
+      ;;
+  esac
+}
+
+detect_arch() {
+  case "$(uname -m)" in
+    x86_64|amd64) echo "amd64" ;;
+    arm64|aarch64) echo "arm64" ;;
+    *)
+      echo "unsupported architecture for install-path version smoke: $(uname -m)" >&2
+      exit 2
+      ;;
+  esac
+}
+
+sha256_file() {
+  local path="$1"
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$path" | awk '{print $1}'
+    return
+  fi
+  shasum -a 256 "$path" | awk '{print $1}'
+}
+
+extract_version() {
+  local bin="$1"
+  "$bin" --version | awk 'NR==1{print $2}'
+}
+
+assert_version() {
+  local label="$1"
+  local bin="$2"
+  local expected="$3"
+  local got
+  got="$(extract_version "$bin")"
+  if [[ "$got" != "$expected" ]]; then
+    echo "${label}: expected version ${expected}, got ${got}" >&2
+    exit 1
+  fi
+  echo "${label}: version ${got}"
+}
+
+os="$(detect_os)"
+arch="$(detect_arch)"
+release_version_tag="v9.9.9-test"
+release_version="${release_version_tag#v}"
+
+work_dir="$(mktemp -d)"
+trap 'rm -rf "${work_dir}"' EXIT
+
+release_dir="${work_dir}/release"
+install_dir="${work_dir}/install/bin"
+mkdir -p "${release_dir}" "${install_dir}"
+
+source_bin="${work_dir}/gait-source"
+cp "${BIN_PATH}" "${source_bin}"
+chmod 0755 "${source_bin}"
+assert_version "source-build" "${source_bin}" "0.0.0-dev"
+
+release_bin="${work_dir}/gait-release"
+go build -ldflags "-X main.version=${release_version}" -o "${release_bin}" ./cmd/gait
+
+asset_arm64="gait_${release_version}_darwin_arm64.tar.gz"
+asset_amd64="gait_${release_version}_darwin_amd64.tar.gz"
+project_asset_arm64="gait-local_${release_version}_darwin_arm64.tar.gz"
+project_asset_amd64="gait-local_${release_version}_darwin_amd64.tar.gz"
+
+tmp_extract="${work_dir}/extract"
+mkdir -p "${tmp_extract}/gait" "${tmp_extract}/gait-local"
+
+cp "${release_bin}" "${tmp_extract}/gait/gait"
+cp "${release_bin}" "${tmp_extract}/gait-local/gait-local"
+
+tar -czf "${release_dir}/${asset_arm64}" -C "${tmp_extract}/gait" gait
+tar -czf "${release_dir}/${asset_amd64}" -C "${tmp_extract}/gait" gait
+tar -czf "${release_dir}/${project_asset_arm64}" -C "${tmp_extract}/gait-local" gait-local
+tar -czf "${release_dir}/${project_asset_amd64}" -C "${tmp_extract}/gait-local" gait-local
+
+{
+  printf '%s  %s\n' "$(sha256_file "${release_dir}/${asset_amd64}")" "${asset_amd64}"
+  printf '%s  %s\n' "$(sha256_file "${release_dir}/${asset_arm64}")" "${asset_arm64}"
+  printf '%s  %s\n' "$(sha256_file "${release_dir}/${project_asset_amd64}")" "${project_asset_amd64}"
+  printf '%s  %s\n' "$(sha256_file "${release_dir}/${project_asset_arm64}")" "${project_asset_arm64}"
+} > "${release_dir}/checksums.txt"
+
+echo "==> install.sh release path"
+GAIT_RELEASE_BASE_URL="file://${release_dir}" \
+  bash "${REPO_ROOT}/scripts/install.sh" \
+    --version "${release_version_tag}" \
+    --install-dir "${install_dir}"
+assert_version "install-script" "${install_dir}/gait" "${release_version}"
+
+echo "==> homebrew formula local path"
+tap_name="local/gait-version-smoke-$$"
+cleanup_brew_tap() {
+  brew uninstall --formula "${tap_name}/gait-local" >/dev/null 2>&1 || true
+  brew untap "${tap_name}" >/dev/null 2>&1 || true
+}
+trap 'cleanup_brew_tap; rm -rf "${work_dir}"' EXIT
+brew tap-new "${tap_name}" >/dev/null
+tap_repo="$(brew --repo "${tap_name}")"
+brew_formula_path="${tap_repo}/Formula/gait-local.rb"
+
+bash "${REPO_ROOT}/scripts/render_homebrew_formula.sh" \
+  --version "${release_version_tag}" \
+  --repo "davidahmann/gait" \
+  --project "gait-local" \
+  --checksums "${release_dir}/checksums.txt" \
+  --release-base-url "file://${release_dir}" \
+  --out "${brew_formula_path}"
+
+if ! grep -q "version \"${release_version}\"" "${brew_formula_path}"; then
+  echo "homebrew formula missing explicit version ${release_version}" >&2
+  exit 1
+fi
+
+HOMEBREW_NO_AUTO_UPDATE=1 brew install "${tap_name}/gait-local"
+brew_prefix="$(brew --prefix)"
+assert_version "brew-install" "${brew_prefix}/bin/gait-local" "${release_version}"
+cleanup_brew_tap
+
+echo "install-path version smoke: pass"

--- a/scripts/test_cli_version_install_paths.sh
+++ b/scripts/test_cli_version_install_paths.sh
@@ -4,16 +4,53 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
-if [[ $# -gt 1 ]]; then
-  echo "usage: $0 [path-to-gait-binary]" >&2
-  exit 2
-fi
+SKIP_BREW="false"
+BIN_INPUT=""
 
-if [[ $# -eq 1 ]]; then
-  if [[ "$1" = /* ]]; then
-    BIN_PATH="$1"
+usage() {
+  cat <<'EOF'
+Validate CLI version behavior across install paths.
+
+Usage:
+  test_cli_version_install_paths.sh [--skip-brew] [path-to-gait-binary]
+
+Options:
+  --skip-brew  Skip Homebrew path verification.
+  -h, --help   Show this help.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --skip-brew)
+      SKIP_BREW="true"
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    -*)
+      echo "unknown option: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+    *)
+      if [[ -n "${BIN_INPUT}" ]]; then
+        echo "usage: $0 [--skip-brew] [path-to-gait-binary]" >&2
+        exit 2
+      fi
+      BIN_INPUT="$1"
+      shift
+      ;;
+  esac
+done
+
+if [[ -n "${BIN_INPUT}" ]]; then
+  if [[ "${BIN_INPUT}" = /* ]]; then
+    BIN_PATH="${BIN_INPUT}"
   else
-    BIN_PATH="$(pwd)/$1"
+    BIN_PATH="$(pwd)/${BIN_INPUT}"
   fi
 else
   BIN_PATH="${REPO_ROOT}/gait"
@@ -25,8 +62,8 @@ if [[ ! -x "${BIN_PATH}" ]]; then
   exit 2
 fi
 
-if ! command -v brew >/dev/null 2>&1; then
-  echo "brew is required for install-path version smoke" >&2
+if [[ "${SKIP_BREW}" != "true" ]] && ! command -v brew >/dev/null 2>&1; then
+  echo "brew is required for install-path version smoke (or pass --skip-brew)" >&2
   exit 2
 fi
 
@@ -85,7 +122,15 @@ release_version_tag="v9.9.9-test"
 release_version="${release_version_tag#v}"
 
 work_dir="$(mktemp -d)"
-trap 'rm -rf "${work_dir}"' EXIT
+tap_name=""
+cleanup() {
+  if [[ -n "${tap_name}" ]]; then
+    brew uninstall --formula "${tap_name}/gait-local" >/dev/null 2>&1 || true
+    brew untap "${tap_name}" >/dev/null 2>&1 || true
+  fi
+  rm -rf "${work_dir}"
+}
+trap cleanup EXIT
 
 release_dir="${work_dir}/release"
 install_dir="${work_dir}/install/bin"
@@ -99,8 +144,7 @@ assert_version "source-build" "${source_bin}" "0.0.0-dev"
 release_bin="${work_dir}/gait-release"
 go build -ldflags "-X main.version=${release_version}" -o "${release_bin}" ./cmd/gait
 
-asset_arm64="gait_${release_version}_darwin_arm64.tar.gz"
-asset_amd64="gait_${release_version}_darwin_amd64.tar.gz"
+asset_release="gait_${release_version}_${os}_${arch}.tar.gz"
 project_asset_arm64="gait-local_${release_version}_darwin_arm64.tar.gz"
 project_asset_amd64="gait-local_${release_version}_darwin_amd64.tar.gz"
 
@@ -110,14 +154,12 @@ mkdir -p "${tmp_extract}/gait" "${tmp_extract}/gait-local"
 cp "${release_bin}" "${tmp_extract}/gait/gait"
 cp "${release_bin}" "${tmp_extract}/gait-local/gait-local"
 
-tar -czf "${release_dir}/${asset_arm64}" -C "${tmp_extract}/gait" gait
-tar -czf "${release_dir}/${asset_amd64}" -C "${tmp_extract}/gait" gait
+tar -czf "${release_dir}/${asset_release}" -C "${tmp_extract}/gait" gait
 tar -czf "${release_dir}/${project_asset_arm64}" -C "${tmp_extract}/gait-local" gait-local
 tar -czf "${release_dir}/${project_asset_amd64}" -C "${tmp_extract}/gait-local" gait-local
 
 {
-  printf '%s  %s\n' "$(sha256_file "${release_dir}/${asset_amd64}")" "${asset_amd64}"
-  printf '%s  %s\n' "$(sha256_file "${release_dir}/${asset_arm64}")" "${asset_arm64}"
+  printf '%s  %s\n' "$(sha256_file "${release_dir}/${asset_release}")" "${asset_release}"
   printf '%s  %s\n' "$(sha256_file "${release_dir}/${project_asset_amd64}")" "${project_asset_amd64}"
   printf '%s  %s\n' "$(sha256_file "${release_dir}/${project_asset_arm64}")" "${project_asset_arm64}"
 } > "${release_dir}/checksums.txt"
@@ -130,32 +172,30 @@ GAIT_RELEASE_BASE_URL="file://${release_dir}" \
 assert_version "install-script" "${install_dir}/gait" "${release_version}"
 
 echo "==> homebrew formula local path"
-tap_name="local/gait-version-smoke-$$"
-cleanup_brew_tap() {
-  brew uninstall --formula "${tap_name}/gait-local" >/dev/null 2>&1 || true
-  brew untap "${tap_name}" >/dev/null 2>&1 || true
-}
-trap 'cleanup_brew_tap; rm -rf "${work_dir}"' EXIT
-brew tap-new "${tap_name}" >/dev/null
-tap_repo="$(brew --repo "${tap_name}")"
-brew_formula_path="${tap_repo}/Formula/gait-local.rb"
+if [[ "${SKIP_BREW}" == "true" ]]; then
+  echo "brew-install: skipped"
+else
+  tap_name="local/gait-version-smoke-$$"
+  brew tap-new "${tap_name}" >/dev/null
+  tap_repo="$(brew --repo "${tap_name}")"
+  brew_formula_path="${tap_repo}/Formula/gait-local.rb"
 
-bash "${REPO_ROOT}/scripts/render_homebrew_formula.sh" \
-  --version "${release_version_tag}" \
-  --repo "davidahmann/gait" \
-  --project "gait-local" \
-  --checksums "${release_dir}/checksums.txt" \
-  --release-base-url "file://${release_dir}" \
-  --out "${brew_formula_path}"
+  bash "${REPO_ROOT}/scripts/render_homebrew_formula.sh" \
+    --version "${release_version_tag}" \
+    --repo "davidahmann/gait" \
+    --project "gait-local" \
+    --checksums "${release_dir}/checksums.txt" \
+    --release-base-url "file://${release_dir}" \
+    --out "${brew_formula_path}"
 
-if ! grep -q "version \"${release_version}\"" "${brew_formula_path}"; then
-  echo "homebrew formula missing explicit version ${release_version}" >&2
-  exit 1
+  if ! grep -q "version \"${release_version}\"" "${brew_formula_path}"; then
+    echo "homebrew formula missing explicit version ${release_version}" >&2
+    exit 1
+  fi
+
+  HOMEBREW_NO_AUTO_UPDATE=1 brew install "${tap_name}/gait-local"
+  brew_prefix="$(brew --prefix)"
+  assert_version "brew-install" "${brew_prefix}/bin/gait-local" "${release_version}"
 fi
-
-HOMEBREW_NO_AUTO_UPDATE=1 brew install "${tap_name}/gait-local"
-brew_prefix="$(brew --prefix)"
-assert_version "brew-install" "${brew_prefix}/bin/gait-local" "${release_version}"
-cleanup_brew_tap
 
 echo "install-path version smoke: pass"

--- a/scripts/test_release_smoke.sh
+++ b/scripts/test_release_smoke.sh
@@ -109,6 +109,7 @@ bash "$REPO_ROOT/scripts/render_homebrew_formula.sh" \
   --out "$WORK_DIR/gait.rb"
 
 grep -q '^class Gait < Formula$' "$WORK_DIR/gait.rb"
+grep -q '^  version "0.0.0"$' "$WORK_DIR/gait.rb"
 grep -q 'gait_v0.0.0_darwin_amd64.tar.gz' "$WORK_DIR/gait.rb"
 grep -q 'gait_v0.0.0_darwin_arm64.tar.gz' "$WORK_DIR/gait.rb"
 grep -q '1111111111111111111111111111111111111111111111111111111111111111' "$WORK_DIR/gait.rb"

--- a/scripts/test_uat_local.sh
+++ b/scripts/test_uat_local.sh
@@ -164,6 +164,7 @@ run_step "quality_chaos" make -C "${REPO_ROOT}" test-chaos
 run_step "quality_session_soak" bash "${REPO_ROOT}/scripts/test_session_soak.sh"
 run_step "quality_runtime_slo" make -C "${REPO_ROOT}" test-runtime-slo
 run_step "quality_perf_bench_check" make -C "${REPO_ROOT}" bench-check
+run_step "quality_install_path_versions" make -C "${REPO_ROOT}" test-install-path-versions
 
 if [[ "${SKIP_DOCS_SITE}" == "true" ]]; then
   log "SKIP quality_docs_site (requested)"

--- a/scripts/test_uat_local.sh
+++ b/scripts/test_uat_local.sh
@@ -164,7 +164,11 @@ run_step "quality_chaos" make -C "${REPO_ROOT}" test-chaos
 run_step "quality_session_soak" bash "${REPO_ROOT}/scripts/test_session_soak.sh"
 run_step "quality_runtime_slo" make -C "${REPO_ROOT}" test-runtime-slo
 run_step "quality_perf_bench_check" make -C "${REPO_ROOT}" bench-check
-run_step "quality_install_path_versions" make -C "${REPO_ROOT}" test-install-path-versions
+if [[ "${SKIP_BREW}" == "true" ]]; then
+  run_step "quality_install_path_versions" bash "${REPO_ROOT}/scripts/test_cli_version_install_paths.sh" --skip-brew
+else
+  run_step "quality_install_path_versions" make -C "${REPO_ROOT}" test-install-path-versions
+fi
 
 if [[ "${SKIP_DOCS_SITE}" == "true" ]]; then
   log "SKIP quality_docs_site (requested)"


### PR DESCRIPTION
## Summary
- stamp CLI version in release binaries via GoReleaser ldflags
- switch CLI version constant to mutable build-time variable
- emit explicit Homebrew formula version to avoid inferred "stable 64"
- add install-path version smoke test (source, install.sh, brew formula)
- include install-path version gate in local UAT flow

## Validation
- `go test ./cmd/gait ./core/...`
- `bash scripts/test_release_smoke.sh ./gait`
- `make test-install`
- `make test-install-path-versions`
- `bash scripts/test_uat_local.sh` (PASS)
- `goreleaser build --snapshot --clean --single-target` (version stamped)
