### PR TITLE
v2.7 distribution: GitHub-first lane, CI portability kits, and minimal OTEL timing

### DIFF
--- a/.github/actions/gait-regress/README.md
+++ b/.github/actions/gait-regress/README.md
@@ -2,6 +2,9 @@
 
 Run deterministic Gait checks in CI with a verified release binary.
 
+This is the step-level reusable surface for the GitHub-first "one PR to adopt" lane.
+For workflow-level reuse and non-GitHub portability mappings, see `docs/ci_regress_kit.md`.
+
 ## Inputs
 
 - `version` (default: `latest`): release tag (for example `v1.0.7`) or `latest`

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ BENCH_REGEX := Benchmark(EvaluatePolicyTypical|VerifyZipTypical|DiffRunpacksTypi
 BENCH_OUTPUT ?= perf/bench_output.txt
 BENCH_BASELINE ?= perf/bench_baseline.json
 
-.PHONY: fmt lint lint-fast codeql test test-fast prepush prepush-full github-guardrails github-guardrails-strict test-hardening test-hardening-acceptance test-chaos test-e2e test-acceptance test-v1-6-acceptance test-v1-7-acceptance test-v1-8-acceptance test-v2-3-acceptance test-v2-4-acceptance test-v2-5-acceptance test-v2-6-acceptance test-context-conformance test-context-chaos test-packspec-tck test-ui-acceptance test-ui-unit test-ui-e2e-smoke test-ui-perf test-adoption test-adapter-parity test-ecosystem-automation test-release-smoke test-install test-install-path-versions test-contracts test-intent-receipt-conformance test-ci-regress-template test-live-connectors test-skill-supply-chain test-runtime-slo test-ent-consumer-contract test-uat-local test-openclaw-skill-install test-beads-bridge test-docs-storyline test-demo-recording openclaw-skill-install build bench bench-check bench-budgets context-budgets skills-validate ecosystem-validate ecosystem-release-notes demo-90s demo-hero-gif homebrew-formula wiki-publish tool-allowlist-policy ui-build ui-sync ui-deps-check
+.PHONY: fmt lint lint-fast codeql test test-fast prepush prepush-full github-guardrails github-guardrails-strict test-hardening test-hardening-acceptance test-chaos test-e2e test-acceptance test-v1-6-acceptance test-v1-7-acceptance test-v1-8-acceptance test-v2-3-acceptance test-v2-4-acceptance test-v2-5-acceptance test-v2-6-acceptance test-context-conformance test-context-chaos test-packspec-tck test-ui-acceptance test-ui-unit test-ui-e2e-smoke test-ui-perf test-adoption test-adapter-parity test-ecosystem-automation test-release-smoke test-install test-install-path-versions test-contracts test-intent-receipt-conformance test-ci-regress-template test-ci-portability-templates test-live-connectors test-skill-supply-chain test-runtime-slo test-ent-consumer-contract test-uat-local test-openclaw-skill-install test-beads-bridge test-docs-storyline test-demo-recording openclaw-skill-install build bench bench-check bench-budgets context-budgets skills-validate ecosystem-validate ecosystem-release-notes demo-90s demo-hero-gif homebrew-formula wiki-publish tool-allowlist-policy ui-build ui-sync ui-deps-check
 .PHONY: hooks
 .PHONY: docs-site-install docs-site-build docs-site-lint docs-site-check
 
@@ -171,6 +171,7 @@ test-adapter-parity:
 test-ecosystem-automation:
 	bash scripts/test_ecosystem_release_automation.sh
 	bash scripts/test_ci_regress_template.sh
+	bash scripts/test_ci_portability_templates.sh
 
 test-release-smoke: build
 	bash scripts/test_release_smoke.sh ./gait
@@ -190,6 +191,9 @@ test-intent-receipt-conformance: build
 
 test-ci-regress-template: build
 	bash scripts/test_ci_regress_template.sh
+
+test-ci-portability-templates: build
+	bash scripts/test_ci_portability_templates.sh
 
 test-ent-consumer-contract: build
 	bash scripts/test_ent_consumer_contract.sh ./gait

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Public docs: [https://davidahmann.github.io/gait/](https://davidahmann.github.io
 Wiki: [https://github.com/davidahmann/gait/wiki](https://github.com/davidahmann/gait/wiki)  
 Runpack format: [`docs/contracts/primitive_contract.md`](docs/contracts/primitive_contract.md)  
 PackSpec v1: [`docs/contracts/packspec_v1.md`](docs/contracts/packspec_v1.md)  
+PackSpec TCK: [`docs/contracts/packspec_tck.md`](docs/contracts/packspec_tck.md)  
+Intent+receipt conformance: [`docs/contracts/intent_receipt_conformance.md`](docs/contracts/intent_receipt_conformance.md)  
 Changelog: [CHANGELOG.md](CHANGELOG.md)
 
 **For platform and AI engineering teams** that run multi-step and multi-hour agent jobs and need state, provenance, and control without losing work mid-flight.
@@ -38,6 +40,14 @@ Gait maps directly to those needs:
 - prove: signed traces plus `guard` / `incident` evidence bundles
 
 Gait is not an agent orchestrator or model host. It is the deterministic control/evidence layer at the tool boundary.
+
+## Verifiable Evidence (Spec + Verify + Conformance)
+
+Gait's durable product contract is offline-verifiable artifacts and schemas:
+
+- spec: `primitive_contract` + `PackSpec v1` define what an evidence bundle contains
+- verify: `gait verify`, `gait pack verify`, and `gait trace verify` validate integrity offline
+- conformance vectors: `make test-packspec-tck` and `bash scripts/test_intent_receipt_conformance.sh ./gait` keep producers and consumers compatible
 
 ## Try It (Offline, <60s)
 
@@ -187,9 +197,11 @@ gait report top --runs ./gait-out --traces ./gait-out --limit 5
 
 `gait report top` ranks the highest-risk actions deterministically by tool class and blast radius, then writes `./gait-out/report_top_actions.json`.
 
-## Optional: Enforce At The Tool Boundary
+## Enforce At The Tool Boundary (Wrapper or MCP)
 
 Gait does not auto-intercept your framework. Your dispatcher must call Gait and enforce non-`allow` as non-executable.
+
+MCP-native option: use `gait mcp serve` (or one-shot `gait mcp proxy`) at the standard tool boundary, then enforce decisions in the caller runtime. Details: [`docs/mcp_capability_matrix.md`](docs/mcp_capability_matrix.md)
 
 ```python
 def dispatch_tool(tool_call):

--- a/README.md
+++ b/README.md
@@ -189,6 +189,14 @@ Deterministic failure contract:
 Template workflow: [`.github/workflows/adoption-regress-template.yml`](.github/workflows/adoption-regress-template.yml)
 Drop-in action: [`.github/actions/gait-regress/README.md`](.github/actions/gait-regress/README.md)
 
+### One-PR CI Adoption (GitHub First)
+
+1. Copy [`.github/workflows/adoption-regress-template.yml`](.github/workflows/adoption-regress-template.yml) into your repo.
+2. Commit fixture/config paths (or rely on deterministic fallback init from `run_demo`).
+3. Open a PR and confirm uploaded artifacts under `gait-out/adoption_regress/`.
+
+Portable follow-on kits for GitLab/Jenkins/Circle are documented in [`docs/ci_regress_kit.md`](docs/ci_regress_kit.md) and map to the same CLI exit/artifact contract.
+
 ## Triage Top Risks Fast
 
 ```bash

--- a/core/mcp/exporters.go
+++ b/core/mcp/exporters.go
@@ -21,6 +21,7 @@ type ExportEvent struct {
 	ReasonCodes     []string  `json:"reason_codes,omitempty"`
 	PolicyDigest    string    `json:"policy_digest"`
 	IntentDigest    string    `json:"intent_digest"`
+	DecisionLatency int64     `json:"decision_latency_ms,omitempty"`
 	DelegationRef   string    `json:"delegation_ref,omitempty"`
 	DelegationDepth int       `json:"delegation_depth,omitempty"`
 }
@@ -49,16 +50,17 @@ func ExportOTelEvent(path string, event ExportEvent) error {
 		"body":           "gait.mcp.proxy.decision",
 		"trace_id":       strings.TrimSpace(event.TraceID),
 		"attributes": map[string]any{
-			"gait.run_id":           strings.TrimSpace(event.RunID),
-			"gait.session_id":       strings.TrimSpace(event.SessionID),
-			"gait.trace_path":       strings.TrimSpace(event.TracePath),
-			"gait.tool_name":        strings.TrimSpace(event.ToolName),
-			"gait.verdict":          strings.TrimSpace(event.Verdict),
-			"gait.policy_digest":    strings.TrimSpace(event.PolicyDigest),
-			"gait.intent_digest":    strings.TrimSpace(event.IntentDigest),
-			"gait.delegation_ref":   strings.TrimSpace(event.DelegationRef),
-			"gait.delegation_depth": event.DelegationDepth,
-			"gait.reason_codes":     event.ReasonCodes,
+			"gait.run_id":              strings.TrimSpace(event.RunID),
+			"gait.session_id":          strings.TrimSpace(event.SessionID),
+			"gait.trace_path":          strings.TrimSpace(event.TracePath),
+			"gait.tool_name":           strings.TrimSpace(event.ToolName),
+			"gait.verdict":             strings.TrimSpace(event.Verdict),
+			"gait.policy_digest":       strings.TrimSpace(event.PolicyDigest),
+			"gait.intent_digest":       strings.TrimSpace(event.IntentDigest),
+			"gait.decision_latency_ms": event.DecisionLatency,
+			"gait.delegation_ref":      strings.TrimSpace(event.DelegationRef),
+			"gait.delegation_depth":    event.DelegationDepth,
+			"gait.reason_codes":        event.ReasonCodes,
 		},
 	}
 	encoded, err := json.Marshal(payload)

--- a/core/mcp/proxy_test.go
+++ b/core/mcp/proxy_test.go
@@ -162,6 +162,7 @@ func TestExportersWriteJSONL(t *testing.T) {
 		Verdict:         "allow",
 		PolicyDigest:    strings.Repeat("a", 64),
 		IntentDigest:    strings.Repeat("b", 64),
+		DecisionLatency: 42,
 		ProducerVersion: "0.0.0-test",
 	}
 	if err := ExportLogEvent(logPath, event); err != nil {
@@ -182,6 +183,9 @@ func TestExportersWriteJSONL(t *testing.T) {
 	if logEntry["run_id"] != "run_mcp_test" {
 		t.Fatalf("unexpected log run id: %#v", logEntry)
 	}
+	if logEntry["decision_latency_ms"] != float64(42) {
+		t.Fatalf("unexpected log decision latency: %#v", logEntry)
+	}
 
 	otelRaw, err := os.ReadFile(otelPath)
 	if err != nil {
@@ -197,6 +201,9 @@ func TestExportersWriteJSONL(t *testing.T) {
 	}
 	if attrs["gait.run_id"] != "run_mcp_test" {
 		t.Fatalf("unexpected otel run id: %#v", attrs)
+	}
+	if attrs["gait.decision_latency_ms"] != float64(42) {
+		t.Fatalf("unexpected otel decision latency: %#v", attrs)
 	}
 }
 

--- a/docs/PLAN_v2.7_distribution.md
+++ b/docs/PLAN_v2.7_distribution.md
@@ -1,0 +1,217 @@
+# PLAN v2.7 Distribution: Integrate Into Existing Gravity Wells
+
+Date: 2026-02-14
+Scope: Distribution and adoption packaging only (no core policy/runtime rewrite)
+
+## Goal
+
+Make Gait adoptable with one pull request by meeting teams where they already run work:
+
+1. GitHub Actions first.
+2. CI portability second (GitLab CI, Jenkins, CircleCI).
+3. Agent tool-boundary integrations third (MCP + SDK middleware).
+4. Minimal OpenTelemetry export fourth.
+
+North-star outcome: "one PR to adopt," not "migrate to a new platform."
+
+## Why This Order
+
+- GitHub Actions has the highest OSS distribution leverage and shortest trust path.
+- CI portability is mostly packaging and templates once a canonical lane exists.
+- Tool-boundary integrations are the enforcement value path, but require more integration detail than CI.
+- OTEL is valuable for observability fit, but should stay additive and optional after core adoption paths are frictionless.
+
+## Non-Goals
+
+- No Kubernetes admission-control work in v2.7.
+- No hosted control-plane or dashboard-first scope.
+- No provider-specific policy logic in core Go paths.
+- No breaking schema or exit-code changes.
+
+## Success Metrics (Locked)
+
+- `G1`: A repo can add Gait CI regression gating in one PR using the default GitHub Actions path.
+- `G2`: GitHub Actions quickstart path succeeds with deterministic artifacts and stable exit semantics (`0`, `5`, passthrough).
+- `C1`: Provider templates for GitLab/Jenkins/Circle are copy-paste usable and map to the same CLI contract.
+- `C2`: CI portability docs specify local parity checks before remote CI rollout.
+- `B1`: Tool-boundary integration kits cover MCP and at least the blessed SDK middleware path with fail-closed examples.
+- `B2`: Adapter parity and adoption smoke suites remain green for official integration references.
+- `O1`: Minimal OTEL decision export contract is documented and stable for low-risk fields (`run_id`, `verdict`, `policy_digest`, timing, trace reference).
+- `O2`: OTEL export remains optional and does not alter enforcement correctness.
+
+## Workstream 1: GitHub Actions First (Primary Gravity Well)
+
+### W1.1 One-PR GitHub adoption path
+
+Tasks:
+- Promote one canonical "drop-in" workflow path in onboarding docs with minimal required edits.
+- Keep reusable workflow + composite action path aligned and cross-linked.
+- Ensure README path leads directly to CI runbook without ambiguity.
+
+Acceptance:
+- New repo can adopt by adding one workflow file and baseline fixture/config.
+- Docs show exact expected artifacts and exit-code semantics.
+
+### W1.2 Harden action contract as distribution surface
+
+Tasks:
+- Keep action output contract explicit (`exit_code`, summary path, artifact path).
+- Validate release-binary verification and deterministic artifact layout in docs/tests.
+- Ensure failure triage starts from workflow summary, not raw logs.
+
+Acceptance:
+- Action contract is stable and tested by existing regress-template checks.
+- Adoption docs contain a deterministic troubleshooting path.
+
+### W1.3 Add provider-agnostic CI handoff from GitHub lane
+
+Tasks:
+- Publish "contract-first" mapping from GitHub workflow behavior to shell-based CI contract.
+- Keep GitHub as default lane, with portability as extension.
+
+Acceptance:
+- Non-GitHub users can identify equivalent contract in under five minutes from docs.
+
+## Workstream 2: CI Portability Kits (Second Gravity Well)
+
+### W2.1 Ship copy-paste templates for major CI providers
+
+Tasks:
+- Add versioned templates/examples for:
+  - GitLab CI
+  - Jenkins
+  - CircleCI
+- Keep template logic thin: call existing CLI commands and honor stable exit codes.
+
+Acceptance:
+- Templates require only path/environment edits, not behavioral rewrites.
+- Templates preserve deterministic artifact paths and regress semantics.
+
+### W2.2 Create one compatibility script contract
+
+Tasks:
+- Define one shell contract script as source-of-truth behavior.
+- Make provider templates wrappers around this contract.
+
+Acceptance:
+- Contract script can run locally and in CI runners with equivalent outputs.
+- Provider templates differ only in CI syntax, not Gait behavior.
+
+### W2.3 Add CI portability validation gate
+
+Tasks:
+- Add deterministic checks for template correctness (path expectations, exit handling, required outputs).
+- Include docs checks so examples do not drift.
+
+Acceptance:
+- Template regressions are caught before release.
+
+## Workstream 3: Tool-Boundary Integrations (Third Gravity Well)
+
+### W3.1 Prioritize boundary kits with highest adoption pull
+
+Tasks:
+- Keep MCP boundary path first-class (`proxy`/`serve`) with fail-closed examples.
+- Keep one blessed SDK middleware path as default (OpenAI Agents) and maintain parity references.
+- Ensure docs emphasize interception requirement and non-`allow` non-execute behavior.
+
+Acceptance:
+- Integration checklist and examples guide users to a default boundary path without branching confusion.
+- Adapter parity suite remains the conformance guardrail for official references.
+
+### W3.2 Publish "one PR boundary integration" recipes
+
+Tasks:
+- Add minimal recipes for:
+  - wrapper middleware insertion
+  - sidecar/boundary service path
+  - MCP-first path
+- Include expected allow/block/require_approval output contracts.
+
+Acceptance:
+- Teams can prove fail-closed behavior from recipes with existing acceptance commands.
+
+### W3.3 Keep Python and adapters thin
+
+Tasks:
+- Reassert boundary: Go is authoritative for policy/signing/verification.
+- Keep SDK/adapters as serialization and subprocess ergonomics only.
+
+Acceptance:
+- No framework-local policy semantics added.
+- Existing SDK and adapter tests remain contract-compatible.
+
+## Workstream 4: Minimal OpenTelemetry Export (Fourth Gravity Well)
+
+### W4.1 Lock minimal OTEL field contract
+
+Tasks:
+- Define a minimal, low-risk event mapping for decision telemetry:
+  - run/session/trace references
+  - verdict and reason codes
+  - policy and intent digests
+  - timing fields
+- Keep mapping aligned with existing artifact identifiers for offline correlation.
+
+Acceptance:
+- OTEL mapping is documented as additive observability output, not source of truth.
+
+### W4.2 Extend and unify OTEL export surfaces
+
+Tasks:
+- Keep existing MCP export path stable.
+- Evaluate and add equivalent export options on additional decision surfaces only where deterministic and low-risk.
+- Avoid mandatory collector/network dependencies.
+
+Acceptance:
+- OTEL export can be enabled or disabled without changing enforcement behavior or artifacts.
+
+### W4.3 Publish observability quick recipes
+
+Tasks:
+- Expand ingestion docs with minimal collector/SIEM examples tied to the locked field contract.
+- Document privacy defaults and recommended redaction posture.
+
+Acceptance:
+- Users can route events to existing stacks quickly without schema guesswork.
+
+## Repository Touch Map (Planned)
+
+- `README.md` (GitHub-first adoption call path)
+- `docs/ci_regress_kit.md` (primary + portability contract)
+- `docs/integration_checklist.md` (boundary default path and one-PR framing)
+- `docs/siem_ingestion_recipes.md` (minimal OTEL contract and recipes)
+- `examples/ci/*` (GitLab/Jenkins/Circle templates)
+- `.github/actions/gait-regress/*` and `.github/workflows/adoption-regress-template.yml` (GitHub lane hardening)
+- `scripts/test_ci_regress_template.sh` (existing gate)
+- `scripts/test_ci_portability_templates.sh` (planned)
+
+## Validation Gates (for v2.7 slices)
+
+Minimum per-PR validation set for this scope:
+
+- `make lint-fast`
+- `make test-fast`
+- `bash scripts/test_ci_regress_template.sh`
+- `make test-adoption`
+- `make test-adapter-parity`
+- `make test-v2-6-acceptance`
+
+Additional gates when portability templates land:
+
+- `bash scripts/test_ci_portability_templates.sh` (planned)
+
+## Delivery Sequence
+
+- Phase 1: Workstream 1 (GitHub Actions first)
+- Phase 2: Workstream 2 (CI portability templates)
+- Phase 3: Workstream 3 (tool-boundary integration kits)
+- Phase 4: Workstream 4 (minimal OTEL expansion + docs)
+
+## Definition of Done (v2.7 Distribution)
+
+- GitHub Actions is the clearest and fastest documented adoption path.
+- Non-GitHub CI users get copy-paste templates backed by the same CLI contract.
+- Boundary integration recipes exist for MCP and blessed middleware path with fail-closed proof.
+- Minimal OTEL export is documented and optional, using stable low-risk fields.
+- Kubernetes admission-control work is explicitly deferred from v2.7.

--- a/docs/README.md
+++ b/docs/README.md
@@ -64,6 +64,7 @@ This file defines where each topic lives so docs stay accurate and non-duplicati
 - Ecosystem contribution flow: `docs/ecosystem/contribute.md`
 - Launch/distribution assets: `docs/launch/README.md`
 - Activation KPI definition (v2.6): `docs/launch/activation_kpi_v2_6.md`
+- Distribution plan (v2.7 gravity wells): `docs/PLAN_v2.7_distribution.md`
 - Content cadence plan (v2.6): `docs/launch/content_cadence_v2_6.md`
 - Hero demo asset review (v2.6): `docs/launch/hero_demo_asset_review_v2_6.md`
 

--- a/docs/integration_checklist.md
+++ b/docs/integration_checklist.md
@@ -14,6 +14,7 @@ Blessed default lane:
 
 - local coding-agent wrapper flow (`examples/integrations/openai_agents/`)
 - GitHub Actions CI regress gate (`.github/workflows/adoption-regress-template.yml`)
+- one-PR CI adoption target via reusable workflow or composite action
 
 Expansion policy:
 
@@ -205,7 +206,10 @@ return execute_real_tool(tool_call)
 
 ## CI Mapping (Local -> GitHub Actions)
 
-Use `.github/workflows/adoption-regress-template.yml` directly.
+Default path (GitHub Actions):
+
+- use `.github/workflows/adoption-regress-template.yml` directly for one-PR adoption
+- optional step-level control: `.github/actions/gait-regress/action.yml`
 
 Required parity:
 
@@ -213,4 +217,12 @@ Required parity:
 - same stable exit handling (`0` pass, `5` deterministic failure)
 - same retained artifacts (`regress_result.json`, `junit.xml`, fixture files)
 
-See `docs/ci_regress_kit.md` for workflow-call inputs/outputs.
+Non-GitHub portability path:
+
+- run `bash scripts/ci_regress_contract.sh` as the provider-agnostic CI contract
+- copy provider template from:
+  - `examples/ci/portability/gitlab/.gitlab-ci.yml`
+  - `examples/ci/portability/jenkins/Jenkinsfile`
+  - `examples/ci/portability/circleci/config.yml`
+
+See `docs/ci_regress_kit.md` for workflow/action contracts and portability guidance.

--- a/docs/siem_ingestion_recipes.md
+++ b/docs/siem_ingestion_recipes.md
@@ -72,6 +72,7 @@ Recommended indexed keys:
 - `reason_codes`
 - `policy_digest`
 - `intent_digest`
+- `decision_latency_ms`
 - `delegation_ref`
 - `delegation_depth`
 

--- a/examples/ci/portability/README.md
+++ b/examples/ci/portability/README.md
@@ -1,0 +1,17 @@
+# CI Portability Templates
+
+These templates wrap the same CI contract script:
+
+- `scripts/ci_regress_contract.sh`
+
+Provider templates:
+
+- GitLab: `examples/ci/portability/gitlab/.gitlab-ci.yml`
+- Jenkins: `examples/ci/portability/jenkins/Jenkinsfile`
+- CircleCI: `examples/ci/portability/circleci/config.yml`
+
+All templates preserve:
+
+- stable regress exit handling (`0`, `5`, passthrough)
+- deterministic artifacts under `gait-out/adoption_regress/`
+- deterministic fixture fallback init from `run_demo`

--- a/examples/ci/portability/circleci/config.yml
+++ b/examples/ci/portability/circleci/config.yml
@@ -1,0 +1,19 @@
+version: 2.1
+
+jobs:
+  gait_regress:
+    docker:
+      - image: cimg/go:1.24
+    steps:
+      - checkout
+      - run:
+          name: Run Gait regress contract
+          command: bash scripts/ci_regress_contract.sh
+      - store_artifacts:
+          path: gait-out/adoption_regress
+          destination: gait-out/adoption_regress
+
+workflows:
+  regress:
+    jobs:
+      - gait_regress

--- a/examples/ci/portability/gitlab/.gitlab-ci.yml
+++ b/examples/ci/portability/gitlab/.gitlab-ci.yml
@@ -1,0 +1,12 @@
+stages:
+  - regress
+
+gait_regress:
+  stage: regress
+  image: golang:1.24
+  script:
+    - bash scripts/ci_regress_contract.sh
+  artifacts:
+    when: always
+    paths:
+      - gait-out/adoption_regress/

--- a/examples/ci/portability/jenkins/Jenkinsfile
+++ b/examples/ci/portability/jenkins/Jenkinsfile
@@ -1,0 +1,17 @@
+pipeline {
+  agent any
+
+  stages {
+    stage('Gait Regress Contract') {
+      steps {
+        sh 'bash scripts/ci_regress_contract.sh'
+      }
+    }
+  }
+
+  post {
+    always {
+      archiveArtifacts artifacts: 'gait-out/adoption_regress/**', allowEmptyArchive: true
+    }
+  }
+}

--- a/scripts/ci_regress_contract.sh
+++ b/scripts/ci_regress_contract.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+BIN_PATH="${GAIT_BIN:-$REPO_ROOT/gait}"
+ARTIFACT_ROOT="${ARTIFACT_ROOT:-$REPO_ROOT/gait-out/adoption_regress}"
+
+if [[ ! -x "$BIN_PATH" ]]; then
+  go build -o "$BIN_PATH" ./cmd/gait
+fi
+
+mkdir -p "$ARTIFACT_ROOT"
+
+if [[ ! -f "$REPO_ROOT/fixtures/run_demo/runpack.zip" || ! -f "$REPO_ROOT/gait.yaml" ]]; then
+  "$BIN_PATH" demo --json >/dev/null
+  "$BIN_PATH" regress init --from run_demo --json >"$ARTIFACT_ROOT/regress_init_result.json"
+fi
+
+set +e
+"$BIN_PATH" regress run --json --junit "$ARTIFACT_ROOT/junit.xml" >"$ARTIFACT_ROOT/regress_result.json"
+regress_status=$?
+set -e
+
+if [[ "$regress_status" -eq 5 ]]; then
+  echo "regress fail (stable exit code 5)"
+  exit 5
+fi
+if [[ "$regress_status" -ne 0 ]]; then
+  echo "unexpected regress exit code: $regress_status" >&2
+  exit "$regress_status"
+fi
+
+"$BIN_PATH" policy test examples/policy/endpoint/allow_safe_endpoints.yaml examples/policy/endpoint/fixtures/intent_allow.json --json >/dev/null
+set +e
+"$BIN_PATH" policy test examples/policy/endpoint/block_denied_endpoints.yaml examples/policy/endpoint/fixtures/intent_block.json --json >/dev/null
+block_status=$?
+"$BIN_PATH" policy test examples/policy/endpoint/require_approval_destructive.yaml examples/policy/endpoint/fixtures/intent_destructive.json --json >/dev/null
+approval_status=$?
+set -e
+if [[ "$block_status" -ne 3 ]]; then
+  echo "endpoint block fixture exit mismatch: $block_status" >&2
+  exit 1
+fi
+if [[ "$approval_status" -ne 4 ]]; then
+  echo "endpoint approval fixture exit mismatch: $approval_status" >&2
+  exit 1
+fi
+
+echo "ci regress contract: pass"

--- a/scripts/test_ci_portability_templates.sh
+++ b/scripts/test_ci_portability_templates.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+go build -o ./gait ./cmd/gait
+
+required_files=(
+  "scripts/ci_regress_contract.sh"
+  "examples/ci/portability/README.md"
+  "examples/ci/portability/gitlab/.gitlab-ci.yml"
+  "examples/ci/portability/jenkins/Jenkinsfile"
+  "examples/ci/portability/circleci/config.yml"
+)
+
+for path in "${required_files[@]}"; do
+  if [[ ! -f "$path" ]]; then
+    echo "missing portability template artifact: $path" >&2
+    exit 1
+  fi
+done
+
+python3 - <<'PY'
+from pathlib import Path
+
+checks = {
+    "examples/ci/portability/gitlab/.gitlab-ci.yml": [
+        "scripts/ci_regress_contract.sh",
+        "gait-out/adoption_regress/",
+    ],
+    "examples/ci/portability/jenkins/Jenkinsfile": [
+        "scripts/ci_regress_contract.sh",
+        "gait-out/adoption_regress",
+    ],
+    "examples/ci/portability/circleci/config.yml": [
+        "scripts/ci_regress_contract.sh",
+        "gait-out/adoption_regress",
+    ],
+}
+
+for path, fragments in checks.items():
+    text = Path(path).read_text(encoding="utf-8")
+    missing = [fragment for fragment in fragments if fragment not in text]
+    if missing:
+        raise SystemExit(f"{path} missing required fragments: {missing}")
+PY
+
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+ARTIFACT_ROOT_PATH="$WORK_DIR/adoption_regress"
+ARTIFACT_ROOT="$ARTIFACT_ROOT_PATH" GAIT_BIN="$REPO_ROOT/gait" bash "$REPO_ROOT/scripts/ci_regress_contract.sh"
+
+if [[ ! -f "$ARTIFACT_ROOT_PATH/regress_result.json" ]]; then
+  echo "missing regress_result.json from contract script" >&2
+  exit 1
+fi
+if [[ ! -f "$ARTIFACT_ROOT_PATH/junit.xml" ]]; then
+  echo "missing junit.xml from contract script" >&2
+  exit 1
+fi
+
+python3 - "$ARTIFACT_ROOT_PATH/regress_result.json" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+payload = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+if payload.get("status") != "pass":
+    raise SystemExit(f"expected regress status=pass, got {payload.get('status')}")
+if payload.get("ok") is not True:
+    raise SystemExit("expected regress ok=true")
+PY
+
+echo "ci portability templates: pass"


### PR DESCRIPTION
## Summary
- add v2.7 distribution plan and docs map entry
- tighten GitHub-first one-PR CI adoption guidance
- add CI portability contract script plus GitLab/Jenkins/Circle templates
- add portability validation gate and Make targets
- add minimal `decision_latency_ms` field to MCP log/OTEL exports with tests

## Validation
- make codeql
- make lint-fast
- make test-fast
- make test-ci-regress-template
- make test-ci-portability-templates
- make test-adoption
- make test-adapter-parity
- make test-v2-6-acceptance
- make test-ecosystem-automation
