### PR TITLE
ci(portability): align GitLab/Circle images with go.mod toolchain

### DIFF
--- a/examples/ci/portability/circleci/config.yml
+++ b/examples/ci/portability/circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 jobs:
   gait_regress:
     docker:
-      - image: cimg/go:1.24
+      - image: cimg/go:1.25
     steps:
       - checkout
       - run:

--- a/examples/ci/portability/gitlab/.gitlab-ci.yml
+++ b/examples/ci/portability/gitlab/.gitlab-ci.yml
@@ -3,7 +3,7 @@ stages:
 
 gait_regress:
   stage: regress
-  image: golang:1.24
+  image: golang:1.25
   script:
     - bash scripts/ci_regress_contract.sh
   artifacts:


### PR DESCRIPTION
## Summary
- update GitLab portability template image from `golang:1.24` to `golang:1.25`
- update CircleCI portability template image from `cimg/go:1.24` to `cimg/go:1.25`
- align portability templates with `go.mod` toolchain requirement (`go 1.25.7`)

## Why
The portability contract script builds `./cmd/gait` when no binary is present. Pinning `1.24` can fail in locked-down CI environments (`GOTOOLCHAIN=local` or no egress) before regress runs.

## Validation
- `bash scripts/test_ci_portability_templates.sh`
- pre-push fast gates (`make prepush`) passed during push
