### PR TITLE
fix: harden runpack verify contract checks

### DIFF
--- a/docs-site/public/favicon.svg
+++ b/docs-site/public/favicon.svg
@@ -1,0 +1,10 @@
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="16" cy="16" r="16" fill="url(#g)"/>
+  <path d="M11 22V8h8v5.3h-3.5v2.2h3v5.3h-3V22H11Z" fill="white"/>
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="32" y2="32" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#22D3EE"/>
+      <stop offset="1" stop-color="#2563EB"/>
+    </linearGradient>
+  </defs>
+</svg>

--- a/docs-site/src/app/layout.tsx
+++ b/docs-site/src/app/layout.tsx
@@ -27,6 +27,9 @@ export const metadata: Metadata = {
       },
     ],
   },
+  icons: {
+    icon: '/favicon.svg',
+  },
   twitter: {
     card: 'summary_large_image',
     title: 'Gait | Durable Agent Runtime with Signed Proof',

--- a/product/CODEX_REVIEW.md
+++ b/product/CODEX_REVIEW.md
@@ -1,0 +1,65 @@
+# Codex-Style Repo Review Findings
+
+Date: 2026-02-15  
+Scope: full repository (`main`)  
+Mode: read-only investigation (no functional code changes)
+
+## Findings
+
+### [P1] `gait verify` accepts runpacks that omit required artifact files
+
+- Files:
+  - `core/runpack/verify.go:75`
+  - `core/runpack/verify.go:83`
+  - `cmd/gait/verify.go:392`
+- Problem:
+  - `VerifyZip` only validates files declared in `manifest.files`.
+  - It never enforces that runpack-required files (`run.json`, `intents.jsonl`, `results.jsonl`, `refs.json`) are declared/present.
+  - `verifyRunpackArtifact` marks verification `ok=true` when `missing_files` and `hash_mismatches` are empty, so an artifact with `files: []` is accepted as valid.
+- Why this matters:
+  - It breaks the runpack contract and allows structurally incomplete artifacts to pass integrity verification.
+  - Downstream systems can treat non-replayable/non-auditable packs as trusted.
+- Repro:
+  1. Create zip containing only `manifest.json` with `run_id`, `files: []`.
+  2. Run `./gait verify <zip> --json`.
+  3. Current result returns `"ok": true`.
+
+### [P1] `gait verify` does not validate `manifest_digest` correctness
+
+- Files:
+  - `core/runpack/verify.go:77`
+  - `core/runpack/verify.go:150`
+  - `cmd/gait/verify.go:83`
+- Problem:
+  - `manifest_digest` is surfaced in output but never recomputed and compared against the manifest content.
+  - Any arbitrary digest string is accepted.
+- Why this matters:
+  - The command explicitly claims manifest-digest verification, but it currently does not provide that guarantee.
+  - This weakens integrity signaling in security/compliance workflows.
+- Repro:
+  1. Set `manifest_digest` to `"deadbeef"` in `manifest.json`.
+  2. Run `./gait verify <zip> --json`.
+  3. Current result can still return `"ok": true` with the bogus digest echoed back.
+
+### [P2] `gait verify` does not enforce runpack manifest schema identity/version
+
+- Files:
+  - `core/runpack/verify.go:67`
+  - `core/runpack/verify.go:71`
+- Problem:
+  - Verification checks only that `manifest.json` parses and has non-empty `run_id`.
+  - It does not validate `schema_id == gait.runpack.manifest` and `schema_version == 1.0.0`.
+- Why this matters:
+  - A non-runpack manifest shape can be accepted as a valid runpack verification target.
+  - This undermines schema-stability guarantees and contract enforcement.
+- Repro:
+  1. Create `manifest.json` with `schema_id: "not.gait"` and `schema_version: "999"`, plus `run_id`.
+  2. Run `./gait verify <zip> --json`.
+  3. Current result can still return `"ok": true`.
+
+## What I Ran
+
+- `go test ./...` (pass)
+- `make lint-fast` (pass)
+- `python3 scripts/check_docs_site_validation.py` (pass)
+- Direct CLI repros of malformed runpack manifests (showing false-positive `ok: true` in `gait verify`)


### PR DESCRIPTION
## Summary
- harden verify error: expected run_id or path runpack validation to enforce runpack manifest schema identity/version
- enforce presence of required runpack entries (, , , ) in 
- recompute and validate  during verification and report digest mismatch via  hash mismatch
- extend runpack verify tests for schema version validation, required-entry enforcement, and manifest digest mismatch
- include current workspace updates requested for commit: docs-site layout/favicon and 

## Validation
- ok  	github.com/davidahmann/gait/cmd/gait	5.358s
ok  	github.com/davidahmann/gait/core/contextproof	(cached)
ok  	github.com/davidahmann/gait/core/credential	(cached)
ok  	github.com/davidahmann/gait/core/doctor	0.611s
ok  	github.com/davidahmann/gait/core/errors	(cached)
ok  	github.com/davidahmann/gait/core/fsx	(cached)
ok  	github.com/davidahmann/gait/core/gate	(cached)
ok  	github.com/davidahmann/gait/core/guard	(cached)
ok  	github.com/davidahmann/gait/core/jcs	(cached)
ok  	github.com/davidahmann/gait/core/jobruntime	(cached)
ok  	github.com/davidahmann/gait/core/mcp	(cached)
ok  	github.com/davidahmann/gait/core/pack	0.865s
ok  	github.com/davidahmann/gait/core/policytest	(cached)
ok  	github.com/davidahmann/gait/core/projectconfig	(cached)
ok  	github.com/davidahmann/gait/core/registry	(cached)
ok  	github.com/davidahmann/gait/core/regress	(cached)
ok  	github.com/davidahmann/gait/core/runpack	9.037s
?   	github.com/davidahmann/gait/core/schema/v1/context	[no test files]
?   	github.com/davidahmann/gait/core/schema/v1/gate	[no test files]
?   	github.com/davidahmann/gait/core/schema/v1/guard	[no test files]
?   	github.com/davidahmann/gait/core/schema/v1/pack	[no test files]
?   	github.com/davidahmann/gait/core/schema/v1/policytest	[no test files]
?   	github.com/davidahmann/gait/core/schema/v1/registry	[no test files]
?   	github.com/davidahmann/gait/core/schema/v1/regress	[no test files]
?   	github.com/davidahmann/gait/core/schema/v1/runpack	[no test files]
?   	github.com/davidahmann/gait/core/schema/v1/scout	[no test files]
?   	github.com/davidahmann/gait/core/schema/v1/voice	[no test files]
ok  	github.com/davidahmann/gait/core/schema/validate	(cached)
ok  	github.com/davidahmann/gait/core/scout	(cached)
ok  	github.com/davidahmann/gait/core/sign	(cached)
ok  	github.com/davidahmann/gait/core/ui	(cached)
ok  	github.com/davidahmann/gait/core/zipx	(cached)
ok  	github.com/davidahmann/gait/internal/e2e	9.102s
ok  	github.com/davidahmann/gait/internal/integration	(cached)
ok  	github.com/davidahmann/gait/internal/testutil	0.608s
?   	github.com/davidahmann/gait/internal/uiassets	[no test files]
- /Applications/Xcode.app/Contents/Developer/usr/bin/make lint
python3 scripts/validate_repo_skills.py
validated 3 skills under /Users/davidahmann/Projects/gait/.agents/skills for provider=both
python3 scripts/validate_community_index.py
community index validation passed: docs/ecosystem/community_index.json (9 entries)
bash scripts/check_repo_hygiene.sh
bash scripts/check_hooks_config.sh
go vet ./...
go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.0.1 run ./...
0 issues.
go run github.com/securego/gosec/v2/cmd/gosec@v2.22.0 ./...
Results:


Summary:
  Gosec  : dev
  Files  : 110
  Lines  : 33272
  Nosec  : 92
  Issues : 0

go build -o ./gait ./cmd/gait
go run golang.org/x/vuln/cmd/govulncheck@latest -mode=binary ./gait
No vulnerabilities found.
(cd sdk/python && uv run --python 3.13 --extra dev ruff check)
All checks passed!
(cd sdk/python && uv run --python 3.13 --extra dev mypy)
Success: no issues found in 6 source files
(cd sdk/python && uv run --python 3.13 --extra dev bandit -q -r gait)
/Applications/Xcode.app/Contents/Developer/usr/bin/make test
go test ./... -cover > coverage-go-packages.out
cat coverage-go-packages.out
ok  	github.com/davidahmann/gait/cmd/gait	3.645s	coverage: 84.9% of statements
ok  	github.com/davidahmann/gait/core/contextproof	(cached)	coverage: 85.1% of statements
ok  	github.com/davidahmann/gait/core/credential	(cached)	coverage: 84.7% of statements
ok  	github.com/davidahmann/gait/core/doctor	0.780s	coverage: 82.4% of statements
ok  	github.com/davidahmann/gait/core/errors	(cached)	coverage: 96.3% of statements
ok  	github.com/davidahmann/gait/core/fsx	(cached)	coverage: 79.9% of statements
ok  	github.com/davidahmann/gait/core/gate	(cached)	coverage: 85.3% of statements
ok  	github.com/davidahmann/gait/core/guard	(cached)	coverage: 83.2% of statements
ok  	github.com/davidahmann/gait/core/jcs	(cached)	coverage: 100.0% of statements
ok  	github.com/davidahmann/gait/core/jobruntime	(cached)	coverage: 93.3% of statements
ok  	github.com/davidahmann/gait/core/mcp	(cached)	coverage: 84.8% of statements
ok  	github.com/davidahmann/gait/core/pack	0.859s	coverage: 84.3% of statements
ok  	github.com/davidahmann/gait/core/policytest	(cached)	coverage: 80.6% of statements
ok  	github.com/davidahmann/gait/core/projectconfig	(cached)	coverage: 95.0% of statements
ok  	github.com/davidahmann/gait/core/registry	(cached)	coverage: 82.4% of statements
ok  	github.com/davidahmann/gait/core/regress	(cached)	coverage: 80.0% of statements
ok  	github.com/davidahmann/gait/core/runpack	(cached)	coverage: 84.0% of statements
?   	github.com/davidahmann/gait/core/schema/v1/context	[no test files]
?   	github.com/davidahmann/gait/core/schema/v1/gate	[no test files]
?   	github.com/davidahmann/gait/core/schema/v1/guard	[no test files]
?   	github.com/davidahmann/gait/core/schema/v1/pack	[no test files]
?   	github.com/davidahmann/gait/core/schema/v1/policytest	[no test files]
?   	github.com/davidahmann/gait/core/schema/v1/registry	[no test files]
?   	github.com/davidahmann/gait/core/schema/v1/regress	[no test files]
?   	github.com/davidahmann/gait/core/schema/v1/runpack	[no test files]
?   	github.com/davidahmann/gait/core/schema/v1/scout	[no test files]
?   	github.com/davidahmann/gait/core/schema/v1/voice	[no test files]
ok  	github.com/davidahmann/gait/core/schema/validate	(cached)	coverage: 85.4% of statements
ok  	github.com/davidahmann/gait/core/scout	(cached)	coverage: 87.5% of statements
ok  	github.com/davidahmann/gait/core/sign	(cached)	coverage: 89.8% of statements
ok  	github.com/davidahmann/gait/core/ui	(cached)	coverage: 94.4% of statements
ok  	github.com/davidahmann/gait/core/zipx	(cached)	coverage: 84.0% of statements
ok  	github.com/davidahmann/gait/internal/e2e	7.897s	coverage: [no statements]
ok  	github.com/davidahmann/gait/internal/integration	(cached)	coverage: [no statements]
ok  	github.com/davidahmann/gait/internal/testutil	0.586s	coverage: 76.1% of statements
?   	github.com/davidahmann/gait/internal/uiassets	[no test files]
python3 scripts/check_go_package_coverage.py coverage-go-packages.out 75
Go package coverage OK: 23 packages >= 75.0%
go test ./core/... ./cmd/gait -coverprofile=coverage-go.out
ok  	github.com/davidahmann/gait/core/contextproof	(cached)	coverage: 85.1% of statements
ok  	github.com/davidahmann/gait/core/credential	(cached)	coverage: 84.7% of statements
ok  	github.com/davidahmann/gait/core/doctor	0.377s	coverage: 82.4% of statements
ok  	github.com/davidahmann/gait/core/errors	(cached)	coverage: 96.3% of statements
ok  	github.com/davidahmann/gait/core/fsx	(cached)	coverage: 79.9% of statements
ok  	github.com/davidahmann/gait/core/gate	(cached)	coverage: 85.3% of statements
ok  	github.com/davidahmann/gait/core/guard	(cached)	coverage: 83.2% of statements
ok  	github.com/davidahmann/gait/core/jcs	(cached)	coverage: 100.0% of statements
ok  	github.com/davidahmann/gait/core/jobruntime	(cached)	coverage: 93.3% of statements
ok  	github.com/davidahmann/gait/core/mcp	(cached)	coverage: 84.8% of statements
ok  	github.com/davidahmann/gait/core/pack	0.426s	coverage: 84.3% of statements
ok  	github.com/davidahmann/gait/core/policytest	(cached)	coverage: 80.6% of statements
ok  	github.com/davidahmann/gait/core/projectconfig	(cached)	coverage: 95.0% of statements
ok  	github.com/davidahmann/gait/core/registry	(cached)	coverage: 82.4% of statements
ok  	github.com/davidahmann/gait/core/regress	(cached)	coverage: 80.0% of statements
ok  	github.com/davidahmann/gait/core/runpack	(cached)	coverage: 84.0% of statements
?   	github.com/davidahmann/gait/core/schema/v1/context	[no test files]
?   	github.com/davidahmann/gait/core/schema/v1/gate	[no test files]
?   	github.com/davidahmann/gait/core/schema/v1/guard	[no test files]
?   	github.com/davidahmann/gait/core/schema/v1/pack	[no test files]
?   	github.com/davidahmann/gait/core/schema/v1/policytest	[no test files]
?   	github.com/davidahmann/gait/core/schema/v1/registry	[no test files]
?   	github.com/davidahmann/gait/core/schema/v1/regress	[no test files]
?   	github.com/davidahmann/gait/core/schema/v1/runpack	[no test files]
?   	github.com/davidahmann/gait/core/schema/v1/scout	[no test files]
?   	github.com/davidahmann/gait/core/schema/v1/voice	[no test files]
ok  	github.com/davidahmann/gait/core/schema/validate	(cached)	coverage: 85.4% of statements
ok  	github.com/davidahmann/gait/core/scout	(cached)	coverage: 87.5% of statements
ok  	github.com/davidahmann/gait/core/sign	(cached)	coverage: 89.8% of statements
ok  	github.com/davidahmann/gait/core/ui	(cached)	coverage: 94.4% of statements
ok  	github.com/davidahmann/gait/core/zipx	(cached)	coverage: 84.0% of statements
ok  	github.com/davidahmann/gait/cmd/gait	3.072s	coverage: 84.9% of statements
python3 scripts/check_go_coverage.py coverage-go.out 85
Go coverage OK: 85.0% (required 85.0%)
(cd sdk/python && PYTHONPATH=. uv run --python 3.13 --extra dev pytest --cov=gait --cov-report=term-missing --cov-fail-under=85)
============================= test session starts ==============================
platform darwin -- Python 3.13.7, pytest-9.0.2, pluggy-1.6.0
rootdir: /Users/davidahmann/Projects/gait/sdk/python
configfile: pyproject.toml
testpaths: tests
plugins: cov-7.0.0
collected 31 items

tests/test_adapter.py ........                                           [ 25%]
tests/test_basic.py .                                                    [ 29%]
tests/test_client.py .............                                       [ 70%]
tests/test_decorators.py ....                                            [ 83%]
tests/test_primitive_fixtures.py ...                                     [ 93%]
tests/test_session.py ..                                                 [100%]

================================ tests coverage ================================
_______________ coverage: platform darwin, python 3.13.7-final-0 _______________

Name                 Stmts   Miss  Cover   Missing
--------------------------------------------------
gait/__init__.py         7      0   100%
gait/adapter.py         67      2    97%   93, 121
gait/client.py         164     22    87%   116, 118-119, 133, 135, 137, 139, 155-156, 168, 172, 185, 208, 236-237, 245, 278, 280, 284, 292-293, 301
gait/decorators.py      54      4    93%   87, 99-101
gait/models.py         188     30    84%   10, 34, 36, 50, 52, 77, 79, 81, 83, 85, 87, 89, 91, 103-111, 122-131, 163, 167, 332
gait/session.py        167     25    85%   75, 77, 126, 142, 152, 154, 156-158, 171, 202, 242, 274, 276, 278, 299, 302-304, 311, 339-343
--------------------------------------------------
TOTAL                  647     83    87%
Required test coverage of 85% reached. Total coverage: 87.17%
============================== 31 passed in 0.46s ==============================
/Applications/Xcode.app/Contents/Developer/usr/bin/make codeql
bash scripts/run_codeql_local.sh
[codeql] creating go database
[2026-02-15 07:17:21] [build-stderr] Scanning for files in /Users/davidahmann/Projects/gait...
[2026-02-15 07:17:22] [build-stderr] /var/folders/xf/nh2svl1x1_94jfvlmhz4njzh0000gn/T/gait-codeql-Ut0rFO/go-db: Indexing files in in /Users/davidahmann/Projects/gait...
[2026-02-15 07:17:22] [build-stderr] Running command in /Users/davidahmann/Projects/gait: [/opt/homebrew/Caskroom/codeql/2.24.1/codeql/html/tools/index-files.sh, /var/folders/xf/nh2svl1x1_94jfvlmhz4njzh0000gn/T/gait-codeql-Ut0rFO/go-db/working/files-to-index9834261552776809649.list]
[codeql] analyzing go database
CodeQL scanned 110 out of 198 Go files in this invocation. Typically CodeQL is configured to analyze a single CodeQL language per invocation, so check other invocations to determine overall coverage information.
[codeql] creating python database
[2026-02-15 07:17:33] [build-stderr] /bin/sh: python2: command not found
[2026-02-15 07:17:34] [build-stdout] No directories containing root identifiers were found. Returning working directory as root.
[2026-02-15 07:17:34] [build-stdout] Will try to guess Python version, as it was not specified in `lgtm.yml`
[2026-02-15 07:17:34] [build-stdout] Trying to guess Python version based on Trove classifiers in setup.py
[2026-02-15 07:17:34] [build-stdout] Did not find setup.py (expected it to be at /Users/davidahmann/Projects/gait/setup.py)
[2026-02-15 07:17:34] [build-stdout] Trying to guess Python version based on travis file
[2026-02-15 07:17:34] [build-stdout] Did not find any travis files (expected them at either ['/Users/davidahmann/Projects/gait/.travis.yml', '/Users/davidahmann/Projects/gait/travis.yml'])
[2026-02-15 07:17:34] [build-stdout] Trying to guess Python version based on installed versions
[2026-02-15 07:17:34] [build-stdout] Wanted to run Python 2, but it is not available. Using Python 3 instead
[2026-02-15 07:17:34] [build-stdout] This script is running Python 3, but Python 2 is also available (as 'python3')
[2026-02-15 07:17:34] [build-stdout] Could not guess Python version, will use default: Python 3
[2026-02-15 07:17:34] [build-stdout] Excluding the following directories from extraction, since they look like virtual environments: ['/Users/davidahmann/Projects/gait/sdk/python/.venv']
[2026-02-15 07:17:34] [build-stdout] You can disable this behavior by setting the environment variable CODEQL_EXTRACTOR_PYTHON_DISABLE_AUTOMATIC_VENV_EXCLUDE=1
[2026-02-15 07:17:34] [build-stdout] Calling python3 -S /opt/homebrew/Caskroom/codeql/2.24.1/codeql/python/tools/python_tracer.py --verbosity 3 -z all -c /var/folders/xf/nh2svl1x1_94jfvlmhz4njzh0000gn/T/gait-codeql-Ut0rFO/python-db/working/trap_cache -R /Users/davidahmann/Projects/gait -Y /Users/davidahmann/Projects/gait/sdk/python/.venv
[2026-02-15 07:17:34] [build-stdout] INFO: The Python extractor has recently stopped extracting the standard library by default. If you encounter problems, please let us know by submitting an issue to https://github.com/github/codeql. It is possible to re-enable extraction of the standard library by setting the environment variable CODEQL_EXTRACTOR_PYTHON_EXTRACT_STDLIB.
[2026-02-15 07:17:34] [build-stdout] [INFO] Extraction will use the Python 3 standard library.
[2026-02-15 07:17:34] [build-stdout] [INFO] sys_path is: ['/opt/homebrew/Caskroom/codeql/2.24.1/codeql/python/tools', '/opt/homebrew/Cellar/python@3.14/3.14.0_1/Frameworks/Python.framework/Versions/3.14/lib/python314.zip', '/opt/homebrew/Cellar/python@3.14/3.14.0_1/Frameworks/Python.framework/Versions/3.14/lib/python3.14', '/opt/homebrew/Cellar/python@3.14/3.14.0_1/Frameworks/Python.framework/Versions/3.14/lib/python3.14/lib-dynload']
[2026-02-15 07:17:34] [build-stdout] [INFO] Python version 3.14.0
[2026-02-15 07:17:34] [build-stdout] [INFO] Python extractor version 7.1.7
[2026-02-15 07:17:34] [build-stdout] [INFO] [1] Extracted folder /Users/davidahmann/Projects/gait/ui/local/node_modules/flatted/python in 1ms
[2026-02-15 07:17:34] [build-stdout] [INFO] [1] Extracted folder /Users/davidahmann/Projects/gait/ui/local/node_modules/flatted in 0ms
[2026-02-15 07:17:34] [build-stdout] [INFO] [5] Extracted file /Users/davidahmann/Projects/gait/ui/local/node_modules/flatted/python/flatted.py in 38ms
[2026-02-15 07:17:34] [build-stdout] [INFO] [1] Extracted folder /Users/davidahmann/Projects/gait/ui/local/node_modules in 0ms
[2026-02-15 07:17:34] [build-stdout] [INFO] [11] Extracted folder /Users/davidahmann/Projects/gait/ui/local in 1ms
[2026-02-15 07:17:34] [build-stdout] [INFO] [13] Extracted folder /Users/davidahmann/Projects/gait/ui in 1ms
[2026-02-15 07:17:34] [build-stdout] [INFO] [8] Skipped built-in file /opt/homebrew/Cellar/python@3.14/3.14.0_1/Frameworks/Python.framework/Versions/3.14/lib/python3.14/json/__init__.py
[2026-02-15 07:17:34] [build-stdout] [INFO] [4] Extracted folder /opt/homebrew/Cellar/python@3.14/3.14.0_1/Frameworks/Python.framework/Versions/3.14/lib/python3.14/json in 1ms
[2026-02-15 07:17:34] [build-stdout] [INFO] [3] Extracted folder /Users/davidahmann/Projects/gait/docs-site/node_modules/flatted/python in 1ms
[2026-02-15 07:17:34] [build-stdout] [INFO] [7] Extracted folder /Users/davidahmann/Projects/gait/docs-site/node_modules/flatted in 1ms
[2026-02-15 07:17:34] [build-stdout] [INFO] [5] Extracted folder /Users/davidahmann/Projects/gait/docs-site/node_modules/katex/src/metrics in 1ms
[2026-02-15 07:17:34] [build-stdout] [INFO] [14] Extracted folder /Users/davidahmann/Projects/gait/docs-site/node_modules/katex/src/fonts in 1ms
[2026-02-15 07:17:34] [build-stdout] [INFO] [2] Extracted file /Users/davidahmann/Projects/gait/docs-site/node_modules/katex/src/metrics/format_json.py in 11ms
[2026-02-15 07:17:34] [build-stdout] [INFO] [1] Extracted file /Users/davidahmann/Projects/gait/docs-site/node_modules/katex/src/fonts/generate_fonts.py in 18ms
[2026-02-15 07:17:34] [build-stdout] [INFO] [12] Extracted file /Users/davidahmann/Projects/gait/docs-site/node_modules/katex/src/metrics/extract_tfms.py in 22ms
[2026-02-15 07:17:34] [build-stdout] [INFO] [9] Extracted file /Users/davidahmann/Projects/gait/docs-site/node_modules/katex/src/metrics/extract_ttfs.py in 25ms
[2026-02-15 07:17:34] [build-stdout] [INFO] [6] Extracted file /Users/davidahmann/Projects/gait/docs-site/node_modules/flatted/python/flatted.py in 33ms
[2026-02-15 07:17:34] [build-stdout] [INFO] [10] Extracted file /Users/davidahmann/Projects/gait/docs-site/node_modules/katex/src/metrics/parse_tfm.py in 53ms
[2026-02-15 07:17:34] [build-stdout] [INFO] [11] Extracted folder /Users/davidahmann/Projects/gait/docs-site/node_modules/katex/src in 0ms
[2026-02-15 07:17:34] [build-stdout] [INFO] [13] Extracted folder /Users/davidahmann/Projects/gait/docs-site/node_modules in 0ms
[2026-02-15 07:17:34] [build-stdout] [INFO] [4] Extracted folder /Users/davidahmann/Projects/gait/docs-site in 0ms
[2026-02-15 07:17:34] [build-stdout] [INFO] [3] Extracted folder /Users/davidahmann/Projects/gait/docs-site/node_modules/katex in 0ms
[2026-02-15 07:17:34] [build-stdout] [INFO] [5] Extracted module sys in 0ms
[2026-02-15 07:17:34] [build-stdout] [INFO] [9] Skipped built-in file /opt/homebrew/Cellar/python@3.14/3.14.0_1/Frameworks/Python.framework/Versions/3.14/lib/python3.14/os.py
[2026-02-15 07:17:34] [build-stdout] [INFO] [13] Extracted folder /opt/homebrew/Cellar/python@3.14/3.14.0_1/Frameworks/Python.framework/Versions/3.14/lib/python3.14/collections in 0ms
[2026-02-15 07:17:34] [build-stdout] [INFO] [11] Extracted folder /Users/davidahmann/Projects/gait/sdk/python/tests in 1ms
[2026-02-15 07:17:34] [build-stdout] [INFO] [8] Extracted file /Users/davidahmann/Projects/gait/sdk/python/tests/test_basic.py in 4ms
[2026-02-15 07:17:34] [build-stdout] [INFO] [2] Extracted file /Users/davidahmann/Projects/gait/sdk/python/tests/helpers.py in 4ms
[2026-02-15 07:17:34] [build-stdout] [INFO] [3] Skipped built-in file /opt/homebrew/Cellar/python@3.14/3.14.0_1/Frameworks/Python.framework/Versions/3.14/lib/python3.14/subprocess.py
[2026-02-15 07:17:34] [build-stdout] [INFO] [8] Skipped built-in file /opt/homebrew/Cellar/python@3.14/3.14.0_1/Frameworks/Python.framework/Versions/3.14/lib/python3.14/collections/__init__.py
[2026-02-15 07:17:34] [build-stdout] [INFO] [2] Extracted folder /Users/davidahmann/Projects/gait/sdk/python/examples in 1ms
[2026-02-15 07:17:34] [build-stdout] [INFO] [2] Extracted folder /Users/davidahmann/Projects/gait/examples/python in 1ms
[2026-02-15 07:17:34] [build-stdout] [INFO] [8] Extracted folder /Users/davidahmann/Projects/gait/sdk/python/gait in 1ms
[2026-02-15 07:17:34] [build-stdout] [INFO] [13] Extracted file /Users/davidahmann/Projects/gait/sdk/python/examples/openai_style_tool_decorator.py in 7ms
[2026-02-15 07:17:34] [build-stdout] [INFO] [13] Extracted folder /Users/davidahmann/Projects/gait/sdk/python in 0ms
[2026-02-15 07:17:34] [build-stdout] [INFO] [5] Extracted file /Users/davidahmann/Projects/gait/sdk/python/gait/__init__.py in 8ms
[2026-02-15 07:17:34] [build-stdout] [INFO] [14] Extracted file /Users/davidahmann/Projects/gait/sdk/python/tests/test_primitive_fixtures.py in 14ms
[2026-02-15 07:17:34] [build-stdout] [INFO] [14] Extracted file /Users/davidahmann/Projects/gait/sdk/python/examples/langchain_style_tool_decorator.py in 5ms
[2026-02-15 07:17:34] [build-stdout] [INFO] [14] Extracted folder /Users/davidahmann/Projects/gait/examples/integrations/openclaw/skill in 0ms
[2026-02-15 07:17:34] [build-stdout] [INFO] [1] Extracted file /Users/davidahmann/Projects/gait/sdk/python/tests/test_session.py in 24ms
[2026-02-15 07:17:34] [build-stdout] [INFO] [7] Extracted file /Users/davidahmann/Projects/gait/sdk/python/tests/test_decorators.py in 37ms
[2026-02-15 07:17:34] [build-stdout] [INFO] [7] Extracted folder /Users/davidahmann/Projects/gait/examples/integrations in 0ms
[2026-02-15 07:17:34] [build-stdout] [INFO] [2] Extracted file /Users/davidahmann/Projects/gait/examples/python/reference_adapter_demo.py in 24ms
[2026-02-15 07:17:34] [build-stdout] [INFO] [6] Extracted file /Users/davidahmann/Projects/gait/sdk/python/tests/test_adapter.py in 43ms
[2026-02-15 07:17:34] [build-stdout] [INFO] [2] Extracted folder /Users/davidahmann/Projects/gait/sdk in 1ms
[2026-02-15 07:17:34] [build-stdout] [INFO] [6] Extracted folder /Users/davidahmann/Projects/gait/examples/sidecar in 0ms
[2026-02-15 07:17:34] [build-stdout] [INFO] [9] Extracted file /Users/davidahmann/Projects/gait/sdk/python/gait/decorators.py in 46ms
[2026-02-15 07:17:34] [build-stdout] [INFO] [2] Extracted folder /Users/davidahmann/Projects/gait/examples/integrations/template in 1ms
[2026-02-15 07:17:34] [build-stdout] [INFO] [2] Extracted folder /Users/davidahmann/Projects/gait/examples/integrations/openclaw in 0ms
[2026-02-15 07:17:34] [build-stdout] [INFO] [2] Extracted folder /Users/davidahmann/Projects/gait/examples/integrations/langchain in 0ms
[2026-02-15 07:17:34] [build-stdout] [INFO] [2] Extracted folder /Users/davidahmann/Projects/gait/examples/integrations/voice_reference in 0ms
[2026-02-15 07:17:34] [build-stdout] [INFO] [2] Skipped built-in file /opt/homebrew/Cellar/python@3.14/3.14.0_1/Frameworks/Python.framework/Versions/3.14/lib/python3.14/__future__.py
[2026-02-15 07:17:34] [build-stdout] [INFO] [11] Extracted file /Users/davidahmann/Projects/gait/sdk/python/gait/adapter.py in 53ms
[2026-02-15 07:17:34] [build-stdout] [INFO] [5] Extracted file /Users/davidahmann/Projects/gait/examples/integrations/langchain/quickstart.py in 48ms
[2026-02-15 07:17:34] [build-stdout] [INFO] [8] Extracted file /Users/davidahmann/Projects/gait/examples/integrations/openclaw/quickstart.py in 64ms
[2026-02-15 07:17:34] [build-stdout] [INFO] [14] Extracted file /Users/davidahmann/Projects/gait/examples/integrations/template/quickstart.py in 53ms
[2026-02-15 07:17:34] [build-stdout] [INFO] [13] Extracted file /Users/davidahmann/Projects/gait/examples/integrations/openclaw/skill/gait_openclaw_gate.py in 65ms
[2026-02-15 07:17:34] [build-stdout] [INFO] [10] Extracted file /Users/davidahmann/Projects/gait/sdk/python/gait/session.py in 77ms
[2026-02-15 07:17:34] [build-stdout] [INFO] [12] Extracted file /Users/davidahmann/Projects/gait/sdk/python/tests/test_client.py in 78ms
[2026-02-15 07:17:34] [build-stdout] [INFO] [7] Extracted file /Users/davidahmann/Projects/gait/examples/integrations/autogpt/quickstart.py in 53ms
[2026-02-15 07:17:34] [build-stdout] [INFO] [3] Extracted file /Users/davidahmann/Projects/gait/sdk/python/gait/client.py in 88ms
[2026-02-15 07:17:34] [build-stdout] [INFO] [2] Extracted file /Users/davidahmann/Projects/gait/examples/integrations/gastown/quickstart.py in 60ms
[2026-02-15 07:17:34] [build-stdout] [INFO] [4] Extracted file /Users/davidahmann/Projects/gait/sdk/python/gait/models.py in 94ms
[2026-02-15 07:17:35] [build-stdout] [INFO] [1] Extracted file /Users/davidahmann/Projects/gait/examples/integrations/voice_reference/quickstart.py in 90ms
[2026-02-15 07:17:35] [build-stdout] [INFO] [6] Extracted folder /Users/davidahmann/Projects/gait/examples in 0ms
[2026-02-15 07:17:35] [build-stdout] [INFO] [11] Extracted folder /Users/davidahmann/Projects/gait/examples/integrations/autogen in 0ms
[2026-02-15 07:17:35] [build-stdout] [INFO] [8] Extracted folder /Users/davidahmann/Projects/gait/examples/integrations/openai_agents in 0ms
[2026-02-15 07:17:35] [build-stdout] [INFO] [14] Extracted folder /Users/davidahmann/Projects/gait/examples/integrations/autogpt in 0ms
[2026-02-15 07:17:35] [build-stdout] [INFO] [10] Extracted folder /Users/davidahmann/Projects/gait/examples/integrations/gastown in 1ms
[2026-02-15 07:17:35] [build-stdout] [INFO] [7] Extracted folder /opt/homebrew/Cellar/python@3.14/3.14.0_1/Frameworks/Python.framework/Versions/3.14/lib/python3.14/pathlib in 0ms
[2026-02-15 07:17:35] [build-stdout] [INFO] [4] Skipped built-in file /opt/homebrew/Cellar/python@3.14/3.14.0_1/Frameworks/Python.framework/Versions/3.14/lib/python3.14/pathlib/__init__.py
[2026-02-15 07:17:35] [build-stdout] [INFO] [3] Extracted file /Users/davidahmann/Projects/gait/scripts/check_resource_budgets.py in 30ms
[2026-02-15 07:17:35] [build-stdout] [INFO] [9] Extracted file /Users/davidahmann/Projects/gait/examples/integrations/openai_agents/quickstart.py in 44ms
[2026-02-15 07:17:35] [build-stdout] [INFO] [1] Extracted file /Users/davidahmann/Projects/gait/examples/integrations/autogen/quickstart.py in 44ms
[2026-02-15 07:17:35] [build-stdout] [INFO] [12] Extracted file /Users/davidahmann/Projects/gait/scripts/check_docs_site_validation.py in 54ms
[2026-02-15 07:17:35] [build-stdout] [INFO] [5] Extracted file /Users/davidahmann/Projects/gait/scripts/check_integration_lane_scorecard.py in 54ms
[2026-02-15 07:17:35] [build-stdout] [INFO] [13] Extracted file /Users/davidahmann/Projects/gait/scripts/check_ui_budgets.py in 69ms
[2026-02-15 07:17:35] [build-stdout] [INFO] [2] Extracted file /Users/davidahmann/Projects/gait/scripts/check_command_budgets.py in 170ms
[2026-02-15 07:17:35] [build-stdout] [INFO] [12] Skipped built-in file /opt/homebrew/Cellar/python@3.14/3.14.0_1/Frameworks/Python.framework/Versions/3.14/lib/python3.14/inspect.py
[2026-02-15 07:17:35] [build-stdout] [INFO] [5] Skipped built-in file /opt/homebrew/Cellar/python@3.14/3.14.0_1/Frameworks/Python.framework/Versions/3.14/lib/python3.14/typing.py
[2026-02-15 07:17:35] [build-stdout] [INFO] [13] Skipped built-in file /opt/homebrew/Cellar/python@3.14/3.14.0_1/Frameworks/Python.framework/Versions/3.14/lib/python3.14/argparse.py
[2026-02-15 07:17:35] [build-stdout] [INFO] [2] Skipped built-in file /opt/homebrew/Cellar/python@3.14/3.14.0_1/Frameworks/Python.framework/Versions/3.14/lib/python3.14/shutil.py
[2026-02-15 07:17:35] [build-stdout] [INFO] [12] Skipped built-in file /opt/homebrew/Cellar/python@3.14/3.14.0_1/Frameworks/Python.framework/Versions/3.14/lib/python3.14/contextvars.py
[2026-02-15 07:17:35] [build-stdout] [INFO] [9] Extracted folder /Users/davidahmann/Projects/gait/scripts in 1ms
[2026-02-15 07:17:35] [build-stdout] [INFO] [5] Skipped built-in file /opt/homebrew/Cellar/python@3.14/3.14.0_1/Frameworks/Python.framework/Versions/3.14/lib/python3.14/hashlib.py
[2026-02-15 07:17:35] [build-stdout] [INFO] [13] Skipped built-in file /opt/homebrew/Cellar/python@3.14/3.14.0_1/Frameworks/Python.framework/Versions/3.14/lib/python3.14/dataclasses.py
[2026-02-15 07:17:35] [build-stdout] [INFO] [2] Skipped built-in file /opt/homebrew/Cellar/python@3.14/3.14.0_1/Frameworks/Python.framework/Versions/3.14/lib/python3.14/functools.py
[2026-02-15 07:17:35] [build-stdout] [INFO] [12] Skipped built-in file /opt/homebrew/Cellar/python@3.14/3.14.0_1/Frameworks/Python.framework/Versions/3.14/lib/python3.14/platform.py
[2026-02-15 07:17:35] [build-stdout] [INFO] [9] Skipped built-in file /opt/homebrew/Cellar/python@3.14/3.14.0_1/Frameworks/Python.framework/Versions/3.14/lib/python3.14/datetime.py
[2026-02-15 07:17:35] [build-stdout] [INFO] [5] Skipped built-in file /opt/homebrew/Cellar/python@3.14/3.14.0_1/Frameworks/Python.framework/Versions/3.14/lib/python3.14/tempfile.py
[2026-02-15 07:17:35] [build-stdout] [INFO] [2] Skipped built-in file /opt/homebrew/Cellar/python@3.14/3.14.0_1/Frameworks/Python.framework/Versions/3.14/lib/python3.14/re/__init__.py
[2026-02-15 07:17:35] [build-stdout] [INFO] [12] Skipped built-in file /opt/homebrew/Cellar/python@3.14/3.14.0_1/Frameworks/Python.framework/Versions/3.14/lib/python3.14/statistics.py
[2026-02-15 07:17:35] [build-stdout] [INFO] [9] Skipped built-in file /opt/homebrew/Cellar/python@3.14/3.14.0_1/Frameworks/Python.framework/Versions/3.14/lib/python3.14/socket.py
[2026-02-15 07:17:35] [build-stdout] [INFO] [13] Extracted folder /opt/homebrew/Cellar/python@3.14/3.14.0_1/Frameworks/Python.framework/Versions/3.14/lib/python3.14/re in 0ms
[2026-02-15 07:17:35] [build-stdout] [INFO] [2] Skipped built-in file /opt/homebrew/Cellar/python@3.14/3.14.0_1/Frameworks/Python.framework/Versions/3.14/lib/python3.14/urllib/__init__.py
[2026-02-15 07:17:35] [build-stdout] [INFO] [12] Skipped built-in file /opt/homebrew/Cellar/python@3.14/3.14.0_1/Frameworks/Python.framework/Versions/3.14/lib/python3.14/urllib/error.py
[2026-02-15 07:17:35] [build-stdout] [INFO] [9] Skipped built-in file /opt/homebrew/Cellar/python@3.14/3.14.0_1/Frameworks/Python.framework/Versions/3.14/lib/python3.14/urllib/request.py
[2026-02-15 07:17:35] [build-stdout] [INFO] [2] Extracted folder /opt/homebrew/Cellar/python@3.14/3.14.0_1/Frameworks/Python.framework/Versions/3.14/lib/python3.14/urllib in 0ms
[2026-02-15 07:17:35] [build-stdout] [INFO] [13] Extracted module math in 2ms
[2026-02-15 07:17:35] [build-stdout] [INFO] [5] Extracted module time in 3ms
[2026-02-15 07:17:35] [build-stdout] [INFO] [14] Extracted file /Users/davidahmann/Projects/gait/scripts/check_go_coverage.py in 13ms
[2026-02-15 07:17:35] [build-stdout] [INFO] [7] Extracted file /Users/davidahmann/Projects/gait/scripts/check_go_package_coverage.py in 19ms
[2026-02-15 07:17:35] [build-stdout] [INFO] [4] Extracted file /Users/davidahmann/Projects/gait/scripts/render_tool_allowlist_policy.py in 24ms
[2026-02-15 07:17:35] [build-stdout] [INFO] [8] Extracted file /Users/davidahmann/Projects/gait/examples/sidecar/gate_sidecar.py in 28ms
[2026-02-15 07:17:35] [build-stdout] [INFO] [6] Extracted file /Users/davidahmann/Projects/gait/scripts/check_bench_regression.py in 30ms
[2026-02-15 07:17:35] [build-stdout] [INFO] [11] Extracted file /Users/davidahmann/Projects/gait/scripts/validate_community_index.py in 41ms
[2026-02-15 07:17:35] [build-stdout] [INFO] [10] Extracted file /Users/davidahmann/Projects/gait/scripts/render_ecosystem_release_notes.py in 63ms
[2026-02-15 07:17:35] [build-stdout] [INFO] [1] Extracted file /Users/davidahmann/Projects/gait/scripts/validate_repo_skills.py in 70ms
[2026-02-15 07:17:35] [build-stdout] [INFO] [3] Extracted file /Users/davidahmann/Projects/gait/scripts/check_context_budgets.py in 100ms
[2026-02-15 07:17:35] [build-stdout] [INFO] Processed 109 modules in 1.61s
[2026-02-15 07:17:36] [build-stderr] Scanning for files in /Users/davidahmann/Projects/gait...
[2026-02-15 07:17:36] [build-stderr] /var/folders/xf/nh2svl1x1_94jfvlmhz4njzh0000gn/T/gait-codeql-Ut0rFO/python-db: Indexing files in in /Users/davidahmann/Projects/gait...
[2026-02-15 07:17:36] [build-stderr] Running command in /Users/davidahmann/Projects/gait: [/opt/homebrew/Caskroom/codeql/2.24.1/codeql/yaml/tools/index-files.sh, /var/folders/xf/nh2svl1x1_94jfvlmhz4njzh0000gn/T/gait-codeql-Ut0rFO/python-db/working/files-to-index7353376263727636549.list]
[codeql] analyzing python database
CodeQL scanned 14 out of 14 GitHub Actions files and 39 out of 39 Python files in this invocation. Typically CodeQL is configured to analyze a single CodeQL language per invocation, so check other invocations to determine overall coverage information.
[codeql] no findings >= warning (lint, security scans, full test+coverage gates, python checks, local CodeQL)
- git pre-push hook /Applications/Xcode.app/Contents/Developer/usr/bin/make lint-fast
python3 scripts/validate_repo_skills.py
validated 3 skills under /Users/davidahmann/Projects/gait/.agents/skills for provider=both
python3 scripts/validate_community_index.py
community index validation passed: docs/ecosystem/community_index.json (9 entries)
bash scripts/check_repo_hygiene.sh
bash scripts/check_hooks_config.sh
go vet ./...
go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.0.1 run ./...
0 issues.
(cd sdk/python && uv run --python 3.13 --extra dev ruff check)
All checks passed!
(cd sdk/python && uv run --python 3.13 --extra dev mypy)
Success: no issues found in 6 source files
/Applications/Xcode.app/Contents/Developer/usr/bin/make test-fast
go test ./...
ok  	github.com/davidahmann/gait/cmd/gait	3.644s
ok  	github.com/davidahmann/gait/core/contextproof	(cached)
ok  	github.com/davidahmann/gait/core/credential	(cached)
ok  	github.com/davidahmann/gait/core/doctor	0.699s
ok  	github.com/davidahmann/gait/core/errors	(cached)
ok  	github.com/davidahmann/gait/core/fsx	(cached)
ok  	github.com/davidahmann/gait/core/gate	(cached)
ok  	github.com/davidahmann/gait/core/guard	(cached)
ok  	github.com/davidahmann/gait/core/jcs	(cached)
ok  	github.com/davidahmann/gait/core/jobruntime	(cached)
ok  	github.com/davidahmann/gait/core/mcp	(cached)
ok  	github.com/davidahmann/gait/core/pack	0.809s
ok  	github.com/davidahmann/gait/core/policytest	(cached)
ok  	github.com/davidahmann/gait/core/projectconfig	(cached)
ok  	github.com/davidahmann/gait/core/registry	(cached)
ok  	github.com/davidahmann/gait/core/regress	(cached)
ok  	github.com/davidahmann/gait/core/runpack	(cached)
?   	github.com/davidahmann/gait/core/schema/v1/context	[no test files]
?   	github.com/davidahmann/gait/core/schema/v1/gate	[no test files]
?   	github.com/davidahmann/gait/core/schema/v1/guard	[no test files]
?   	github.com/davidahmann/gait/core/schema/v1/pack	[no test files]
?   	github.com/davidahmann/gait/core/schema/v1/policytest	[no test files]
?   	github.com/davidahmann/gait/core/schema/v1/registry	[no test files]
?   	github.com/davidahmann/gait/core/schema/v1/regress	[no test files]
?   	github.com/davidahmann/gait/core/schema/v1/runpack	[no test files]
?   	github.com/davidahmann/gait/core/schema/v1/scout	[no test files]
?   	github.com/davidahmann/gait/core/schema/v1/voice	[no test files]
ok  	github.com/davidahmann/gait/core/schema/validate	(cached)
ok  	github.com/davidahmann/gait/core/scout	(cached)
ok  	github.com/davidahmann/gait/core/sign	(cached)
ok  	github.com/davidahmann/gait/core/ui	(cached)
ok  	github.com/davidahmann/gait/core/zipx	(cached)
ok  	github.com/davidahmann/gait/internal/e2e	8.065s
ok  	github.com/davidahmann/gait/internal/integration	(cached)
ok  	github.com/davidahmann/gait/internal/testutil	0.643s
?   	github.com/davidahmann/gait/internal/uiassets	[no test files]
(cd sdk/python && PYTHONPATH=. uv run --python 3.13 --extra dev pytest)
============================= test session starts ==============================
platform darwin -- Python 3.13.7, pytest-9.0.2, pluggy-1.6.0
rootdir: /Users/davidahmann/Projects/gait/sdk/python
configfile: pyproject.toml
testpaths: tests
plugins: cov-7.0.0
collected 31 items

tests/test_adapter.py ........                                           [ 25%]
tests/test_basic.py .                                                    [ 29%]
tests/test_client.py .............                                       [ 70%]
tests/test_decorators.py ....                                            [ 83%]
tests/test_primitive_fixtures.py ...                                     [ 93%]
tests/test_session.py ..                                                 [100%]

============================== 31 passed in 0.42s ============================== on push
