### PR TITLE
Docs consistency pass for v2.3/v2.4/v2.5 and UAT summary retention

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ perf/ui_budget_report.json
 /gait.yaml
 /regress_result.json
 /fixtures/
+/.uat_local/
 docs-site/node_modules/
 docs-site/.next/
 docs-site/out/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Control and Prove Agent Tool Calls with Verifiable Runpacks
+# Gait — Run Durable Agent Jobs, Capture Tool Calls, Prove What Happened
 
-Gait captures a signed runpack for every tool-using AI run so you can verify, replay (stub mode), and diff behavior offline. Add regressions to stop drift in CI. Optionally gate high-risk tool calls with policy and approvals.
+Gait is an offline-first runtime for production AI agents. Dispatch durable jobs with checkpointed state. Capture every state-changing tool call as a signed pack you can verify, diff, and replay. Turn incidents into deterministic CI regressions. Gate high-risk actions with fail-closed policy and approvals before side effects execute.
 
 ![PR Fast](https://github.com/davidahmann/gait/actions/workflows/pr-fast.yml/badge.svg)
 ![CodeQL](https://github.com/davidahmann/gait/actions/workflows/codeql.yml/badge.svg)
@@ -12,14 +12,14 @@ Runpack format: [`docs/contracts/primitive_contract.md`](docs/contracts/primitiv
 PackSpec v1: [`docs/contracts/packspec_v1.md`](docs/contracts/packspec_v1.md)  
 Changelog: [CHANGELOG.md](CHANGELOG.md)
 
-Primary CTA: `gait demo` (offline, <60s)  
-Secondary CTA: verify artifacts with `gait verify <path>`
+**For platform and AI engineering teams** that run multi-step and multi-hour agent jobs and need state, provenance, and control without losing work mid-flight.
 
-- verifiable receipts: signed runpacks and trace records
-- debuggable by default: replay and diff two runs to see what changed
-- prevent repeats: convert a run into a regression test in CI
+**For security engineers and production owners** that need every high-risk tool call to pass a deterministic policy decision with portable, independently verifiable proof.
 
-Outputs: `run_id`, `runpack_<run_id>.zip`, and a ticket footer you can paste into incidents.
+- durable jobs: dispatch long-running work with checkpoints, pause/resume/cancel, and deterministic stop reasons
+- signed packs: every run and job emits a verifiable artifact you can attach to PRs, incidents, and audits
+- incident-to-regression: one command converts a failure into a permanent CI gate
+- fail-closed enforcement: policy decides before the action runs; non-allow means non-execute
 
 ## Try It (Offline, <60s)
 
@@ -51,16 +51,17 @@ Regenerate asset: `bash scripts/record_runpack_hero_demo.sh`
 
 ## Why Gait
 
-AI agents now execute high-authority actions: write data, mutate repos, call external APIs, rotate infra. Most stacks still rely on prompt scanning and after-the-fact observability.
+Autonomous agents are capable enough to execute real work, but teams cannot run them safely at scale. The limiting factor is not intelligence — it is operability and governance: long-running work fails mid-flight, state-changing tool calls are hard to reconstruct, and post-hoc logs are not dispute-grade evidence.
 
 Gait keeps the contract deterministic and offline-first:
 
-- runpack: signed artifact per run (`gait verify`, `gait run replay`, `gait run diff`)
-- regress: convert incidents into CI checks (`gait regress init`, `gait regress run`)
-- report top: rank highest-risk actions from runpacks/traces offline (`gait report top`)
-- optional gate: enforce policy and approvals at tool-call time (`gait gate eval`)
+- **durable jobs**: dispatch multi-step, multi-hour agent work with checkpointed state, pause/resume/cancel, and deterministic stop reasons (`gait job submit`, `gait job checkpoint`, `gait job status`)
+- **signed packs**: unified artifact for runs and jobs — verify, diff, and inspect offline (`gait pack build`, `gait pack verify`, `gait pack diff`)
+- **regress**: convert any incident into a permanent CI check with stable exit codes (`gait regress bootstrap`, `gait regress run`)
+- **report top**: rank highest-risk actions from runpacks/traces offline (`gait report top`)
+- **gate**: enforce policy and approvals at tool-call time — non-allow means non-execute (`gait gate eval`)
 
-If your agent touched production, attach the runpack.
+If your agent touched production, attach the pack.
 
 ## First Win
 
@@ -76,7 +77,7 @@ Expected output includes:
 - signed bundle under `gait-out/`
 - `ticket_footer=GAIT run_id=...` for PRs/incidents
 
-## Optional Local UI
+## Optional Local UI Playground
 
 Run a local-only UI for guided demo and onboarding flows:
 
@@ -90,16 +91,16 @@ Details: [`docs/ui_localhost.md`](docs/ui_localhost.md) and [`docs/contracts/ui_
 
 ## Core OSS Surfaces
 
-- `runpack`: record, inspect, verify, diff, receipt, replay (stub default)
-- `job`: durable lifecycle controls (submit/status/checkpoints/pause/approve/resume/cancel)
-- `pack`: unified artifact build/verify/inspect/diff for `run` and `job` evidence
-- `regress`: incident-to-regression workflow with CI/JUnit outputs
-- `gate`: policy evaluation for tool intent with signed trace output
+- `job`: dispatch durable long-running agent work with checkpointed state, pause/resume/cancel, approval gates, and deterministic stop reasons
+- `pack`: unified evidence artifact (run or job) — build, verify, inspect, diff offline with stable schemas and exit codes
+- `runpack`: record, inspect, verify, diff, receipt, replay (stub default) for individual tool-call runs
+- `regress`: incident-to-regression workflow with CI/JUnit outputs — one command to never ship the same failure again
+- `gate`: fail-closed policy evaluation for tool intent with signed trace output and approval/delegation token support
 - `doctor`: first-run diagnostics and production-readiness checks
+- `mcp proxy/bridge/serve`: transport adapters that enforce through Gate (one-shot, bridged, or long-running service)
 - `scout`: local snapshot/diff/signal analysis for drift clustering
 - `guard` and `incident`: deterministic evidence and incident bundles
 - `registry`: signed/pinned skill-pack install and verify workflows
-- `mcp proxy/bridge/serve`: transport adapters that enforce through Gate
 
 ## Turn Incidents Into CI Regressions
 
@@ -156,9 +157,9 @@ gait gate eval \
 
 Policy authoring and rollout docs: [`docs/policy_authoring.md`](docs/policy_authoring.md), [`docs/policy_rollout.md`](docs/policy_rollout.md), [`docs/approval_runbook.md`](docs/approval_runbook.md)
 
-## Long-Running Sessions And Delegation
+## Durable Sessions and Multi-Agent Delegation
 
-Checkpoint multi-day runs without losing deterministic history:
+Run multi-step, multi-day agent work without losing state or provenance. Checkpoints create verifiable runpacks at each boundary so you can resume, audit, or regress any segment:
 
 ```bash
 gait run session start --journal ./gait-out/sessions/demo.journal.jsonl --session-id sess_demo --run-id run_demo --json
@@ -287,8 +288,8 @@ Contributor guide: [`CONTRIBUTING.md`](CONTRIBUTING.md)
 
 ## OSS And Enterprise Boundary
 
-- OSS is the executable substrate: runpack, regress, gate, doctor, scout, guard, adapters
-- Enterprise is a separate fleet governance layer that consumes OSS artifacts
+- OSS is the execution substrate: durable jobs, signed packs, regressions, fail-closed gates, diagnostics, and adapters
+- Enterprise is a separate fleet governance layer that consumes OSS artifacts for cross-team rollout, compliance, and fleet-scale simulation
 - Enterprise packaging does not change OSS runtime contracts
 
 Boundary details: [`docs/packaging.md`](docs/packaging.md)

--- a/docs-site/src/app/page.tsx
+++ b/docs-site/src/app/page.tsx
@@ -3,9 +3,9 @@ import type { Metadata } from 'next';
 import { canonicalUrl } from '@/lib/site';
 
 export const metadata: Metadata = {
-  title: 'Gait | Agent Control and Proof',
+  title: 'Gait | Durable Agent Runtime with Signed Proof',
   description:
-    'Gait is the offline-first execution boundary for production AI agents: runpack, regress, gate, doctor.',
+    'Gait is an offline-first runtime for production AI agents: durable jobs, signed packs, deterministic regressions, and fail-closed policy gates.',
   alternates: {
     canonical: canonicalUrl('/'),
   },
@@ -15,24 +15,24 @@ const QUICKSTART = `curl -fsSL https://raw.githubusercontent.com/davidahmann/gai
 
 const features = [
   {
-    title: 'Runpack: Verifiable Incident Evidence',
-    description: 'Capture signed, deterministic execution artifacts you can verify offline and paste into tickets.',
+    title: 'Durable Jobs: Run Without Losing State',
+    description: 'Dispatch multi-step, multi-hour agent work with checkpoints, pause/resume/cancel, approval gates, and deterministic stop reasons.',
+    href: '/docs/flows',
+  },
+  {
+    title: 'Signed Packs: Portable Proof',
+    description: 'Every run and job emits a signed pack you can verify, diff, and inspect offline. Attach it to PRs, incidents, and audits.',
     href: '/docs/concepts/mental_model',
   },
   {
-    title: 'Regress: Incident -> Never Again',
-    description: 'Turn a runpack into deterministic CI regressions with machine-readable output and JUnit.',
+    title: 'Regress: Incident to CI Gate',
+    description: 'One command converts a failure into a permanent regression test with JUnit output and stable exit codes.',
     href: '/docs/ci_regress_kit',
   },
   {
-    title: 'Gate: Fail-Closed Tool Control',
-    description: 'Evaluate structured tool-call intent against YAML policy and approval constraints.',
+    title: 'Gate: Fail-Closed Policy Enforcement',
+    description: 'Evaluate structured tool-call intent against policy before side effects execute. Non-allow means non-execute.',
     href: '/docs/policy_rollout',
-  },
-  {
-    title: 'Doctor: First 5 Minutes',
-    description: 'Diagnose environment issues quickly with stable JSON and explicit fix guidance.',
-    href: '/docs/uat_functional_plan',
   },
   {
     title: 'Vendor-Neutral Integrations',
@@ -40,27 +40,27 @@ const features = [
     href: '/docs/integration_checklist',
   },
   {
-    title: 'Security and Contracts',
-    description: 'Stable artifacts, explicit schemas, skill provenance, and endpoint action taxonomy.',
+    title: 'Contracts and Schemas',
+    description: 'Stable artifacts, versioned schemas, deterministic outputs, and offline verification. No network dependency for core workflows.',
     href: '/docs/contracts/primitive_contract',
   },
 ];
 
 const faqs = [
   {
+    question: 'What problem does Gait solve for long-running agent work?',
+    answer:
+      'Multi-step and multi-hour agent jobs fail mid-flight, losing state and provenance. Gait dispatches durable jobs with checkpointed state, pause/resume/cancel, and deterministic stop reasons so work survives failures and stays auditable.',
+  },
+  {
     question: 'What does Gait do that logs do not?',
     answer:
-      'Gait produces signed runpacks and traces with deterministic verification, so incidents are reproducible evidence rather than best-effort log interpretation.',
+      'Gait produces signed packs and traces with deterministic verification, so incidents are portable, independently verifiable evidence rather than best-effort log interpretation.',
   },
   {
     question: 'Does Gait require a hosted service?',
     answer:
       'No. Core workflows are offline-first and run locally: capture, verify, diff, policy evaluation, and regressions can run without a network dependency.',
-  },
-  {
-    question: 'How long does integration typically take?',
-    answer:
-      'Most teams can go from demo to first boundary enforcement in 30 to 120 minutes using one wrapper or one sidecar plus policy fixtures.',
   },
   {
     question: 'How does Gait handle prompt-injection style risk?',
@@ -76,7 +76,7 @@ const softwareApplicationJsonLd = {
   applicationCategory: 'DeveloperApplication',
   operatingSystem: 'Linux, macOS, Windows',
   description:
-    'Offline-first CLI for controlling and proving production AI agent actions with runpacks, regressions, and fail-closed policy gates.',
+    'Offline-first runtime for production AI agents: durable jobs, signed packs, deterministic regressions, and fail-closed policy gates at the tool boundary.',
   url: 'https://davidahmann.github.io/gait/',
   softwareHelp: 'https://davidahmann.github.io/gait/docs/',
   codeRepository: 'https://github.com/davidahmann/gait',
@@ -108,12 +108,12 @@ export default function HomePage() {
 
       <div className="text-center py-12 lg:py-20">
         <h1 className="text-4xl lg:text-6xl font-bold text-white mb-6">
-          Control and Prove
-          <span className="bg-gradient-to-r from-cyan-400 to-blue-500 bg-clip-text text-transparent"> Agent Actions</span>
+          Run Durable Agent Jobs.
+          <span className="bg-gradient-to-r from-cyan-400 to-blue-500 bg-clip-text text-transparent"> Prove What Happened.</span>
         </h1>
         <p className="text-xl text-gray-400 max-w-3xl mx-auto mb-8">
-          Gait turns production agent behavior into a governable execution substrate: signed runpacks, deterministic regressions,
-          and fail-closed policy gates at the tool boundary.
+          Gait is an offline-first runtime that dispatches durable agent jobs, captures state-changing tool calls,
+          and emits signed packs you can verify, diff, and turn into deterministic CI regressions.
         </p>
         <div className="flex flex-col sm:flex-row gap-4 justify-center">
           <Link href="/docs/install" className="px-6 py-3 bg-cyan-500 hover:bg-cyan-400 text-gray-900 font-semibold rounded-lg transition-colors">
@@ -156,14 +156,19 @@ export default function HomePage() {
           </thead>
           <tbody className="divide-y divide-gray-800">
             <tr>
+              <td className="py-3 px-4 text-gray-300 font-medium">Long-running agent work</td>
+              <td className="py-3 px-4 text-gray-500">fails mid-flight, lost state</td>
+              <td className="py-3 px-4 text-gray-300">durable jobs with checkpoints + resume</td>
+            </tr>
+            <tr>
               <td className="py-3 px-4 text-gray-300 font-medium">Incident evidence</td>
               <td className="py-3 px-4 text-gray-500">logs + screenshots</td>
-              <td className="py-3 px-4 text-gray-300">signed runpack + ticket footer</td>
+              <td className="py-3 px-4 text-gray-300">signed pack + ticket footer</td>
             </tr>
             <tr>
               <td className="py-3 px-4 text-gray-300 font-medium">Regression loop</td>
               <td className="py-3 px-4 text-gray-500">manual repro, often skipped</td>
-              <td className="py-3 px-4 text-gray-300">deterministic fixture + CI lane</td>
+              <td className="py-3 px-4 text-gray-300">deterministic fixture + CI gate</td>
             </tr>
             <tr>
               <td className="py-3 px-4 text-gray-300 font-medium">High-risk tool calls</td>
@@ -173,7 +178,7 @@ export default function HomePage() {
             <tr>
               <td className="py-3 px-4 text-gray-300 font-medium">Audit posture</td>
               <td className="py-3 px-4 text-gray-500">incomplete reconstruction</td>
-              <td className="py-3 px-4 text-gray-300">offline verifiable artifacts</td>
+              <td className="py-3 px-4 text-gray-300">offline verifiable signed artifacts</td>
             </tr>
           </tbody>
         </table>
@@ -192,8 +197,8 @@ export default function HomePage() {
       </div>
 
       <div className="text-center py-12 border-t border-gray-800">
-        <h2 className="text-2xl font-bold text-white mb-4">Start with one command. Keep the evidence forever.</h2>
-        <p className="text-gray-400 mb-6">Read the install and integration checklist, then wire your first policy-gated tool boundary.</p>
+        <h2 className="text-2xl font-bold text-white mb-4">First pack in 60 seconds. Durable jobs from day one.</h2>
+        <p className="text-gray-400 mb-6">Install, run the demo, then wire your first durable job or policy-gated tool boundary.</p>
         <Link href="/docs/install" className="inline-block px-6 py-3 bg-cyan-500 hover:bg-cyan-400 text-gray-900 font-semibold rounded-lg transition-colors">
           Open Install Guide
         </Link>

--- a/docs/README.md
+++ b/docs/README.md
@@ -29,6 +29,7 @@ This file defines where each topic lives so docs stay accurate and non-duplicati
 ## Contracts And Compatibility
 
 - Primitive contract: `docs/contracts/primitive_contract.md`
+- ContextSpec v1 contract: `docs/contracts/contextspec_v1.md`
 - PackSpec v1 contract: `docs/contracts/packspec_v1.md`
 - PackSpec TCK: `docs/contracts/packspec_tck.md`
 - Artifact graph: `docs/contracts/artifact_graph.md`
@@ -45,6 +46,8 @@ This file defines where each topic lives so docs stay accurate and non-duplicati
 - Retention profiles: `docs/slo/retention_profiles.md`
 - CI regress runbook: `docs/ci_regress_kit.md`
 - UAT plan: `docs/uat_functional_plan.md`
+- Test cadence: `docs/test_cadence.md`
+- Hardening release checklist: `docs/hardening/release_checklist.md`
 
 ## Adoption And Ecosystem
 

--- a/docs/contracts/artifact_graph.md
+++ b/docs/contracts/artifact_graph.md
@@ -9,6 +9,7 @@ This contract defines how Gait artifacts compose into a verifiable graph over ti
 Applies to:
 
 - Runpack artifacts (`gait.runpack.*`)
+- Context evidence artifacts (`gait.context.envelope`, `gait.context.reference_record`, `gait.context.budget_report`)
 - Session artifacts (`gait.runpack.session_journal`, `gait.runpack.session_checkpoint`, `gait.runpack.session_chain`)
 - Gate traces (`gait.gate.trace`)
 - Delegation artifacts (`gait.gate.delegation_token`, `gait.gate.delegation_audit_record`)
@@ -26,13 +27,15 @@ Applies to:
 ## Graph Integrity Expectations
 
 - A `TraceRecord` MUST bind verdict context (`intent_digest`, `policy_digest`) for one tool decision.
+- A `TraceRecord` SHOULD carry `context_set_digest` when context evidence is present in the evaluated intent path.
 - A `Runpack` MUST include the deterministic run timeline and manifest digests for replay and verification.
+- A context-enabled `Runpack` SHOULD preserve `refs.context_set_digest` continuity with any bundled `context_envelope.json`.
 - A `SessionCheckpoint` MUST bind checkpoint index/range to runpack `manifest_digest` and `checkpoint_digest`.
 - A `SessionChain` MUST preserve `prev_checkpoint_digest` continuity across checkpoint sequence.
 - A `RegressResult` SHOULD reference fixture/run identity so failures can map back to captured artifacts.
 - Evidence bundles SHOULD include pointers back to the exact runpack/trace/regress artifacts they summarize.
 - Delegation audits SHOULD reference the trace and delegation token IDs used for allow/block outcomes.
-- Consumer projections SHOULD preserve intent/receipt digest continuity (`intent_digest`, `policy_digest`, `refs.receipts[*].{query_digest,content_digest}`) when deriving audit views.
+- Consumer projections SHOULD preserve intent/receipt digest continuity (`intent_digest`, `policy_digest`, `refs.context_set_digest`, `refs.receipts[*].{query_digest,content_digest}`) when deriving audit views.
 
 ## Compatibility Model
 

--- a/docs/flows.md
+++ b/docs/flows.md
@@ -43,6 +43,30 @@ sequenceDiagram
 
 Outcome: durable runtime control and portable evidence under one pack contract.
 
+## 1c) Context Evidence Proof Flow (v2.5)
+
+```mermaid
+sequenceDiagram
+    participant Dev as Developer
+    participant Record as gait run record
+    participant Gate as gait gate eval
+    participant Pack as gait pack inspect/diff
+    participant Regress as gait regress run
+    participant FS as Local Filesystem
+
+    Dev->>Record: run record --context-envelope --context-evidence-mode required
+    Record->>FS: write runpack + refs.context_set_digest
+    Record->>FS: write context_envelope.json when receipts exist
+    Dev->>Gate: gate eval (high-risk intent)
+    Gate-->>Dev: allow/block with context reason codes + trace context_set_digest
+    Dev->>Pack: pack inspect / pack diff
+    Pack-->>Dev: deterministic context summary + drift classification
+    Dev->>Regress: regress run
+    Regress-->>Dev: context conformance grader result (semantic/runtime/none)
+```
+
+Outcome: context usage is deterministic, auditable, and release-gatable without weakening offline-first behavior.
+
 ## 2) Execution-Boundary Gate Flow
 
 ```mermaid

--- a/docs/hardening/release_checklist.md
+++ b/docs/hardening/release_checklist.md
@@ -9,6 +9,14 @@ Use this checklist before creating a release tag. Items marked "MANDATORY" are r
   - Go coverage >= 85%
   - Python coverage >= 85%
 - [ ] `make test-hardening-acceptance` passes.
+- [ ] Versioned acceptance/context gates pass:
+  - `make test-v2-3-acceptance`
+  - `make test-v2-4-acceptance`
+  - `make test-v2-5-acceptance`
+  - `make test-context-conformance`
+  - `make test-context-chaos`
+- [ ] Full local UAT passes: `bash scripts/test_uat_local.sh`
+  - verify `.uat_local/summary.txt` contains `UAT COMPLETE: PASS`
 - [ ] CI `hardening` job is green on the release commit.
 
 ## 2) Contract Integrity (MANDATORY)
@@ -38,6 +46,10 @@ Use this checklist before creating a release tag. Items marked "MANDATORY" are r
 ## 5) Supply Chain Integrity (MANDATORY)
 
 - [ ] Release workflow tool versions are pinned.
+- [ ] Release workflow gate jobs are green and release depends on all version gates:
+  - `v2_3_gate`
+  - `v2_4_gate`
+  - `v2_5_gate`
 - [ ] Checksums generated and verified.
 - [ ] Signatures/provenance artifacts generated and verifiable.
 - [ ] Homebrew formula asset rendered from release checksums (`dist/gait.rb`).

--- a/docs/uat_functional_plan.md
+++ b/docs/uat_functional_plan.md
@@ -89,7 +89,7 @@ bash scripts/test_uat_local.sh
 Options:
 
 ```bash
-GAIT_UAT_RELEASE_VERSION=vX.Y.Z bash scripts/test_uat_local.sh --output-dir ./gait-out/uat_local
+GAIT_UAT_RELEASE_VERSION=vX.Y.Z bash scripts/test_uat_local.sh --output-dir ./.uat_local
 bash scripts/test_uat_local.sh --skip-brew
 bash scripts/test_uat_local.sh --skip-docs-site
 ```
@@ -103,9 +103,10 @@ bash scripts/test_uat_local.sh --baseline-install-paths
 
 ## Outputs
 
-- Human-readable logs: `gait-out/uat_local/logs/*.log`
-- Machine-readable summary: `gait-out/uat_local/summary.txt`
+- Human-readable logs: `.uat_local/logs/*.log`
+- Machine-readable summary: `.uat_local/summary.txt`
 - Primary path marker in summary: `PRIMARY_INSTALL_PATH_STATUS release-installer PASS`
+- Default output is `.uat_local` (outside `gait-out/`) so cleanup steps in downstream suites do not truncate the orchestrator summary.
 
 ## Pass Criteria
 
@@ -128,7 +129,7 @@ bash scripts/test_uat_local.sh --baseline-install-paths
 
 On failure:
 
-1. Open failing log under `gait-out/uat_local/logs/`.
+1. Open failing log under `.uat_local/logs/`.
 2. Fix root cause in code/docs/scripts (not by weakening tests).
 3. Re-run `bash scripts/test_uat_local.sh`.
 4. Only merge when summary is fully green.

--- a/product/PLAN_v2.5.md
+++ b/product/PLAN_v2.5.md
@@ -553,6 +553,7 @@ Add required quality steps:
 
 Acceptance criteria:
 - Local UAT summary includes v2.5 and context lanes with PASS/FAIL.
+- Default UAT artifact path preserves the full orchestrator summary (`.uat_local/summary.txt`) even when downstream suites clean `gait-out/`.
 - Existing install-path checks (source/release/brew) remain intact.
 
 ### 6.4 Integration + e2e + acceptance additions

--- a/product/TESTS_GAPS.md
+++ b/product/TESTS_GAPS.md
@@ -13,7 +13,7 @@ This plan closes test-matrix and coverage gaps found during repo audit, plus che
 
 | Gap | Evidence | Action | Status |
 |---|---|---|---|
-| Release gate lagging v2.4 contract | `product/PLAN_2.4.md` release gates vs `release.yml` only gating v2.3 | Add a `v2_4_gate` release workflow job that runs v2.4 acceptance + TCK + e2e + integration + chaos + perf budgets. Make release depend on both v2.3 and v2.4 gates. | Implemented |
+| Release gate lagging v2.4 contract | `product/PLAN_2.4.md` release gates vs `release.yml` only gating v2.3 | Added `v2_4_gate`; release dependency now includes `v2_3_gate`, `v2_4_gate`, and v2.5 context gate `v2_5_gate` to preserve continuity across v2.3/v2.4/v2.5 contracts. | Implemented |
 | UI acceptance not part of CI/UAT quality gate | `test-ui-acceptance` exists but was not wired into CI and UAT orchestrator | Add dedicated CI `ui-acceptance` job. Add `quality_ui_acceptance` step to `scripts/test_uat_local.sh`. Update UAT plan docs. | Implemented |
 | Package-level Go coverage floor not enforced | Existing checks only enforced aggregate coverage | Add package coverage checker script and enforce >=75% package coverage in `make test` and CI test lanes. | Implemented |
 | Failing CI run due missing tracked PackSpec fixture | Run `22018642257` failed in `v2-4-acceptance` and `packspec-tck` with missing `fixtures/packspec_tck/v1/run_record_input.json` | Move PackSpec fixture to tracked `scripts/testdata/packspec_tck/v1/run_record_input.json` and update scripts/docs to use it. | Implemented |
@@ -21,6 +21,7 @@ This plan closes test-matrix and coverage gaps found during repo audit, plus che
 | Docs-site route/link rendering checks beyond lint/build | Plan asks for deeper link/render checks | Added `scripts/check_docs_site_validation.py`, CI docs validation step + artifact, and UAT `docs-site-check` wiring. | Implemented |
 | UI frontend unit/e2e and UI performance budget lane | `PLAN_UI.md` requests frontend unit/e2e/perf budget lanes | Added Vitest-based frontend unit tests, `scripts/test_ui_e2e_smoke.sh` CI lane, and UI budget enforcement (`perf/ui_budgets.json`, `scripts/check_ui_budgets.py`, nightly workflow + perf-nightly integration). | Implemented |
 | Runtime perf coverage missing job/pack lifecycle commands | Runtime SLO budgets previously focused on demo/regress/gate/session | Extended command budget matrix and runtime budgets with `job_submit`, `job_checkpoint_add`, `job_approve`, `job_resume`, `pack_build_job`, and `pack_verify_job`. | Implemented |
+| UAT summary omitted earlier quality lanes under `gait-out/uat_local` | Some suites clean `gait-out/`, which could truncate orchestrator summary and hide v2.5/context PASS lines | Moved default UAT output to `.uat_local` and updated docs so full v2.3/v2.4/v2.5 context lanes remain visible in final summary. | Implemented |
 
 ## Verification Commands
 
@@ -32,6 +33,9 @@ make test
 make test-e2e
 go test ./internal/integration -count=1
 make test-v2-4-acceptance
+make test-v2-5-acceptance
+make test-context-conformance
+make test-context-chaos
 make test-packspec-tck
 make test-ui-acceptance
 make test-ui-unit
@@ -47,5 +51,5 @@ make codeql
 ## Exit Criteria
 
 - All commands above pass locally.
-- PR CI lanes pass, including new `ui-acceptance` and updated coverage/release gates.
-- No regressions against v2.4 acceptance and PackSpec TCK.
+- PR CI lanes pass, including `ui-acceptance`, v2.5 context lanes, and updated coverage/release gates.
+- No regressions against v2.4/v2.5 acceptance and PackSpec TCK.

--- a/scripts/test_uat_local.sh
+++ b/scripts/test_uat_local.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
-OUTPUT_DIR="${REPO_ROOT}/gait-out/uat_local"
+OUTPUT_DIR="${REPO_ROOT}/.uat_local"
 RELEASE_VERSION="${GAIT_UAT_RELEASE_VERSION:-}"
 SKIP_BREW="false"
 SKIP_DOCS_SITE="false"
@@ -19,7 +19,7 @@ Usage:
   test_uat_local.sh [--output-dir <path>] [--release-version <tag>] [--skip-brew] [--skip-docs-site] [--baseline-install-paths]
 
 Options:
-  --output-dir <path>      UAT artifacts directory (default: gait-out/uat_local)
+  --output-dir <path>      UAT artifacts directory (default: .uat_local)
   --release-version <tag>  GitHub release tag for installer path (default: latest published release)
   --skip-brew              Skip Homebrew install path checks
   --skip-docs-site         Skip docs-site lint/build checks in local quality gate


### PR DESCRIPTION
## Summary
- align docs and contracts references across v2.3, v2.4, and v2.5 work
- refresh README and docs-site homepage positioning for durable jobs + signed packs
- add explicit v2.5 context proof flow and artifact graph references
- hardening release checklist now explicitly includes v2.3/v2.4/v2.5 + context gates
- fix UAT summary retention by defaulting orchestrator output to `.uat_local`

## Validation
- make docs-site-lint docs-site-build docs-site-check
- pre-push gate (make prepush) passed during push
