### PR TITLE
Close v2.4 testing gaps and fix missing CI fixtures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,19 @@ jobs:
         run: |
           bash scripts/check_ui_deps_freshness.sh
 
+  ui-acceptance:
+    needs: changes
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - name: Run local UI acceptance gate
+        shell: bash
+        run: |
+          make test-ui-acceptance
+
   test:
     needs: changes
     runs-on: ${{ matrix.os }}
@@ -137,7 +150,8 @@ jobs:
       - name: Go tests with coverage
         shell: bash
         run: |
-          go test ./...
+          go test ./... -cover | tee coverage-go-packages.out
+          python scripts/check_go_package_coverage.py coverage-go-packages.out 75
           go test ./core/... ./cmd/gait -coverprofile=coverage-go.out
           if [[ "$RUNNER_OS" == "Linux" ]]; then
             python scripts/check_go_coverage.py coverage-go.out 85

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,15 @@ jobs:
           npm ci
           npm run lint
           npm run build
+      - name: Validate docs links and Mermaid rendering
+        run: |
+          python3 scripts/check_docs_site_validation.py --report gait-out/docs_site_validation_report.json
+      - name: Upload docs validation report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: docs-site-validation-${{ github.run_id }}
+          path: gait-out/docs_site_validation_report.json
 
   ui-local:
     needs: changes
@@ -111,10 +120,24 @@ jobs:
           cd ui/local
           npm ci
           npm run lint
+          npm run test
           npm run build
       - name: Check UI dependency freshness
         run: |
           bash scripts/check_ui_deps_freshness.sh
+
+  ui-e2e-smoke:
+    needs: changes
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - name: Run UI e2e smoke
+        shell: bash
+        run: |
+          make test-ui-e2e-smoke
 
   ui-acceptance:
     needs: changes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,7 +173,8 @@ jobs:
       - name: Go tests with coverage
         shell: bash
         run: |
-          go test ./... -cover | tee coverage-go-packages.out
+          go test ./... -cover > coverage-go-packages.out
+          cat coverage-go-packages.out
           python scripts/check_go_package_coverage.py coverage-go-packages.out 75
           go test ./core/... ./cmd/gait -coverprofile=coverage-go.out
           if [[ "$RUNNER_OS" == "Linux" ]]; then

--- a/.github/workflows/perf-nightly.yml
+++ b/.github/workflows/perf-nightly.yml
@@ -37,7 +37,10 @@ jobs:
           go build -o ./gait ./cmd/gait
       - name: Check command latency budgets
         run: |
-          python scripts/check_command_budgets.py ./gait perf/command_budget_report.json
+          python scripts/check_command_budgets.py ./gait perf/command_budget_report.json perf/runtime_slo_budgets.json
+      - name: Check UI runtime budgets
+        run: |
+          python scripts/check_ui_budgets.py ./gait perf/ui_budgets.json perf/ui_budget_report.json
       - name: Upload benchmark artifacts
         if: always()
         uses: actions/upload-artifact@v4
@@ -48,3 +51,4 @@ jobs:
             perf/bench_report.json
             perf/resource_budget_report.json
             perf/command_budget_report.json
+            perf/ui_budget_report.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,8 +37,30 @@ jobs:
             gait-out/integration_lane_scorecard.json
             gait-out/adoption_metrics.json
 
+  v2_4_gate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - name: Run v2.4 release contract gate
+        run: |
+          make test-v2-4-acceptance
+          make test-packspec-tck
+          make test-e2e
+          go test ./internal/integration -count=1
+          make test-chaos
+          make test-runtime-slo
+          make bench-check
+
   release:
-    needs: v2_3_gate
+    needs: [v2_3_gate, v2_4_gate]
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/ui-nightly.yml
+++ b/.github/workflows/ui-nightly.yml
@@ -1,0 +1,42 @@
+name: ui-nightly
+
+on:
+  schedule:
+    - cron: "30 6 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  actions: write
+
+jobs:
+  ui-e2e-smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - name: Run UI e2e smoke
+        run: |
+          make test-ui-e2e-smoke
+
+  ui-perf-budgets:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - name: Run UI performance budgets
+        run: |
+          make test-ui-perf
+      - name: Upload UI perf report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ui-nightly-perf-${{ github.run_id }}
+          path: perf/ui_budget_report.json

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,8 @@ codeql:
 	bash scripts/run_codeql_local.sh
 
 test:
-	$(GO) test ./... -cover | tee coverage-go-packages.out
+	$(GO) test ./... -cover > coverage-go-packages.out
+	cat coverage-go-packages.out
 	$(PYTHON) scripts/check_go_package_coverage.py coverage-go-packages.out $(GO_PACKAGE_COVERAGE_THRESHOLD)
 	$(GO) test $(GO_COVERAGE_PACKAGES) -coverprofile=coverage-go.out
 	$(PYTHON) scripts/check_go_coverage.py coverage-go.out $(GO_COVERAGE_THRESHOLD)

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ SHELL := /bin/sh
 GO ?= go
 PYTHON ?= python3
 GO_COVERAGE_THRESHOLD ?= 85
+GO_PACKAGE_COVERAGE_THRESHOLD ?= 75
 PYTHON_COVERAGE_THRESHOLD ?= 85
 GAIT_BINARY ?= ./gait
 
@@ -54,7 +55,8 @@ codeql:
 	bash scripts/run_codeql_local.sh
 
 test:
-	$(GO) test ./...
+	$(GO) test ./... -cover | tee coverage-go-packages.out
+	$(PYTHON) scripts/check_go_package_coverage.py coverage-go-packages.out $(GO_PACKAGE_COVERAGE_THRESHOLD)
 	$(GO) test $(GO_COVERAGE_PACKAGES) -coverprofile=coverage-go.out
 	$(PYTHON) scripts/check_go_coverage.py coverage-go.out $(GO_COVERAGE_THRESHOLD)
 	(cd $(SDK_DIR) && PYTHONPATH=. uv run --python $(UV_PY) --extra dev pytest --cov=gait --cov-report=term-missing --cov-fail-under=$(PYTHON_COVERAGE_THRESHOLD))

--- a/Makefile
+++ b/Makefile
@@ -19,9 +19,9 @@ BENCH_REGEX := Benchmark(EvaluatePolicyTypical|VerifyZipTypical|DiffRunpacksTypi
 BENCH_OUTPUT ?= perf/bench_output.txt
 BENCH_BASELINE ?= perf/bench_baseline.json
 
-.PHONY: fmt lint lint-fast codeql test test-fast prepush prepush-full github-guardrails github-guardrails-strict test-hardening test-hardening-acceptance test-chaos test-e2e test-acceptance test-v1-6-acceptance test-v1-7-acceptance test-v1-8-acceptance test-v2-3-acceptance test-v2-4-acceptance test-packspec-tck test-ui-acceptance test-adoption test-adapter-parity test-ecosystem-automation test-release-smoke test-install test-install-path-versions test-contracts test-intent-receipt-conformance test-ci-regress-template test-live-connectors test-skill-supply-chain test-runtime-slo test-ent-consumer-contract test-uat-local test-openclaw-skill-install test-beads-bridge openclaw-skill-install build bench bench-check bench-budgets skills-validate ecosystem-validate ecosystem-release-notes demo-90s demo-hero-gif homebrew-formula wiki-publish tool-allowlist-policy ui-build ui-sync ui-deps-check
+.PHONY: fmt lint lint-fast codeql test test-fast prepush prepush-full github-guardrails github-guardrails-strict test-hardening test-hardening-acceptance test-chaos test-e2e test-acceptance test-v1-6-acceptance test-v1-7-acceptance test-v1-8-acceptance test-v2-3-acceptance test-v2-4-acceptance test-packspec-tck test-ui-acceptance test-ui-unit test-ui-e2e-smoke test-ui-perf test-adoption test-adapter-parity test-ecosystem-automation test-release-smoke test-install test-install-path-versions test-contracts test-intent-receipt-conformance test-ci-regress-template test-live-connectors test-skill-supply-chain test-runtime-slo test-ent-consumer-contract test-uat-local test-openclaw-skill-install test-beads-bridge openclaw-skill-install build bench bench-check bench-budgets skills-validate ecosystem-validate ecosystem-release-notes demo-90s demo-hero-gif homebrew-formula wiki-publish tool-allowlist-policy ui-build ui-sync ui-deps-check
 .PHONY: hooks
-.PHONY: docs-site-install docs-site-build docs-site-lint
+.PHONY: docs-site-install docs-site-build docs-site-lint docs-site-check
 
 fmt:
 	gofmt -w .
@@ -133,6 +133,17 @@ test-ui-acceptance:
 	$(GO) build -o ./gait ./cmd/gait
 	bash scripts/test_ui_acceptance.sh ./gait
 
+test-ui-unit:
+	cd ui/local && npm ci && npm run test
+
+test-ui-e2e-smoke:
+	$(GO) build -o ./gait ./cmd/gait
+	bash scripts/test_ui_e2e_smoke.sh ./gait
+
+test-ui-perf:
+	$(GO) build -o ./gait ./cmd/gait
+	$(PYTHON) scripts/check_ui_budgets.py ./gait perf/ui_budgets.json perf/ui_budget_report.json
+
 test-adoption:
 	bash scripts/test_adoption_smoke.sh
 
@@ -239,6 +250,9 @@ docs-site-build:
 
 docs-site-lint:
 	cd docs-site && npm run lint
+
+docs-site-check:
+	$(PYTHON) scripts/check_docs_site_validation.py --report gait-out/docs_site_validation_report.json
 
 ui-build:
 	bash scripts/ui_build.sh

--- a/core/errors/errors_test.go
+++ b/core/errors/errors_test.go
@@ -44,6 +44,39 @@ func TestUnknownErrorDefaults(t *testing.T) {
 	}
 }
 
+func TestWrapNilCauseReturnsNil(t *testing.T) {
+	if got := Wrap(nil, CategoryInternalFailure, "internal_failure", "retry later", false); got != nil {
+		t.Fatalf("expected nil wrapped error, got=%v", got)
+	}
+}
+
+func TestClassifiedErrorNilCauseDefaults(t *testing.T) {
+	err := &classifiedError{
+		category:  CategoryNetworkTransient,
+		code:      "network_transient",
+		hint:      "retry request",
+		retryable: true,
+	}
+	if err.Error() != "unknown error" {
+		t.Fatalf("unexpected nil-cause error text: %s", err.Error())
+	}
+	if err.Unwrap() != nil {
+		t.Fatalf("expected unwrap nil for nil cause")
+	}
+	if err.Category() != CategoryNetworkTransient {
+		t.Fatalf("unexpected category: %s", err.Category())
+	}
+	if err.Code() != "network_transient" {
+		t.Fatalf("unexpected code: %s", err.Code())
+	}
+	if err.Hint() != "retry request" {
+		t.Fatalf("unexpected hint: %s", err.Hint())
+	}
+	if !err.Retryable() {
+		t.Fatalf("expected retryable=true")
+	}
+}
+
 func TestCategorySetIsStableAndUnique(t *testing.T) {
 	categories := []Category{
 		CategoryInvalidInput,

--- a/docs/contracts/packspec_tck.md
+++ b/docs/contracts/packspec_tck.md
@@ -14,7 +14,7 @@ bash scripts/test_packspec_tck.sh ./gait
 
 ## Fixture Root
 
-- `fixtures/packspec_tck/v1/`
+- `scripts/testdata/packspec_tck/v1/`
 
 Current base vector:
 
@@ -43,6 +43,6 @@ The TCK validates these required vectors:
 
 When modifying PackSpec behavior:
 
-- update/add fixture vectors under `fixtures/packspec_tck/v1/`
+- update/add fixture vectors under `scripts/testdata/packspec_tck/v1/`
 - keep vectors deterministic and content-addressable
 - update this document with any new mandatory vector class

--- a/docs/uat_functional_plan.md
+++ b/docs/uat_functional_plan.md
@@ -32,6 +32,7 @@ The UAT script refreshes Homebrew taps before reinstall to avoid stale formula r
 - `scripts/test_v2_3_acceptance.sh` (v2.3 adoption/conformance/distribution gate + metrics snapshot)
 - `scripts/test_v2_4_acceptance.sh` (v2.4 job/pack/signing/replay/credential-ttl acceptance gate)
 - `scripts/test_ui_acceptance.sh` (localhost UI command/API acceptance gate)
+- `scripts/test_ui_e2e_smoke.sh` (UI first-run + regress headless smoke gate)
 - `scripts/test_packspec_tck.sh` (PackSpec v1 fixture/TCK determinism and verify contract)
 - `scripts/test_release_smoke.sh` (release artifact + core smoke checks)
 - `scripts/test_hardening_acceptance.sh` (hardening acceptance + deterministic boundary checks)
@@ -68,6 +69,7 @@ The acceptance suites together exercise command families including:
 
 - Go toolchain available
 - Python/uv toolchain available for SDK/adapter checks
+- Node.js/npm toolchain available for UI unit and docs-site checks
 - `gh` authenticated (required for release installer path)
 - Homebrew installed (required for brew path)
 - Network access for release asset and brew fetch
@@ -103,10 +105,10 @@ bash scripts/test_uat_local.sh --baseline-install-paths
 
 ## Pass Criteria
 
-- All quality gates pass: `make lint`, `make test`, `make test-e2e`, `go test ./internal/integration -count=1`, `make test-adoption`, `make test-adapter-parity`, `scripts/policy_compliance_ci.sh`, `make test-contracts`, `make test-v2-3-acceptance`, `make test-v2-4-acceptance`, `make test-ui-acceptance`, `make test-packspec-tck`, `make test-hardening-acceptance`, `make test-chaos`, `bash scripts/test_session_soak.sh`
+- All quality gates pass: `make lint`, `make test`, `make test-e2e`, `go test ./internal/integration -count=1`, `make test-adoption`, `make test-adapter-parity`, `scripts/policy_compliance_ci.sh`, `make test-contracts`, `make test-v2-3-acceptance`, `make test-v2-4-acceptance`, `make test-ui-acceptance`, `make test-ui-unit`, `make test-ui-e2e-smoke`, `make test-ui-perf`, `make test-packspec-tck`, `make test-hardening-acceptance`, `make test-chaos`, `bash scripts/test_session_soak.sh`
 - Runtime SLO budget check passes: `make test-runtime-slo`
 - Performance regression checks pass: `make bench-check`
-- Docs site lint/build passes (`make docs-site-lint docs-site-build`) unless explicitly skipped with `--skip-docs-site`
+- Docs site lint/build/render checks pass (`make docs-site-lint docs-site-build docs-site-check`) unless explicitly skipped with `--skip-docs-site`
 - All install-path command suites pass for:
   - source binary
   - release-installer binary

--- a/docs/uat_functional_plan.md
+++ b/docs/uat_functional_plan.md
@@ -31,6 +31,7 @@ The UAT script refreshes Homebrew taps before reinstall to avoid stale formula r
 - `scripts/test_v1_8_acceptance.sh` (v1.8 interception/ecosystem checks)
 - `scripts/test_v2_3_acceptance.sh` (v2.3 adoption/conformance/distribution gate + metrics snapshot)
 - `scripts/test_v2_4_acceptance.sh` (v2.4 job/pack/signing/replay/credential-ttl acceptance gate)
+- `scripts/test_ui_acceptance.sh` (localhost UI command/API acceptance gate)
 - `scripts/test_packspec_tck.sh` (PackSpec v1 fixture/TCK determinism and verify contract)
 - `scripts/test_release_smoke.sh` (release artifact + core smoke checks)
 - `scripts/test_hardening_acceptance.sh` (hardening acceptance + deterministic boundary checks)
@@ -102,7 +103,7 @@ bash scripts/test_uat_local.sh --baseline-install-paths
 
 ## Pass Criteria
 
-- All quality gates pass: `make lint`, `make test`, `make test-e2e`, `go test ./internal/integration -count=1`, `make test-adoption`, `make test-adapter-parity`, `scripts/policy_compliance_ci.sh`, `make test-contracts`, `make test-v2-3-acceptance`, `make test-v2-4-acceptance`, `make test-packspec-tck`, `make test-hardening-acceptance`, `make test-chaos`, `bash scripts/test_session_soak.sh`
+- All quality gates pass: `make lint`, `make test`, `make test-e2e`, `go test ./internal/integration -count=1`, `make test-adoption`, `make test-adapter-parity`, `scripts/policy_compliance_ci.sh`, `make test-contracts`, `make test-v2-3-acceptance`, `make test-v2-4-acceptance`, `make test-ui-acceptance`, `make test-packspec-tck`, `make test-hardening-acceptance`, `make test-chaos`, `bash scripts/test_session_soak.sh`
 - Runtime SLO budget check passes: `make test-runtime-slo`
 - Performance regression checks pass: `make bench-check`
 - Docs site lint/build passes (`make docs-site-lint docs-site-build`) unless explicitly skipped with `--skip-docs-site`

--- a/internal/testutil/testutil_test.go
+++ b/internal/testutil/testutil_test.go
@@ -2,7 +2,13 @@ package testutil
 
 import (
 	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
+	"time"
 )
 
 func TestNormalizeNewlines(t *testing.T) {
@@ -13,4 +19,83 @@ func TestNormalizeNewlines(t *testing.T) {
 	if !bytes.Equal(actual, expected) {
 		t.Fatalf("unexpected newline normalization: got=%q want=%q", string(actual), string(expected))
 	}
+}
+
+func TestRepoRootContainsGoMod(t *testing.T) {
+	root := RepoRoot(t)
+	if _, err := os.Stat(filepath.Join(root, "go.mod")); err != nil {
+		t.Fatalf("expected go.mod at repo root: %v", err)
+	}
+}
+
+func TestBuildGaitBinary(t *testing.T) {
+	root := RepoRoot(t)
+	binPath := BuildGaitBinary(t, root)
+	info, err := os.Stat(binPath)
+	if err != nil {
+		t.Fatalf("expected built binary to exist: %v", err)
+	}
+	if info.Size() == 0 {
+		t.Fatalf("expected non-empty binary at %s", binPath)
+	}
+}
+
+func TestWriteFileAndMustReadFile(t *testing.T) {
+	target := filepath.Join(t.TempDir(), "nested", "output.json")
+	WriteFile(t, target, []byte(`{"ok":true}`))
+	got := MustReadFile(t, target)
+	if string(got) != `{"ok":true}` {
+		t.Fatalf("unexpected file content: %q", string(got))
+	}
+}
+
+func TestFormatJSON(t *testing.T) {
+	formatted := FormatJSON([]byte(`{"ok":true}`))
+	if !strings.Contains(formatted, "\"ok\": true") {
+		t.Fatalf("expected pretty-printed json, got=%q", formatted)
+	}
+
+	raw := "not-json"
+	if got := FormatJSON([]byte(raw)); got != raw {
+		t.Fatalf("expected raw passthrough for invalid json, got=%q", got)
+	}
+}
+
+func TestCommandExitCode(t *testing.T) {
+	var cmd *exec.Cmd
+	if runtime.GOOS == "windows" {
+		cmd = exec.Command("cmd", "/c", "exit 7")
+	} else {
+		cmd = exec.Command("sh", "-c", "exit 7")
+	}
+	err := cmd.Run()
+	if err == nil {
+		t.Fatalf("expected command to fail")
+	}
+	if code := CommandExitCode(t, err); code != 7 {
+		t.Fatalf("unexpected exit code: got=%d want=7", code)
+	}
+}
+
+func TestGoldenHelpersRoundTrip(t *testing.T) {
+	repoRoot := RepoRoot(t)
+	name := strings.ReplaceAll(strings.ToLower(t.Name()), "/", "_")
+	relativePath := filepath.Join(
+		"internal",
+		"testutil",
+		"testdata",
+		"tmp_"+name+"_"+time.Now().UTC().Format("20060102150405")+".json",
+	)
+	fullPath := filepath.Join(repoRoot, relativePath)
+	t.Cleanup(func() {
+		_ = os.Remove(fullPath)
+		_ = os.Remove(filepath.Dir(fullPath))
+	})
+
+	payload := map[string]any{"ok": true, "count": 1}
+	WriteGoldenJSON(t, relativePath, payload)
+	AssertGoldenJSON(t, relativePath, payload)
+
+	t.Setenv("UPDATE_GOLDEN", "1")
+	AssertGoldenJSON(t, relativePath, map[string]any{"ok": true, "count": 2})
 }

--- a/perf/runtime_slo_budgets.json
+++ b/perf/runtime_slo_budgets.json
@@ -80,6 +80,42 @@
       "p95_ms": 1800.0,
       "p99_ms": 2400.0,
       "max_error_rate": 0.0
+    },
+    "job_submit": {
+      "p50_ms": 900.0,
+      "p95_ms": 1800.0,
+      "p99_ms": 2400.0,
+      "max_error_rate": 0.0
+    },
+    "job_checkpoint_add": {
+      "p50_ms": 900.0,
+      "p95_ms": 1800.0,
+      "p99_ms": 2400.0,
+      "max_error_rate": 0.0
+    },
+    "job_approve": {
+      "p50_ms": 900.0,
+      "p95_ms": 1800.0,
+      "p99_ms": 2400.0,
+      "max_error_rate": 0.0
+    },
+    "job_resume": {
+      "p50_ms": 900.0,
+      "p95_ms": 1800.0,
+      "p99_ms": 2400.0,
+      "max_error_rate": 0.0
+    },
+    "pack_build_job": {
+      "p50_ms": 1800.0,
+      "p95_ms": 2800.0,
+      "p99_ms": 3600.0,
+      "max_error_rate": 0.0
+    },
+    "pack_verify_job": {
+      "p50_ms": 900.0,
+      "p95_ms": 1800.0,
+      "p99_ms": 2400.0,
+      "max_error_rate": 0.0
     }
   }
 }

--- a/perf/ui_budgets.json
+++ b/perf/ui_budgets.json
@@ -1,0 +1,7 @@
+{
+  "schema_id": "gait.perf.ui_budgets",
+  "schema_version": "1.0.0",
+  "startup_tti_ms": 4000.0,
+  "command_roundtrip_ms": 5000.0,
+  "max_rss_kib": 450000.0
+}

--- a/product/PLAN_2.4.md
+++ b/product/PLAN_2.4.md
@@ -502,7 +502,7 @@ Objective: create explicit, deterministic TCK artifacts for PackSpec verificatio
 ### Story 6.1: Add fixture vectors
 
 Tasks:
-- Add `fixtures/packspec_tck/v1/` with:
+- Add `scripts/testdata/packspec_tck/v1/` with:
   - valid run pack
   - valid job pack
   - tampered hash pack
@@ -664,4 +664,3 @@ Acceptance criteria:
 - Single primary install path documented and promoted.
 - PackSpec TCK vectors + CI lane operational.
 - Existing UAT, e2e, integration, chaos, and perf lanes remain green.
-

--- a/product/TESTS_GAPS.md
+++ b/product/TESTS_GAPS.md
@@ -18,8 +18,9 @@ This plan closes test-matrix and coverage gaps found during repo audit, plus che
 | Package-level Go coverage floor not enforced | Existing checks only enforced aggregate coverage | Add package coverage checker script and enforce >=75% package coverage in `make test` and CI test lanes. | Implemented |
 | Failing CI run due missing tracked PackSpec fixture | Run `22018642257` failed in `v2-4-acceptance` and `packspec-tck` with missing `fixtures/packspec_tck/v1/run_record_input.json` | Move PackSpec fixture to tracked `scripts/testdata/packspec_tck/v1/run_record_input.json` and update scripts/docs to use it. | Implemented |
 | Low package coverage (`core/errors`, `internal/testutil`) | Coverage audit showed both under 75% | Add focused unit tests in both packages to lift package coverage above floor. | Implemented |
-| Docs-site route/link rendering checks beyond lint/build | Plan asks for deeper link/render checks | Add dedicated docs link/render validation script and CI job with artifacts. | Planned (next) |
-| UI frontend unit/e2e and UI performance budget lane | `PLAN_UI.md` requests frontend unit/e2e/perf budget lanes | Add frontend test runner (`ui/local/src/**/*.test.tsx`), CI headless e2e lane, and UI perf budget checker in nightly. | Planned (next) |
+| Docs-site route/link rendering checks beyond lint/build | Plan asks for deeper link/render checks | Added `scripts/check_docs_site_validation.py`, CI docs validation step + artifact, and UAT `docs-site-check` wiring. | Implemented |
+| UI frontend unit/e2e and UI performance budget lane | `PLAN_UI.md` requests frontend unit/e2e/perf budget lanes | Added Vitest-based frontend unit tests, `scripts/test_ui_e2e_smoke.sh` CI lane, and UI budget enforcement (`perf/ui_budgets.json`, `scripts/check_ui_budgets.py`, nightly workflow + perf-nightly integration). | Implemented |
+| Runtime perf coverage missing job/pack lifecycle commands | Runtime SLO budgets previously focused on demo/regress/gate/session | Extended command budget matrix and runtime budgets with `job_submit`, `job_checkpoint_add`, `job_approve`, `job_resume`, `pack_build_job`, and `pack_verify_job`. | Implemented |
 
 ## Verification Commands
 
@@ -33,6 +34,10 @@ go test ./internal/integration -count=1
 make test-v2-4-acceptance
 make test-packspec-tck
 make test-ui-acceptance
+make test-ui-unit
+make test-ui-e2e-smoke
+make test-ui-perf
+make docs-site-check
 make test-chaos
 make test-runtime-slo
 make bench-check

--- a/product/TESTS_GAPS.md
+++ b/product/TESTS_GAPS.md
@@ -1,0 +1,46 @@
+# TESTS_GAPS Fix Plan
+
+Date: 2026-02-14  
+Owner: Engineering
+
+## Scope
+
+This plan closes test-matrix and coverage gaps found during repo audit, plus checks and addresses failures in GitHub Actions run:
+
+- [Run 22018642257](https://github.com/davidahmann/gait/actions/runs/22018642257)
+
+## Gaps and Actions
+
+| Gap | Evidence | Action | Status |
+|---|---|---|---|
+| Release gate lagging v2.4 contract | `product/PLAN_2.4.md` release gates vs `release.yml` only gating v2.3 | Add a `v2_4_gate` release workflow job that runs v2.4 acceptance + TCK + e2e + integration + chaos + perf budgets. Make release depend on both v2.3 and v2.4 gates. | Implemented |
+| UI acceptance not part of CI/UAT quality gate | `test-ui-acceptance` exists but was not wired into CI and UAT orchestrator | Add dedicated CI `ui-acceptance` job. Add `quality_ui_acceptance` step to `scripts/test_uat_local.sh`. Update UAT plan docs. | Implemented |
+| Package-level Go coverage floor not enforced | Existing checks only enforced aggregate coverage | Add package coverage checker script and enforce >=75% package coverage in `make test` and CI test lanes. | Implemented |
+| Failing CI run due missing tracked PackSpec fixture | Run `22018642257` failed in `v2-4-acceptance` and `packspec-tck` with missing `fixtures/packspec_tck/v1/run_record_input.json` | Move PackSpec fixture to tracked `scripts/testdata/packspec_tck/v1/run_record_input.json` and update scripts/docs to use it. | Implemented |
+| Low package coverage (`core/errors`, `internal/testutil`) | Coverage audit showed both under 75% | Add focused unit tests in both packages to lift package coverage above floor. | Implemented |
+| Docs-site route/link rendering checks beyond lint/build | Plan asks for deeper link/render checks | Add dedicated docs link/render validation script and CI job with artifacts. | Planned (next) |
+| UI frontend unit/e2e and UI performance budget lane | `PLAN_UI.md` requests frontend unit/e2e/perf budget lanes | Add frontend test runner (`ui/local/src/**/*.test.tsx`), CI headless e2e lane, and UI perf budget checker in nightly. | Planned (next) |
+
+## Verification Commands
+
+Run locally from repo root:
+
+```bash
+make lint-fast
+make test
+make test-e2e
+go test ./internal/integration -count=1
+make test-v2-4-acceptance
+make test-packspec-tck
+make test-ui-acceptance
+make test-chaos
+make test-runtime-slo
+make bench-check
+make codeql
+```
+
+## Exit Criteria
+
+- All commands above pass locally.
+- PR CI lanes pass, including new `ui-acceptance` and updated coverage/release gates.
+- No regressions against v2.4 acceptance and PackSpec TCK.

--- a/scripts/check_docs_site_validation.py
+++ b/scripts/check_docs_site_validation.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+
+MERMAID_KEYWORDS = (
+    "flowchart",
+    "graph",
+    "sequencediagram",
+    "classdiagram",
+    "statediagram",
+    "erdiagram",
+    "journey",
+    "gantt",
+    "pie",
+    "mindmap",
+    "timeline",
+    "gitgraph",
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Validate docs-site link and mermaid readiness checks.")
+    parser.add_argument(
+        "--report",
+        default="gait-out/docs_site_validation_report.json",
+        help="output report path",
+    )
+    return parser.parse_args()
+
+
+def collect_markdown_sources(repo_root: Path) -> list[Path]:
+    docs_root = repo_root / "docs"
+    sources = sorted(path for path in docs_root.rglob("*.md") if path.is_file())
+    for root_doc in ("README.md", "SECURITY.md", "CONTRIBUTING.md"):
+        path = repo_root / root_doc
+        if path.exists():
+            sources.append(path)
+    return sources
+
+
+def slug_for_doc(repo_root: Path, path: Path) -> str:
+    docs_root = repo_root / "docs"
+    if path.parent == repo_root:
+        if path.name == "README.md":
+            return "start-here"
+        if path.name == "SECURITY.md":
+            return "security"
+        if path.name == "CONTRIBUTING.md":
+            return "contributing"
+    relative = path.relative_to(docs_root).as_posix()
+    slug = relative[:-3].lower()
+    if slug == "readme":
+        return "start-here"
+    return slug
+
+
+def collect_known_slugs(repo_root: Path, sources: list[Path]) -> set[str]:
+    slugs = {slug_for_doc(repo_root, path) for path in sources}
+    slugs.add("")
+    return slugs
+
+
+def normalize_link_target(raw: str) -> str:
+    target = raw.strip()
+    if target.startswith("<") and target.endswith(">"):
+        target = target[1:-1].strip()
+    if " " in target and not target.startswith("http"):
+        target = target.split(" ", 1)[0]
+    return target
+
+
+def strip_fragment_and_query(target: str) -> str:
+    no_fragment = target.split("#", 1)[0]
+    no_query = no_fragment.split("?", 1)[0]
+    return no_query
+
+
+def validate_navigation_routes(
+    repo_root: Path,
+    known_slugs: set[str],
+    failures: list[str],
+    checked_routes: list[str],
+) -> None:
+    nav_path = repo_root / "docs-site" / "src" / "lib" / "navigation.ts"
+    pattern = re.compile(r"href:\s*'(/docs[^']*)'")
+    for route in pattern.findall(nav_path.read_text(encoding="utf-8")):
+        checked_routes.append(route)
+        if route == "/docs":
+            continue
+        slug = route.removeprefix("/docs/").strip("/").lower()
+        if slug not in known_slugs:
+            failures.append(f"navigation route missing doc source: {route}")
+
+
+def has_balanced_pairs(text: str, open_char: str, close_char: str) -> bool:
+    depth = 0
+    for char in text:
+        if char == open_char:
+            depth += 1
+        elif char == close_char:
+            depth -= 1
+            if depth < 0:
+                return False
+    return depth == 0
+
+
+def validate_mermaid(file_path: Path, content: str, failures: list[str]) -> int:
+    blocks = re.findall(r"```mermaid\s*\n(.*?)\n```", content, flags=re.IGNORECASE | re.DOTALL)
+    for index, block in enumerate(blocks, start=1):
+        trimmed = block.strip()
+        lowered = trimmed.lower()
+        if not trimmed:
+            failures.append(f"{file_path}: mermaid block #{index} is empty")
+            continue
+        if not any(keyword in lowered for keyword in MERMAID_KEYWORDS):
+            failures.append(f"{file_path}: mermaid block #{index} missing diagram keyword")
+        if not has_balanced_pairs(trimmed, "(", ")"):
+            failures.append(f"{file_path}: mermaid block #{index} has unbalanced parentheses")
+        if not has_balanced_pairs(trimmed, "[", "]"):
+            failures.append(f"{file_path}: mermaid block #{index} has unbalanced brackets")
+        if not has_balanced_pairs(trimmed, "{", "}"):
+            failures.append(f"{file_path}: mermaid block #{index} has unbalanced braces")
+    return len(blocks)
+
+
+def validate_markdown_links(
+    repo_root: Path,
+    source: Path,
+    content: str,
+    known_slugs: set[str],
+    failures: list[str],
+) -> int:
+    link_count = 0
+    for raw_target in re.findall(r"\[[^\]]+\]\(([^)]+)\)", content):
+        target = normalize_link_target(raw_target)
+        if not target:
+            continue
+        if target.startswith(("#", "http://", "https://", "mailto:", "tel:")):
+            continue
+        if target.startswith("javascript:"):
+            failures.append(f"{source}: javascript link target is not allowed: {target}")
+            continue
+
+        target_no_fragment = strip_fragment_and_query(target)
+        if not target_no_fragment:
+            continue
+
+        link_count += 1
+        if target_no_fragment.startswith("/docs/"):
+            route_slug = target_no_fragment.removeprefix("/docs/").strip("/").lower()
+            if route_slug not in known_slugs:
+                failures.append(f"{source}: broken docs route target {target}")
+            continue
+
+        if ".md" in target_no_fragment.lower():
+            if target_no_fragment.startswith("/"):
+                resolved = (repo_root / target_no_fragment.lstrip("/")).resolve()
+            else:
+                resolved = (source.parent / target_no_fragment).resolve()
+            if not resolved.exists():
+                failures.append(f"{source}: missing markdown target {target}")
+            continue
+
+        if target_no_fragment.startswith("/"):
+            candidate = (repo_root / target_no_fragment.lstrip("/")).resolve()
+            if not candidate.exists():
+                failures.append(f"{source}: missing repo target {target}")
+    return link_count
+
+
+def main() -> int:
+    args = parse_args()
+    repo_root = Path(__file__).resolve().parents[1]
+    sources = collect_markdown_sources(repo_root)
+    known_slugs = collect_known_slugs(repo_root, sources)
+
+    failures: list[str] = []
+    checked_routes: list[str] = []
+    validate_navigation_routes(repo_root, known_slugs, failures, checked_routes)
+
+    total_links = 0
+    total_mermaid_blocks = 0
+    for source in sources:
+        content = source.read_text(encoding="utf-8")
+        total_links += validate_markdown_links(repo_root, source, content, known_slugs, failures)
+        total_mermaid_blocks += validate_mermaid(source, content, failures)
+
+    report: dict[str, Any] = {
+        "schema_id": "gait.docs.site.validation_report",
+        "schema_version": "1.0.0",
+        "sources_checked": len(sources),
+        "navigation_routes_checked": len(checked_routes),
+        "links_checked": total_links,
+        "mermaid_blocks_checked": total_mermaid_blocks,
+        "failures": failures,
+        "status": "pass" if not failures else "fail",
+    }
+
+    report_path = Path(args.report)
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+    report_path.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+
+    if failures:
+        print("docs-site validation failed:", file=sys.stderr)
+        for failure in failures:
+            print(f"- {failure}", file=sys.stderr)
+        return 1
+
+    print(
+        "docs-site validation passed "
+        f"(sources={len(sources)} links={total_links} mermaid_blocks={total_mermaid_blocks})"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_go_package_coverage.py
+++ b/scripts/check_go_package_coverage.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+LINE_RE = re.compile(
+    r"^ok\s+(\S+)\s+.*coverage:\s+([0-9]+(?:\.[0-9]+)?)% of statements$"
+)
+
+
+def main() -> int:
+    if len(sys.argv) not in (3, 4):
+        print(
+            "usage: check_go_package_coverage.py <go_test_cover_output.txt> <min_percent> [allowlist_csv]",
+            file=sys.stderr,
+        )
+        return 2
+
+    output_path = Path(sys.argv[1])
+    if not output_path.exists():
+        print(f"go test coverage output file not found: {output_path}", file=sys.stderr)
+        return 2
+
+    try:
+        minimum = float(sys.argv[2])
+    except ValueError:
+        print(f"invalid minimum coverage value: {sys.argv[2]}", file=sys.stderr)
+        return 2
+
+    allowlist: set[str] = set()
+    if len(sys.argv) == 4 and sys.argv[3].strip():
+        allowlist = {item.strip() for item in sys.argv[3].split(",") if item.strip()}
+
+    package_coverage: dict[str, float] = {}
+    for raw_line in output_path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        match = LINE_RE.match(line)
+        if not match:
+            continue
+        package, coverage_text = match.groups()
+        if package in allowlist:
+            continue
+        if not package.startswith("github.com/davidahmann/gait/"):
+            continue
+        package_coverage[package] = float(coverage_text)
+
+    if not package_coverage:
+        print("no package coverage rows found in go test output", file=sys.stderr)
+        return 1
+
+    failures = [(pkg, cov) for pkg, cov in sorted(package_coverage.items()) if cov < minimum]
+    if failures:
+        print(
+            f"Go package coverage check failed (minimum {minimum:.1f}%):",
+            file=sys.stderr,
+        )
+        for pkg, cov in failures:
+            print(f"- {pkg}: {cov:.1f}%", file=sys.stderr)
+        return 1
+
+    print(
+        f"Go package coverage OK: {len(package_coverage)} packages >= {minimum:.1f}%"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_ui_budgets.py
+++ b/scripts/check_ui_budgets.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import os
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from urllib import error, request
+
+
+def usage() -> int:
+    print(
+        "usage: check_ui_budgets.py <gait_binary_path> <ui_budgets.json> <report.json>",
+        file=sys.stderr,
+    )
+    return 2
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"{path} must be a JSON object")
+    return payload
+
+
+def pick_port() -> int:
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.bind(("127.0.0.1", 0))
+    port = sock.getsockname()[1]
+    sock.close()
+    return int(port)
+
+
+def get_json(url: str) -> dict[str, Any]:
+    with request.urlopen(url, timeout=2) as response:
+        body = response.read().decode("utf-8")
+    payload = json.loads(body)
+    if not isinstance(payload, dict):
+        raise ValueError(f"expected object response from {url}")
+    return payload
+
+
+def post_json(url: str, payload: dict[str, Any]) -> dict[str, Any]:
+    req = request.Request(
+        url,
+        data=json.dumps(payload).encode("utf-8"),
+        headers={"content-type": "application/json"},
+        method="POST",
+    )
+    with request.urlopen(req, timeout=120) as response:
+        body = response.read().decode("utf-8")
+    parsed = json.loads(body)
+    if not isinstance(parsed, dict):
+        raise ValueError(f"expected object response from {url}")
+    return parsed
+
+
+def read_rss_kib(pid: int) -> int:
+    result = subprocess.run(
+        ["ps", "-o", "rss=", "-p", str(pid)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"failed to read rss for pid {pid}: {result.stderr.strip()}")
+    value = result.stdout.strip()
+    if not value:
+        raise RuntimeError(f"rss output was empty for pid {pid}")
+    return int(value)
+
+
+def now_utc() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def main() -> int:
+    if len(sys.argv) != 4:
+        return usage()
+
+    gait_path = Path(sys.argv[1]).resolve()
+    budget_path = Path(sys.argv[2]).resolve()
+    report_path = Path(sys.argv[3]).resolve()
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+
+    if not gait_path.exists():
+        print(f"gait binary not found: {gait_path}", file=sys.stderr)
+        return 2
+
+    try:
+        budgets = load_json(budget_path)
+    except (OSError, ValueError, json.JSONDecodeError) as err:
+        print(f"load budgets: {err}", file=sys.stderr)
+        return 2
+
+    required = ("startup_tti_ms", "command_roundtrip_ms", "max_rss_kib")
+    for key in required:
+        value = budgets.get(key)
+        if not isinstance(value, (int, float)):
+            print(f"invalid budget field {key}: expected number", file=sys.stderr)
+            return 2
+
+    port = pick_port()
+    base_url = f"http://127.0.0.1:{port}"
+    failures: list[str] = []
+    report: dict[str, Any] = {
+        "schema_id": "gait.perf.ui_budget_report",
+        "schema_version": "1.0.0",
+        "generated_at": now_utc(),
+        "budgets": {
+            "startup_tti_ms": float(budgets["startup_tti_ms"]),
+            "command_roundtrip_ms": float(budgets["command_roundtrip_ms"]),
+            "max_rss_kib": float(budgets["max_rss_kib"]),
+        },
+        "metrics": {},
+        "failures": failures,
+    }
+
+    with tempfile.TemporaryDirectory(prefix="gait-ui-budget-") as temp_dir:
+        work_dir = Path(temp_dir)
+        ui_log = work_dir / "ui_perf.log"
+        with ui_log.open("w", encoding="utf-8") as log_handle:
+            process = subprocess.Popen(
+                [
+                    str(gait_path),
+                    "ui",
+                    "--listen",
+                    f"127.0.0.1:{port}",
+                    "--open-browser=false",
+                ],
+                cwd=work_dir,
+                stdout=log_handle,
+                stderr=log_handle,
+                env=os.environ.copy(),
+            )
+            try:
+                startup_start = time.perf_counter()
+                ready = False
+                for _ in range(120):
+                    if process.poll() is not None:
+                        break
+                    try:
+                        health = get_json(f"{base_url}/api/health")
+                        if health.get("ok") is True:
+                            ready = True
+                            break
+                    except (error.URLError, TimeoutError, ValueError, json.JSONDecodeError):
+                        pass
+                    time.sleep(0.25)
+                startup_tti_ms = (time.perf_counter() - startup_start) * 1000.0
+                report["metrics"]["startup_tti_ms"] = startup_tti_ms
+                report["metrics"]["ready"] = ready
+                report["metrics"]["ui_log_path"] = str(ui_log)
+
+                if not ready:
+                    failures.append("ui server did not become healthy")
+                else:
+                    command_start = time.perf_counter()
+                    demo_payload = post_json(
+                        f"{base_url}/api/exec",
+                        {"command": "demo", "args": {}},
+                    )
+                    command_roundtrip_ms = (time.perf_counter() - command_start) * 1000.0
+                    report["metrics"]["command_roundtrip_ms"] = command_roundtrip_ms
+                    report["metrics"]["demo_exit_code"] = int(demo_payload.get("exit_code", -1))
+                    report["metrics"]["demo_ok"] = bool(demo_payload.get("ok", False))
+                    if demo_payload.get("exit_code") != 0:
+                        failures.append(f"ui demo command failed: exit_code={demo_payload.get('exit_code')}")
+
+                    rss_kib = read_rss_kib(process.pid)
+                    report["metrics"]["rss_kib"] = rss_kib
+
+                if startup_tti_ms > float(budgets["startup_tti_ms"]):
+                    failures.append(
+                        f"startup_tti_ms over budget: observed={startup_tti_ms:.1f} budget={float(budgets['startup_tti_ms']):.1f}"
+                    )
+                if "command_roundtrip_ms" in report["metrics"]:
+                    observed = float(report["metrics"]["command_roundtrip_ms"])
+                    if observed > float(budgets["command_roundtrip_ms"]):
+                        failures.append(
+                            f"command_roundtrip_ms over budget: observed={observed:.1f} budget={float(budgets['command_roundtrip_ms']):.1f}"
+                        )
+                if "rss_kib" in report["metrics"]:
+                    observed_rss = float(report["metrics"]["rss_kib"])
+                    if observed_rss > float(budgets["max_rss_kib"]):
+                        failures.append(
+                            f"rss_kib over budget: observed={observed_rss:.0f} budget={float(budgets['max_rss_kib']):.0f}"
+                        )
+            except Exception as err:  # noqa: BLE001
+                failures.append(f"runtime error: {err}")
+            finally:
+                process.terminate()
+                try:
+                    process.wait(timeout=10)
+                except subprocess.TimeoutExpired:
+                    process.kill()
+                    process.wait(timeout=10)
+
+            log_tail = ui_log.read_text(encoding="utf-8", errors="replace").splitlines()[-30:]
+            report["log_tail"] = log_tail
+
+    report["status"] = "pass" if not failures else "fail"
+    report_path.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+
+    if failures:
+        print("ui budget check failed:", file=sys.stderr)
+        for item in failures:
+            print(f"- {item}", file=sys.stderr)
+        return 1
+
+    print(
+        "ui budget check passed "
+        f"(startup={report['metrics']['startup_tti_ms']:.1f}ms "
+        f"roundtrip={report['metrics']['command_roundtrip_ms']:.1f}ms "
+        f"rss={report['metrics']['rss_kib']}KiB)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_packspec_tck.sh
+++ b/scripts/test_packspec_tck.sh
@@ -28,7 +28,7 @@ fi
 WORK_DIR="$(mktemp -d)"
 trap 'rm -rf "$WORK_DIR"' EXIT
 
-cp "$REPO_ROOT/fixtures/packspec_tck/v1/run_record_input.json" "$WORK_DIR/run_record_input.json"
+cp "$REPO_ROOT/scripts/testdata/packspec_tck/v1/run_record_input.json" "$WORK_DIR/run_record_input.json"
 
 mkdir -p "$WORK_DIR/gait-out" "$WORK_DIR/jobs"
 

--- a/scripts/test_uat_local.sh
+++ b/scripts/test_uat_local.sh
@@ -162,6 +162,7 @@ run_step "quality_policy_compliance" bash "${REPO_ROOT}/scripts/policy_complianc
 run_step "quality_contracts" make -C "${REPO_ROOT}" test-contracts
 run_step "quality_v2_3_acceptance" make -C "${REPO_ROOT}" test-v2-3-acceptance
 run_step "quality_v2_4_acceptance" make -C "${REPO_ROOT}" test-v2-4-acceptance
+run_step "quality_ui_acceptance" make -C "${REPO_ROOT}" test-ui-acceptance
 run_step "quality_packspec_tck" make -C "${REPO_ROOT}" test-packspec-tck
 run_step "quality_hardening_acceptance" make -C "${REPO_ROOT}" test-hardening-acceptance
 run_step "quality_chaos" make -C "${REPO_ROOT}" test-chaos

--- a/scripts/test_uat_local.sh
+++ b/scripts/test_uat_local.sh
@@ -136,6 +136,7 @@ require_cmd go
 require_cmd python3
 require_cmd uv
 require_cmd gh
+require_cmd npm
 
 if [[ "${SKIP_BREW}" != "true" ]]; then
   require_cmd brew
@@ -163,6 +164,9 @@ run_step "quality_contracts" make -C "${REPO_ROOT}" test-contracts
 run_step "quality_v2_3_acceptance" make -C "${REPO_ROOT}" test-v2-3-acceptance
 run_step "quality_v2_4_acceptance" make -C "${REPO_ROOT}" test-v2-4-acceptance
 run_step "quality_ui_acceptance" make -C "${REPO_ROOT}" test-ui-acceptance
+run_step "quality_ui_unit" make -C "${REPO_ROOT}" test-ui-unit
+run_step "quality_ui_e2e_smoke" make -C "${REPO_ROOT}" test-ui-e2e-smoke
+run_step "quality_ui_perf" make -C "${REPO_ROOT}" test-ui-perf
 run_step "quality_packspec_tck" make -C "${REPO_ROOT}" test-packspec-tck
 run_step "quality_hardening_acceptance" make -C "${REPO_ROOT}" test-hardening-acceptance
 run_step "quality_chaos" make -C "${REPO_ROOT}" test-chaos
@@ -178,7 +182,7 @@ fi
 if [[ "${SKIP_DOCS_SITE}" == "true" ]]; then
   log "SKIP quality_docs_site (requested)"
 elif command -v npm >/dev/null 2>&1; then
-  run_step "quality_docs_site" make -C "${REPO_ROOT}" docs-site-lint docs-site-build
+  run_step "quality_docs_site" make -C "${REPO_ROOT}" docs-site-lint docs-site-build docs-site-check
 else
   log "SKIP quality_docs_site (npm missing)"
 fi

--- a/scripts/test_ui_e2e_smoke.sh
+++ b/scripts/test_ui_e2e_smoke.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "usage: $0 <path-to-gait-binary>" >&2
+  exit 2
+fi
+
+BIN_PATH="$1"
+if [[ ! -x "$BIN_PATH" ]]; then
+  echo "binary is not executable: $BIN_PATH" >&2
+  exit 2
+fi
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PORT="${GAIT_UI_E2E_PORT:-7992}"
+SERVER_PID=""
+
+cleanup() {
+  if [[ -n "$SERVER_PID" ]] && kill -0 "$SERVER_PID" >/dev/null 2>&1; then
+    kill "$SERVER_PID" >/dev/null 2>&1 || true
+    wait "$SERVER_PID" >/dev/null 2>&1 || true
+  fi
+  rm -f ui_e2e.log
+  rm -rf gait-out fixtures regress_result.json gait.yaml
+}
+trap cleanup EXIT
+
+cd "$REPO_ROOT"
+
+"$BIN_PATH" ui --listen "127.0.0.1:${PORT}" --open-browser=false >ui_e2e.log 2>&1 &
+SERVER_PID=$!
+
+for _ in $(seq 1 80); do
+  if curl -fsS "http://127.0.0.1:${PORT}/api/health" >/tmp/gait_ui_e2e_health.json 2>/dev/null; then
+    break
+  fi
+  sleep 0.25
+done
+
+if ! curl -fsS "http://127.0.0.1:${PORT}/api/health" >/tmp/gait_ui_e2e_health.json; then
+  echo "ui health endpoint did not become ready" >&2
+  cat ui_e2e.log >&2 || true
+  exit 1
+fi
+
+curl -fsS "http://127.0.0.1:${PORT}/" >/tmp/gait_ui_e2e_index.html
+curl -fsS "http://127.0.0.1:${PORT}/api/state" >/tmp/gait_ui_e2e_state_before.json
+curl -fsS -X POST "http://127.0.0.1:${PORT}/api/exec" -H 'content-type: application/json' -d '{"command":"demo"}' >/tmp/gait_ui_e2e_demo.json
+curl -fsS -X POST "http://127.0.0.1:${PORT}/api/exec" -H 'content-type: application/json' -d '{"command":"verify_demo"}' >/tmp/gait_ui_e2e_verify.json
+curl -fsS -X POST "http://127.0.0.1:${PORT}/api/exec" -H 'content-type: application/json' -d '{"command":"receipt_demo"}' >/tmp/gait_ui_e2e_receipt.json
+curl -fsS -X POST "http://127.0.0.1:${PORT}/api/exec" -H 'content-type: application/json' -d '{"command":"regress_init","args":{"run_id":"run_demo"}}' >/tmp/gait_ui_e2e_regress_init.json
+curl -fsS -X POST "http://127.0.0.1:${PORT}/api/exec" -H 'content-type: application/json' -d '{"command":"regress_run"}' >/tmp/gait_ui_e2e_regress_run.json
+curl -fsS "http://127.0.0.1:${PORT}/api/state" >/tmp/gait_ui_e2e_state_after.json
+
+python3 - <<'PY'
+import json
+from pathlib import Path
+
+def load_json(path: str):
+    return json.loads(Path(path).read_text(encoding="utf-8"))
+
+index_html = Path("/tmp/gait_ui_e2e_index.html").read_text(encoding="utf-8")
+if "Gait Local UI" not in index_html:
+    raise SystemExit("ui page did not render expected heading")
+
+health = load_json("/tmp/gait_ui_e2e_health.json")
+if not health.get("ok"):
+    raise SystemExit("ui health was not ok")
+
+for path in (
+    "/tmp/gait_ui_e2e_demo.json",
+    "/tmp/gait_ui_e2e_verify.json",
+    "/tmp/gait_ui_e2e_receipt.json",
+    "/tmp/gait_ui_e2e_regress_init.json",
+    "/tmp/gait_ui_e2e_regress_run.json",
+):
+    payload = load_json(path)
+    if payload.get("exit_code") != 0:
+        raise SystemExit(f"command failed ({path}): {payload}")
+
+state_after = load_json("/tmp/gait_ui_e2e_state_after.json")
+if not state_after.get("runpack_path"):
+    raise SystemExit("expected runpack_path after e2e flow")
+if not state_after.get("regress_result_path"):
+    raise SystemExit("expected regress_result_path after e2e flow")
+if not state_after.get("junit_path"):
+    raise SystemExit("expected junit_path after e2e flow")
+PY
+
+echo "ui e2e smoke: pass"

--- a/scripts/test_v2_4_acceptance.sh
+++ b/scripts/test_v2_4_acceptance.sh
@@ -29,7 +29,7 @@ WORK_DIR="$(mktemp -d)"
 trap 'rm -rf "$WORK_DIR"' EXIT
 
 mkdir -p "$WORK_DIR/jobs" "$WORK_DIR/gait-out"
-cp "$REPO_ROOT/fixtures/packspec_tck/v1/run_record_input.json" "$WORK_DIR/run_record_input.json"
+cp "$REPO_ROOT/scripts/testdata/packspec_tck/v1/run_record_input.json" "$WORK_DIR/run_record_input.json"
 
 echo "==> v2.4: signed capture path"
 "$BIN_PATH" run record --input "$WORK_DIR/run_record_input.json" --out-dir "$WORK_DIR/gait-out" --key-mode dev --json > "$WORK_DIR/run_record.json"

--- a/scripts/testdata/packspec_tck/v1/run_record_input.json
+++ b/scripts/testdata/packspec_tck/v1/run_record_input.json
@@ -1,0 +1,70 @@
+{
+  "run": {
+    "schema_id": "gait.runpack.run",
+    "schema_version": "1.0.0",
+    "created_at": "2026-02-14T00:00:00Z",
+    "producer_version": "0.0.0-dev",
+    "run_id": "run_tck",
+    "env": {
+      "os": "darwin",
+      "arch": "arm64",
+      "runtime": "go"
+    },
+    "timeline": [
+      {
+        "event": "tool_call",
+        "ts": "2026-02-14T00:00:00Z",
+        "ref": "intent_1"
+      }
+    ]
+  },
+  "intents": [
+    {
+      "schema_id": "gait.runpack.intent",
+      "schema_version": "1.0.0",
+      "created_at": "2026-02-14T00:00:00Z",
+      "producer_version": "0.0.0-dev",
+      "run_id": "run_tck",
+      "intent_id": "intent_1",
+      "tool_name": "echo",
+      "args_digest": "1111111111111111111111111111111111111111111111111111111111111111",
+      "args": {
+        "message": "hello"
+      }
+    }
+  ],
+  "results": [
+    {
+      "schema_id": "gait.runpack.result",
+      "schema_version": "1.0.0",
+      "created_at": "2026-02-14T00:00:00Z",
+      "producer_version": "0.0.0-dev",
+      "run_id": "run_tck",
+      "intent_id": "intent_1",
+      "status": "ok",
+      "result_digest": "2222222222222222222222222222222222222222222222222222222222222222",
+      "result": {
+        "ok": true
+      }
+    }
+  ],
+  "refs": {
+    "schema_id": "gait.runpack.refs",
+    "schema_version": "1.0.0",
+    "created_at": "2026-02-14T00:00:00Z",
+    "producer_version": "0.0.0-dev",
+    "run_id": "run_tck",
+    "receipts": [
+      {
+        "ref_id": "ref_1",
+        "source_type": "http",
+        "source_locator": "https://example.com",
+        "query_digest": "3333333333333333333333333333333333333333333333333333333333333333",
+        "content_digest": "4444444444444444444444444444444444444444444444444444444444444444",
+        "retrieved_at": "2026-02-14T00:00:00Z",
+        "redaction_mode": "metadata"
+      }
+    ]
+  },
+  "capture_mode": "reference"
+}

--- a/ui/local/package-lock.json
+++ b/ui/local/package-lock.json
@@ -16,10 +16,75 @@
         "@types/node": "24.10.1",
         "@types/react": "19.2.4",
         "@types/react-dom": "19.2.3",
+        "@vitest/coverage-v8": "4.0.7",
         "eslint": "9.39.1",
         "eslint-config-next": "16.1.6",
-        "typescript": "5.9.3"
+        "jsdom": "27.2.0",
+        "typescript": "5.9.3",
+        "vitest": "4.0.7"
       }
+    },
+    "node_modules/@acemir/cssom": {
+      "version": "0.9.31",
+      "resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.31.tgz",
+      "integrity": "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-4.1.2.tgz",
+      "integrity": "sha512-NfBUvBaYgKIuq6E/RBLY1m0IohzNHAYyaJGuTK79Z23uNwmz2jl1mPsC5ZxCCxylinKhT1Amn5oNTlx1wN8cQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.0.0",
+        "@csstools/css-color-parser": "^4.0.1",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.2.5"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "11.2.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
+      "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "6.7.8",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.7.8.tgz",
+      "integrity": "sha512-stisC1nULNc9oH5lakAj8MH88ZxeGxzyWNDfbdCxvJSJIvDsHNZqYvscGTgy/ysgXWLJPt6K/4t0/GjvtKcFJQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.1.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.5"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
+      "version": "11.2.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
+      "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -261,6 +326,148 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.1.tgz",
+      "integrity": "sha512-NmXRccUJMk2AWA5A7e5a//3bCIMyOu2hAtdRYrhPPHjDxINuCwX1w6rnIZ4xjLcp0ayv6h8Pc3X0eJUGiAAXHQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.1.1.tgz",
+      "integrity": "sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.0.1.tgz",
+      "integrity": "sha512-vYwO15eRBEkeF6xjAno/KQ61HacNhfQuuU/eGwH67DplL0zD5ZixUa563phQvUelA07yDczIXdtmYojCphKJcw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.1",
+        "@csstools/css-calc": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.0.27",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.0.27.tgz",
+      "integrity": "sha512-sxP33Jwg1bviSUXAV43cVYdmjt2TLnLXNqCWl9xmxHawWVjGz/kEbdkr7F9pxJNBN2Mh+dq0crgItbW6tQvyow==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0"
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
     "node_modules/@emnapi/core": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.8.1.tgz",
@@ -292,6 +499,448 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
+      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
+      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
+      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
+      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
+      "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
+      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
+      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
+      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
+      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
+      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
+      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
+      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
+      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
+      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
+      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
+      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
+      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
+      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
+      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
+      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
+      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -1211,10 +1860,367 @@
         "node": ">=12.4.0"
       }
     },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.57.1.tgz",
+      "integrity": "sha512-A6ehUVSiSaaliTxai040ZpZ2zTevHYbvu/lDoeAteHI8QnaosIzm4qwtezfRg1jOYaUmnzLX1AOD6Z+UJjtifg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.57.1.tgz",
+      "integrity": "sha512-dQaAddCY9YgkFHZcFNS/606Exo8vcLHwArFZ7vxXq4rigo2bb494/xKMMwRRQW6ug7Js6yXmBZhSBRuBvCCQ3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.57.1.tgz",
+      "integrity": "sha512-crNPrwJOrRxagUYeMn/DZwqN88SDmwaJ8Cvi/TN1HnWBU7GwknckyosC2gd0IqYRsHDEnXf328o9/HC6OkPgOg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.57.1.tgz",
+      "integrity": "sha512-Ji8g8ChVbKrhFtig5QBV7iMaJrGtpHelkB3lsaKzadFBe58gmjfGXAOfI5FV0lYMH8wiqsxKQ1C9B0YTRXVy4w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.57.1.tgz",
+      "integrity": "sha512-R+/WwhsjmwodAcz65guCGFRkMb4gKWTcIeLy60JJQbXrJ97BOXHxnkPFrP+YwFlaS0m+uWJTstrUA9o+UchFug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.57.1.tgz",
+      "integrity": "sha512-IEQTCHeiTOnAUC3IDQdzRAGj3jOAYNr9kBguI7MQAAZK3caezRrg0GxAb6Hchg4lxdZEI5Oq3iov/w/hnFWY9Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.57.1.tgz",
+      "integrity": "sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.57.1.tgz",
+      "integrity": "sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.57.1.tgz",
+      "integrity": "sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.57.1.tgz",
+      "integrity": "sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.57.1.tgz",
+      "integrity": "sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.57.1.tgz",
+      "integrity": "sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.57.1.tgz",
+      "integrity": "sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.57.1.tgz",
+      "integrity": "sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.57.1.tgz",
+      "integrity": "sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.57.1.tgz",
+      "integrity": "sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.57.1.tgz",
+      "integrity": "sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.57.1.tgz",
+      "integrity": "sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.57.1.tgz",
+      "integrity": "sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.57.1.tgz",
+      "integrity": "sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.57.1.tgz",
+      "integrity": "sha512-4wYoDpNg6o/oPximyc/NG+mYUejZrCU2q+2w6YZqrAs2UcNUChIZXjtafAiiZSUc7On8v5NyNj34Kzj/Ltk6dQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.57.1.tgz",
+      "integrity": "sha512-O54mtsV/6LW3P8qdTcamQmuC990HDfR71lo44oZMZlXU4tzLrbvTii87Ni9opq60ds0YzuAlEr/GNwuNluZyMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.57.1.tgz",
+      "integrity": "sha512-P3dLS+IerxCT/7D2q2FYcRdWRl22dNbrbBEtxdWhXrfIMPP9lQhb5h4Du04mdl5Woq05jVCDPCMF7Ub0NAjIew==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.57.1.tgz",
+      "integrity": "sha512-VMBH2eOOaKGtIJYleXsi2B8CPVADrh+TyNxJ4mWPnKfLB/DBUmzW+5m1xUrcwWoMfSLagIRpjUFeW5CO5hyciQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.57.1.tgz",
+      "integrity": "sha512-mxRFDdHIWRxg3UfIIAwCm6NzvxG0jDX/wBN6KsQFTvKFqqg9vTrWUE68qEjHt19A5wwx5X5aUi2zuZT7YR0jrA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
       "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "dev": true,
       "license": "MIT"
     },
@@ -1237,6 +2243,24 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -1827,6 +2851,149 @@
         "win32"
       ]
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.0.7.tgz",
+      "integrity": "sha512-MXc+kEA5EUwMMGmNt1S6CIOEl/iCmAhGZQq1QgMNC3/QpYSOxkysEi6pxWhkqJ7YT/RduoVEV5rxFxHG18V3LA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.0.7",
+        "ast-v8-to-istanbul": "^0.3.5",
+        "debug": "^4.4.3",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.3.5",
+        "std-env": "^3.9.0",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.0.7",
+        "vitest": "4.0.7"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.7.tgz",
+      "integrity": "sha512-jGRG6HghnJDjljdjYIoVzX17S6uCVCBRFnsgdLGJ6CaxfPh8kzUKe/2n533y4O/aeZ/sIr7q7GbuEbeGDsWv4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.0.7",
+        "@vitest/utils": "4.0.7",
+        "chai": "^6.0.1",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.7.tgz",
+      "integrity": "sha512-OsDwLS7WnpuNslOV6bJkXVYVV/6RSc4eeVxV7h9wxQPNxnjRvTTrIikfwCbMyl8XJmW6oOccBj2Q07YwZtQcCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.0.7",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.19"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.7.tgz",
+      "integrity": "sha512-YY//yxqTmk29+/pK+Wi1UB4DUH3lSVgIm+M10rAJ74pOSMgT7rydMSc+vFuq9LjZLhFvVEXir8EcqMke3SVM6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.7.tgz",
+      "integrity": "sha512-orU1lsu4PxLEcDWfjVCNGIedOSF/YtZ+XMrd1PZb90E68khWCNzD8y1dtxtgd0hyBIQk8XggteKN/38VQLvzuw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.0.7",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.7.tgz",
+      "integrity": "sha512-xJL+Nkw0OjaUXXQf13B8iKK5pI9QVtN9uOtzNHYuG/o/B7fIEg0DQ+xOe0/RcqwDEI15rud1k7y5xznBKGUXAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.7",
+        "magic-string": "^0.30.19",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.7.tgz",
+      "integrity": "sha512-FW4X8hzIEn4z+HublB4hBF/FhCVaXfIHm8sUfvlznrcy1MQG7VooBgZPMtVCGZtHi0yl3KESaXTqsKh16d8cFg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.7.tgz",
+      "integrity": "sha512-HNrg9CM/Z4ZWB6RuExhuC6FPmLipiShKVMnT9JlQvfhwR47JatWLChA6mtZqVHqypE6p/z6ofcjbyWpM7YLxPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.7",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -1848,6 +3015,16 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/ajv": {
@@ -2060,10 +3237,39 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/ast-types-flow": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
       "integrity": "sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.11.tgz",
+      "integrity": "sha512-Qya9fkoofMjCBNVdWINMjB5KZvkYfaO9/anwkWnjxibpWUxo5iHl2sOdP7/uAqaRuUYuoo8rDwnbaaKVFxoUvw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -2127,6 +3333,16 @@
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/brace-expansion": {
@@ -2267,6 +3483,16 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -2339,6 +3565,46 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
+      "integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.12.2",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/cssstyle": {
+      "version": "5.3.7",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-5.3.7.tgz",
+      "integrity": "sha512-7D2EPVltRrsTkhpQmksIu+LxeWAIEk6wRDMJ1qljlv+CKHJM+cJLlfhWIzNA44eAsHXSNe3+vO6DW1yCYx8SuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^4.1.1",
+        "@csstools/css-syntax-patches-for-csstree": "^1.0.21",
+        "css-tree": "^3.1.0",
+        "lru-cache": "^11.2.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/cssstyle/node_modules/lru-cache": {
+      "version": "11.2.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
+      "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
@@ -2352,6 +3618,30 @@
       "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
       "dev": true,
       "license": "BSD-2-Clause"
+    },
+    "node_modules/data-urls": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-6.0.1.tgz",
+      "integrity": "sha512-euIQENZg6x8mj3fO6o9+fOW8MimUI4PpD/fZBhJfeioZVy9TUpM4UY7KjQNVZFlqwJ0UdzRDzkycB997HEq1BQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^15.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
@@ -2424,6 +3714,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
@@ -2519,6 +3816,19 @@
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/es-abstract": {
       "version": "1.24.1",
@@ -2637,6 +3947,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -2695,6 +4012,48 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
+      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.3",
+        "@esbuild/android-arm": "0.27.3",
+        "@esbuild/android-arm64": "0.27.3",
+        "@esbuild/android-x64": "0.27.3",
+        "@esbuild/darwin-arm64": "0.27.3",
+        "@esbuild/darwin-x64": "0.27.3",
+        "@esbuild/freebsd-arm64": "0.27.3",
+        "@esbuild/freebsd-x64": "0.27.3",
+        "@esbuild/linux-arm": "0.27.3",
+        "@esbuild/linux-arm64": "0.27.3",
+        "@esbuild/linux-ia32": "0.27.3",
+        "@esbuild/linux-loong64": "0.27.3",
+        "@esbuild/linux-mips64el": "0.27.3",
+        "@esbuild/linux-ppc64": "0.27.3",
+        "@esbuild/linux-riscv64": "0.27.3",
+        "@esbuild/linux-s390x": "0.27.3",
+        "@esbuild/linux-x64": "0.27.3",
+        "@esbuild/netbsd-arm64": "0.27.3",
+        "@esbuild/netbsd-x64": "0.27.3",
+        "@esbuild/openbsd-arm64": "0.27.3",
+        "@esbuild/openbsd-x64": "0.27.3",
+        "@esbuild/openharmony-arm64": "0.27.3",
+        "@esbuild/sunos-x64": "0.27.3",
+        "@esbuild/win32-arm64": "0.27.3",
+        "@esbuild/win32-ia32": "0.27.3",
+        "@esbuild/win32-x64": "0.27.3"
       }
     },
     "node_modules/escalade": {
@@ -3134,6 +4493,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -3142,6 +4511,16 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -3283,6 +4662,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {
@@ -3581,6 +4975,67 @@
       "license": "MIT",
       "dependencies": {
         "hermes-estree": "0.25.1"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/ignore": {
@@ -3905,6 +5360,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -4064,6 +5526,60 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/iterator.prototype": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.5.tgz",
@@ -4100,6 +5616,46 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "27.2.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-27.2.0.tgz",
+      "integrity": "sha512-454TI39PeRDW1LgpyLPyURtB4Zx1tklSr6+OFOipsxGUH1WMTvk6C65JQdrj455+DP2uJ1+veBEHTGFKWVLFoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@acemir/cssom": "^0.9.23",
+        "@asamuzakjp/dom-selector": "^6.7.4",
+        "cssstyle": "^5.3.3",
+        "data-urls": "^6.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "parse5": "^8.0.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^15.1.0",
+        "ws": "^8.18.3",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
       }
     },
     "node_modules/jsesc": {
@@ -4255,6 +5811,57 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -4264,6 +5871,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
+      "integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -4624,6 +6238,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse5": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
+      "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -4648,6 +6275,13 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
     },
@@ -4833,6 +6467,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/resolve": {
       "version": "1.22.11",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
@@ -4883,6 +6527,51 @@
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.57.1.tgz",
+      "integrity": "sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.57.1",
+        "@rollup/rollup-android-arm64": "4.57.1",
+        "@rollup/rollup-darwin-arm64": "4.57.1",
+        "@rollup/rollup-darwin-x64": "4.57.1",
+        "@rollup/rollup-freebsd-arm64": "4.57.1",
+        "@rollup/rollup-freebsd-x64": "4.57.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.57.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.57.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.57.1",
+        "@rollup/rollup-linux-arm64-musl": "4.57.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.57.1",
+        "@rollup/rollup-linux-loong64-musl": "4.57.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.57.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.57.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.57.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.57.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.57.1",
+        "@rollup/rollup-linux-x64-gnu": "4.57.1",
+        "@rollup/rollup-linux-x64-musl": "4.57.1",
+        "@rollup/rollup-openbsd-x64": "4.57.1",
+        "@rollup/rollup-openharmony-arm64": "4.57.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.57.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.57.1",
+        "@rollup/rollup-win32-x64-gnu": "4.57.1",
+        "@rollup/rollup-win32-x64-msvc": "4.57.1",
+        "fsevents": "~2.3.2"
       }
     },
     "node_modules/run-parallel": {
@@ -4962,6 +6651,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/scheduler": {
@@ -5186,6 +6895,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -5199,6 +6915,20 @@
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.5.tgz",
       "integrity": "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
       "dev": true,
       "license": "MIT"
     },
@@ -5401,6 +7131,27 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -5449,6 +7200,36 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/tinyrainbow": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
+      "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.0.23",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.23.tgz",
+      "integrity": "sha512-ASdhgQIBSay0R/eXggAkQ53G4nTJqTXqC2kbaBbdDwM7SkjyZyO0OaaN1/FH7U/yCeqOHDwFO5j8+Os/IS1dXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.23"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.23",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.23.tgz",
+      "integrity": "sha512-0g9vrtDQLrNIiCj22HSe9d4mLVG3g5ph5DZ8zCKBr4OtrspmNB6ss7hVyzArAeE88ceZocIEGkyW1Ime7fxPtQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -5460,6 +7241,32 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.0.tgz",
+      "integrity": "sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/ts-api-utils": {
@@ -5738,6 +7545,293 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/vite": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
+      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vite/node_modules/postcss": {
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.7.tgz",
+      "integrity": "sha512-xQroKAadK503CrmbzCISvQUjeuvEZzv6U0wlnlVFOi5i3gnzfH4onyQ29f3lzpe0FresAiTAd3aqK0Bi/jLI8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.0.7",
+        "@vitest/mocker": "4.0.7",
+        "@vitest/pretty-format": "4.0.7",
+        "@vitest/runner": "4.0.7",
+        "@vitest/snapshot": "4.0.7",
+        "@vitest/spy": "4.0.7",
+        "@vitest/utils": "4.0.7",
+        "debug": "^4.4.3",
+        "es-module-lexer": "^1.7.0",
+        "expect-type": "^1.2.2",
+        "magic-string": "^0.30.19",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.0.3",
+        "vite": "^6.0.0 || ^7.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.0.7",
+        "@vitest/browser-preview": "4.0.7",
+        "@vitest/browser-webdriverio": "4.0.7",
+        "@vitest/ui": "4.0.7",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-15.1.0.tgz",
+      "integrity": "sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -5843,6 +7937,23 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -5852,6 +7963,45 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/ws": {
+      "version": "8.19.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
+      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/ui/local/package.json
+++ b/ui/local/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev -p 3020",
     "build": "next build",
     "start": "next start -p 3020",
-    "lint": "eslint . --max-warnings=0"
+    "lint": "eslint . --max-warnings=0",
+    "test": "vitest run --coverage"
   },
   "dependencies": {
     "next": "16.1.6",
@@ -17,8 +18,11 @@
     "@types/node": "24.10.1",
     "@types/react": "19.2.4",
     "@types/react-dom": "19.2.3",
+    "@vitest/coverage-v8": "4.0.7",
     "eslint": "9.39.1",
     "eslint-config-next": "16.1.6",
-    "typescript": "5.9.3"
+    "jsdom": "27.2.0",
+    "typescript": "5.9.3",
+    "vitest": "4.0.7"
   }
 }

--- a/ui/local/src/app/page.test.ts
+++ b/ui/local/src/app/page.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from "vitest";
+import { buildActionArgs, computeArtifactChanges, prettyAction, stateFallback, type StateResponse } from "./page";
+
+describe("ui page helpers", () => {
+  test("prettyAction resolves known labels", () => {
+    expect(prettyAction("demo")).toContain("Run Demo");
+    expect(prettyAction("unknown")).toBe("unknown");
+  });
+
+  test("stateFallback normalizes errors", () => {
+    const fromError = stateFallback(new Error("network down"));
+    expect(fromError.ok).toBe(false);
+    expect(fromError.error).toBe("network down");
+
+    const fromUnknown = stateFallback("boom");
+    expect(fromUnknown.error).toBe("unknown error");
+  });
+
+  test("buildActionArgs wires regress and policy transitions", () => {
+    expect(buildActionArgs("demo", "run_demo", "p.yaml", "i.json")).toEqual({});
+    expect(buildActionArgs("regress_init", "  run_123  ", "p.yaml", "i.json")).toEqual({
+      run_id: "run_123",
+    });
+    expect(buildActionArgs("policy_block_test", "run_demo", "policy.yaml", "intent.json")).toEqual({
+      policy_path: "policy.yaml",
+      intent_path: "intent.json",
+    });
+  });
+
+  test("computeArtifactChanges returns added and modified artifacts", () => {
+    const previousState: StateResponse = {
+      ok: true,
+      workspace: "/tmp/work",
+      gait_config_exists: false,
+      artifacts: [
+        { key: "runpack", path: "a.zip", exists: true, modified_at: "2026-02-14T00:00:00Z" },
+        { key: "junit", path: "junit.xml", exists: false },
+      ],
+    };
+
+    const nextState: StateResponse = {
+      ok: true,
+      workspace: "/tmp/work",
+      gait_config_exists: false,
+      artifacts: [
+        { key: "runpack", path: "a.zip", exists: true, modified_at: "2026-02-14T00:00:02Z" },
+        { key: "junit", path: "junit.xml", exists: true, modified_at: "2026-02-14T00:00:02Z" },
+        { key: "regress_result", path: "regress_result.json", exists: true, modified_at: "2026-02-14T00:00:02Z" },
+      ],
+    };
+
+    const changed = computeArtifactChanges(previousState, nextState);
+    expect(changed).toContain("runpack @ 2026-02-14T00:00:02Z");
+    expect(changed).toContain("junit @ 2026-02-14T00:00:02Z");
+    expect(changed).toContain("regress_result @ 2026-02-14T00:00:02Z");
+  });
+});

--- a/ui/local/vitest.config.ts
+++ b/ui/local/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "jsdom",
+    include: ["src/**/*.test.ts", "src/**/*.test.tsx"],
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "json-summary"],
+      include: ["src/**/*.ts", "src/**/*.tsx"],
+      exclude: ["src/**/*.d.ts"],
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- add `product/TESTS_GAPS.md` with the v2.4 test-gap plan and explicit check item for GitHub run `22018642257`
- fix acceptance/TCK CI breakage from run `22018642257` by moving `run_record_input.json` into tracked `scripts/testdata/packspec_tck/v1/` and updating scripts/docs to use that path
- enforce per-package Go coverage floor (75%) via `scripts/check_go_package_coverage.py` wired into `make test` and CI
- add missing UAT/UI acceptance coverage in `scripts/test_uat_local.sh`, `docs/uat_functional_plan.md`, and CI
- add a dedicated `v2_4_gate` release workflow job and require it before release
- raise low package coverage (`core/errors`, `internal/testutil`) with behavior-focused tests

## Validation
- `make lint-fast`
- `make test`
- `make test-e2e`
- `go test ./internal/integration -count=1`
- `make test-v2-4-acceptance`
- `make test-packspec-tck`
- `make test-ui-acceptance`
- `make test-chaos`
- `make test-runtime-slo`
- `make bench-check`
- `make codeql` (no findings >= warning)

## CI run bug addressed
- failing run: https://github.com/davidahmann/gait/actions/runs/22018642257
- root cause: ignored fixture under `/fixtures/` not present on runners
- fix: tracked fixture in repo testdata + script path updates
