### PR TITLE
Fix windows contracts failure in pack producer kit checksum step

### DIFF
--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -1,15 +1,20 @@
-# Gait Skills (Thin Wrappers)
+# Gait Skills
 
-The official OSS skill set includes exactly three skills:
+This directory contains reusable, portable skills that wrap Gait CLI workflows.
+
+Core publishable skills:
+
+- `incident-to-regression`
+- `ci-failure-triage`
+- `evidence-receipt-generation`
+
+Existing project-specific skills remain available for internal usage:
 
 - `gait-capture-runpack`
 - `gait-incident-to-regression`
 - `gait-policy-test-rollout`
 
-These skills are thin wrappers around the Gait CLI and contracts.
-They do not reimplement policy logic.
-
-Quick validation:
+Validation:
 
 ```bash
 python3 scripts/validate_repo_skills.py

--- a/.agents/skills/ci-failure-triage/SKILL.md
+++ b/.agents/skills/ci-failure-triage/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: ci-failure-triage
+description: Triage CI failures using artifact-first checks. Use when users need fast root-cause isolation from failing runs, integrity verification, and deterministic reruns.
+disable-model-invocation: true
+---
+# CI Failure Triage
+
+Use this skill to isolate failing CI causes with deterministic artifact checks.
+
+## Required Inputs
+
+- `failure_target`: failing run id, runpack path, or pack path.
+- `baseline_target` (optional): known-good runpack or pack for diff.
+- `workdir`: writable directory for triage outputs.
+
+## Workflow
+
+1. Verify the failing artifact first:
+   - `gait verify <failure_target> --json`
+2. If failure came from regress grading, rerun deterministically:
+   - `gait regress run --json`
+3. If baseline evidence exists, compute deterministic diff:
+   - `gait pack diff <baseline_target> <failure_target> --json`
+4. If environment health is uncertain, run diagnostics:
+   - `gait doctor --json`
+5. Return triage summary:
+   - integrity status
+   - failing stage and reason codes
+   - diff highlights (if provided)
+   - exact next command to reproduce
+
+## Safety And Portability Rules
+
+- Never classify root cause without command output evidence.
+- Do not rely on CI provider-specific APIs when local artifacts are available.
+- Preserve stable exit-code semantics in reporting.
+- Keep recommendations reproducible with copy-pastable commands.
+
+## Usage Example
+
+```bash
+gait verify ./artifacts/runpack_failed.zip --json
+gait doctor --json
+gait regress run --json
+```
+
+Expected result:
+- verify output reports integrity status for the target artifact
+- doctor output reports actionable diagnostics
+- regress output reports stable pass/fail status and failures
+
+## Validation Example
+
+```bash
+gait verify ./artifacts/runpack_failed.zip --json > ./artifacts/verify.json
+python3 - <<'PY'
+import json
+from pathlib import Path
+p = json.loads(Path('./artifacts/verify.json').read_text(encoding='utf-8'))
+assert 'ok' in p
+assert 'manifest_digest' in p
+print('validated verify payload keys present')
+PY
+```
+
+Expected result:
+- script prints `validated verify payload keys present`

--- a/.agents/skills/ci-failure-triage/agents/openai.yaml
+++ b/.agents/skills/ci-failure-triage/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "CI Failure Triage"
+  short_description: "Triage CI failures with artifact-first evidence"
+  default_prompt: "Use $ci-failure-triage to verify failing artifacts, isolate cause, and return deterministic rerun commands."

--- a/.agents/skills/evidence-receipt-generation/SKILL.md
+++ b/.agents/skills/evidence-receipt-generation/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: evidence-receipt-generation
+description: Generate portable evidence receipts from run artifacts. Use when users ask for ticket-ready proof, receipt footers, or integrity-backed handoff metadata.
+disable-model-invocation: true
+---
+# Evidence Receipt Generation
+
+Use this skill to generate integrity-backed receipts that are portable across CI, tickets, and audit handoff.
+
+## Required Inputs
+
+- `source`: run id, runpack path, or pack path.
+- `out_path` (optional): destination file for JSON receipt output.
+
+## Workflow
+
+1. Verify integrity before receipt generation:
+   - `gait verify <source> --json`
+2. Generate receipt from source artifact:
+   - `gait run receipt --from <source> --json`
+3. Parse receipt fields for handoff:
+   - `ok`, `run_id`, `manifest_digest`, `ticket_footer`, `bundle`
+4. Return concise evidence block containing:
+   - source identifier
+   - manifest digest
+   - ticket footer text
+   - verification status
+
+## Safety And Portability Rules
+
+- Never invent digests, run ids, or receipt text.
+- Treat failed verification as a blocking state for receipt publication.
+- Keep receipt output machine-readable and transportable.
+- Avoid environment-specific absolute paths in final handoff.
+
+## Usage Example
+
+```bash
+gait verify ./artifacts/runpack.zip --json
+gait run receipt --from ./artifacts/runpack.zip --json
+```
+
+Expected result:
+- verify returns `ok=true` for intact artifacts
+- receipt returns a non-empty `ticket_footer` suitable for issue or PR evidence
+
+## Validation Example
+
+```bash
+gait run receipt --from ./artifacts/runpack.zip --json > ./artifacts/receipt.json
+python3 - <<'PY'
+import json
+from pathlib import Path
+p = json.loads(Path('./artifacts/receipt.json').read_text(encoding='utf-8'))
+assert p.get('ok') is True
+assert str(p.get('ticket_footer', '')).strip()
+print('validated receipt footer present')
+PY
+```
+
+Expected result:
+- script prints `validated receipt footer present`

--- a/.agents/skills/evidence-receipt-generation/agents/openai.yaml
+++ b/.agents/skills/evidence-receipt-generation/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Evidence Receipt Generation"
+  short_description: "Generate portable evidence receipts from runs"
+  default_prompt: "Use $evidence-receipt-generation to verify source artifacts and emit ticket-ready receipt metadata."

--- a/.agents/skills/incident-to-regression/SKILL.md
+++ b/.agents/skills/incident-to-regression/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: incident-to-regression
+description: Convert incident artifacts into deterministic regression fixtures and CI-ready outputs. Use when users ask to reproduce a failure, build repeatable graders, or emit junit evidence.
+disable-model-invocation: true
+---
+# Incident To Regression
+
+Use this skill to transform an observed incident into deterministic regression checks.
+
+## Required Inputs
+
+- `run_source`: run id, runpack path, or equivalent source accepted by `gait regress init`.
+- `workdir`: writable working directory where fixtures and outputs will be created.
+
+## Workflow
+
+1. Initialize deterministic fixture from the incident source:
+   - `gait regress init --from <run_source> --json`
+2. Parse fields from init output and record them:
+   - `ok`, `run_id`, `fixture_name`, `fixture_dir`, `config_path`, `next_commands`
+3. Execute regression graders:
+   - `gait regress run --json`
+4. If CI evidence is needed, rerun with JUnit output:
+   - `gait regress run --json --junit <junit_path>`
+5. Return a concise summary with:
+   - source identifier
+   - fixture directory and config path
+   - status and failed grader count
+   - evidence output paths
+
+## Safety And Portability Rules
+
+- Use CLI outputs only; do not infer grader results from config text.
+- Treat non-zero regress exit codes as actionable outcomes, not warnings.
+- Do not assume repository-specific fixture paths.
+- Keep paths relative to the active workspace unless the user explicitly asks for absolute paths.
+
+## Usage Example
+
+```bash
+gait regress init --from run_demo --json
+gait regress run --json --junit ./artifacts/junit.xml
+```
+
+Expected result:
+- init output includes `ok=true` and a `fixture_dir`
+- run output includes stable `status` and grader failure details
+- JUnit file exists at `./artifacts/junit.xml`
+
+## Validation Example
+
+```bash
+gait regress run --json > ./artifacts/regress_result.json
+python3 - <<'PY'
+import json
+from pathlib import Path
+p = json.loads(Path('./artifacts/regress_result.json').read_text(encoding='utf-8'))
+assert p.get('status') in {'pass', 'fail'}
+print('validated status:', p.get('status'))
+PY
+```
+
+Expected result:
+- script prints `validated status: pass` or `validated status: fail`

--- a/.agents/skills/incident-to-regression/agents/openai.yaml
+++ b/.agents/skills/incident-to-regression/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Incident To Regression"
+  short_description: "Convert incidents into deterministic regress checks"
+  default_prompt: "Use $incident-to-regression to initialize deterministic fixtures, run graders, and return CI-ready evidence outputs."

--- a/.agents/submissions/README.md
+++ b/.agents/submissions/README.md
@@ -1,0 +1,16 @@
+# Skill Submission Exports
+
+This folder contains provider-specific submission copies generated from the core skills in `.agents/skills/`.
+
+Generate or refresh variants:
+
+```bash
+python3 scripts/export_skill_submissions.py
+```
+
+Outputs:
+
+- `./.agents/submissions/openai/<skill>/SKILL.md`
+- `./.agents/submissions/anthropic/<skill>/SKILL.md`
+
+Provider wording tweaks are appended automatically while preserving the same core workflow content.

--- a/.agents/submissions/anthropic/ci-failure-triage/LICENSE.txt
+++ b/.agents/submissions/anthropic/ci-failure-triage/LICENSE.txt
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied,
+   including, without limitation, any warranties or conditions of
+   TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/.agents/submissions/anthropic/ci-failure-triage/SKILL.md
+++ b/.agents/submissions/anthropic/ci-failure-triage/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: ci-failure-triage
+description: Triage CI failures using artifact-first checks. Use when users need fast root-cause isolation from failing runs, integrity verification, and deterministic reruns.
+license: Apache-2.0
+---
+
+# CI Failure Triage
+
+Use this skill to isolate failing CI causes with deterministic artifact checks.
+
+## Required Inputs
+
+- `failure_target`: failing run id, runpack path, or pack path.
+- `baseline_target` (optional): known-good runpack or pack for diff.
+- `workdir`: writable directory for triage outputs.
+
+## Workflow
+
+1. Verify the failing artifact first:
+   - `gait verify <failure_target> --json`
+2. If failure came from regress grading, rerun deterministically:
+   - `gait regress run --json`
+3. If baseline evidence exists, compute deterministic diff:
+   - `gait pack diff <baseline_target> <failure_target> --json`
+4. If environment health is uncertain, run diagnostics:
+   - `gait doctor --json`
+5. Return triage summary:
+   - integrity status
+   - failing stage and reason codes
+   - diff highlights (if provided)
+   - exact next command to reproduce
+
+## Safety And Portability Rules
+
+- Never classify root cause without command output evidence.
+- Do not rely on CI provider-specific APIs when local artifacts are available.
+- Preserve stable exit-code semantics in reporting.
+- Keep recommendations reproducible with copy-pastable commands.
+
+## Usage Example
+
+```bash
+gait verify ./artifacts/runpack_failed.zip --json
+gait doctor --json
+gait regress run --json
+```
+
+Expected result:
+- verify output reports integrity status for the target artifact
+- doctor output reports actionable diagnostics
+- regress output reports stable pass/fail status and failures
+
+## Validation Example
+
+```bash
+gait verify ./artifacts/runpack_failed.zip --json > ./artifacts/verify.json
+python3 - <<'PY'
+import json
+from pathlib import Path
+p = json.loads(Path('./artifacts/verify.json').read_text(encoding='utf-8'))
+assert 'ok' in p
+assert 'manifest_digest' in p
+print('validated verify payload keys present')
+PY
+```
+
+Expected result:
+- script prints `validated verify payload keys present`
+
+## Provider Notes (Anthropic Claude)
+
+- Ask Claude to use the `ci-failure-triage` skill by name when this workflow applies.
+- Keep outputs grounded in command results and `--json` payload fields.

--- a/.agents/submissions/anthropic/evidence-receipt-generation/LICENSE.txt
+++ b/.agents/submissions/anthropic/evidence-receipt-generation/LICENSE.txt
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied,
+   including, without limitation, any warranties or conditions of
+   TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/.agents/submissions/anthropic/evidence-receipt-generation/SKILL.md
+++ b/.agents/submissions/anthropic/evidence-receipt-generation/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: evidence-receipt-generation
+description: Generate portable evidence receipts from run artifacts. Use when users ask for ticket-ready proof, receipt footers, or integrity-backed handoff metadata.
+license: Apache-2.0
+---
+
+# Evidence Receipt Generation
+
+Use this skill to generate integrity-backed receipts that are portable across CI, tickets, and audit handoff.
+
+## Required Inputs
+
+- `source`: run id, runpack path, or pack path.
+- `out_path` (optional): destination file for JSON receipt output.
+
+## Workflow
+
+1. Verify integrity before receipt generation:
+   - `gait verify <source> --json`
+2. Generate receipt from source artifact:
+   - `gait run receipt --from <source> --json`
+3. Parse receipt fields for handoff:
+   - `ok`, `run_id`, `manifest_digest`, `ticket_footer`, `bundle`
+4. Return concise evidence block containing:
+   - source identifier
+   - manifest digest
+   - ticket footer text
+   - verification status
+
+## Safety And Portability Rules
+
+- Never invent digests, run ids, or receipt text.
+- Treat failed verification as a blocking state for receipt publication.
+- Keep receipt output machine-readable and transportable.
+- Avoid environment-specific absolute paths in final handoff.
+
+## Usage Example
+
+```bash
+gait verify ./artifacts/runpack.zip --json
+gait run receipt --from ./artifacts/runpack.zip --json
+```
+
+Expected result:
+- verify returns `ok=true` for intact artifacts
+- receipt returns a non-empty `ticket_footer` suitable for issue or PR evidence
+
+## Validation Example
+
+```bash
+gait run receipt --from ./artifacts/runpack.zip --json > ./artifacts/receipt.json
+python3 - <<'PY'
+import json
+from pathlib import Path
+p = json.loads(Path('./artifacts/receipt.json').read_text(encoding='utf-8'))
+assert p.get('ok') is True
+assert str(p.get('ticket_footer', '')).strip()
+print('validated receipt footer present')
+PY
+```
+
+Expected result:
+- script prints `validated receipt footer present`
+
+## Provider Notes (Anthropic Claude)
+
+- Ask Claude to use the `evidence-receipt-generation` skill by name when this workflow applies.
+- Keep outputs grounded in command results and `--json` payload fields.

--- a/.agents/submissions/anthropic/incident-to-regression/LICENSE.txt
+++ b/.agents/submissions/anthropic/incident-to-regression/LICENSE.txt
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied,
+   including, without limitation, any warranties or conditions of
+   TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/.agents/submissions/anthropic/incident-to-regression/SKILL.md
+++ b/.agents/submissions/anthropic/incident-to-regression/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: incident-to-regression
+description: Convert incident artifacts into deterministic regression fixtures and CI-ready outputs. Use when users ask to reproduce a failure, build repeatable graders, or emit junit evidence.
+license: Apache-2.0
+---
+
+# Incident To Regression
+
+Use this skill to transform an observed incident into deterministic regression checks.
+
+## Required Inputs
+
+- `run_source`: run id, runpack path, or equivalent source accepted by `gait regress init`.
+- `workdir`: writable working directory where fixtures and outputs will be created.
+
+## Workflow
+
+1. Initialize deterministic fixture from the incident source:
+   - `gait regress init --from <run_source> --json`
+2. Parse fields from init output and record them:
+   - `ok`, `run_id`, `fixture_name`, `fixture_dir`, `config_path`, `next_commands`
+3. Execute regression graders:
+   - `gait regress run --json`
+4. If CI evidence is needed, rerun with JUnit output:
+   - `gait regress run --json --junit <junit_path>`
+5. Return a concise summary with:
+   - source identifier
+   - fixture directory and config path
+   - status and failed grader count
+   - evidence output paths
+
+## Safety And Portability Rules
+
+- Use CLI outputs only; do not infer grader results from config text.
+- Treat non-zero regress exit codes as actionable outcomes, not warnings.
+- Do not assume repository-specific fixture paths.
+- Keep paths relative to the active workspace unless the user explicitly asks for absolute paths.
+
+## Usage Example
+
+```bash
+gait regress init --from run_demo --json
+gait regress run --json --junit ./artifacts/junit.xml
+```
+
+Expected result:
+- init output includes `ok=true` and a `fixture_dir`
+- run output includes stable `status` and grader failure details
+- JUnit file exists at `./artifacts/junit.xml`
+
+## Validation Example
+
+```bash
+gait regress run --json > ./artifacts/regress_result.json
+python3 - <<'PY'
+import json
+from pathlib import Path
+p = json.loads(Path('./artifacts/regress_result.json').read_text(encoding='utf-8'))
+assert p.get('status') in {'pass', 'fail'}
+print('validated status:', p.get('status'))
+PY
+```
+
+Expected result:
+- script prints `validated status: pass` or `validated status: fail`
+
+## Provider Notes (Anthropic Claude)
+
+- Ask Claude to use the `incident-to-regression` skill by name when this workflow applies.
+- Keep outputs grounded in command results and `--json` payload fields.

--- a/.agents/submissions/openai/ci-failure-triage/LICENSE.txt
+++ b/.agents/submissions/openai/ci-failure-triage/LICENSE.txt
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied,
+   including, without limitation, any warranties or conditions of
+   TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/.agents/submissions/openai/ci-failure-triage/SKILL.md
+++ b/.agents/submissions/openai/ci-failure-triage/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: ci-failure-triage
+description: Triage CI failures using artifact-first checks. Use when users need fast root-cause isolation from failing runs, integrity verification, and deterministic reruns.
+---
+
+# CI Failure Triage
+
+Use this skill to isolate failing CI causes with deterministic artifact checks.
+
+## Required Inputs
+
+- `failure_target`: failing run id, runpack path, or pack path.
+- `baseline_target` (optional): known-good runpack or pack for diff.
+- `workdir`: writable directory for triage outputs.
+
+## Workflow
+
+1. Verify the failing artifact first:
+   - `gait verify <failure_target> --json`
+2. If failure came from regress grading, rerun deterministically:
+   - `gait regress run --json`
+3. If baseline evidence exists, compute deterministic diff:
+   - `gait pack diff <baseline_target> <failure_target> --json`
+4. If environment health is uncertain, run diagnostics:
+   - `gait doctor --json`
+5. Return triage summary:
+   - integrity status
+   - failing stage and reason codes
+   - diff highlights (if provided)
+   - exact next command to reproduce
+
+## Safety And Portability Rules
+
+- Never classify root cause without command output evidence.
+- Do not rely on CI provider-specific APIs when local artifacts are available.
+- Preserve stable exit-code semantics in reporting.
+- Keep recommendations reproducible with copy-pastable commands.
+
+## Usage Example
+
+```bash
+gait verify ./artifacts/runpack_failed.zip --json
+gait doctor --json
+gait regress run --json
+```
+
+Expected result:
+- verify output reports integrity status for the target artifact
+- doctor output reports actionable diagnostics
+- regress output reports stable pass/fail status and failures
+
+## Validation Example
+
+```bash
+gait verify ./artifacts/runpack_failed.zip --json > ./artifacts/verify.json
+python3 - <<'PY'
+import json
+from pathlib import Path
+p = json.loads(Path('./artifacts/verify.json').read_text(encoding='utf-8'))
+assert 'ok' in p
+assert 'manifest_digest' in p
+print('validated verify payload keys present')
+PY
+```
+
+Expected result:
+- script prints `validated verify payload keys present`
+
+## Provider Notes (OpenAI Codex)
+
+- Invoke explicitly as `$ci-failure-triage` when asking Codex to run this workflow.
+- Keep outputs grounded in command results and `--json` payload fields.

--- a/.agents/submissions/openai/evidence-receipt-generation/LICENSE.txt
+++ b/.agents/submissions/openai/evidence-receipt-generation/LICENSE.txt
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied,
+   including, without limitation, any warranties or conditions of
+   TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/.agents/submissions/openai/evidence-receipt-generation/SKILL.md
+++ b/.agents/submissions/openai/evidence-receipt-generation/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: evidence-receipt-generation
+description: Generate portable evidence receipts from run artifacts. Use when users ask for ticket-ready proof, receipt footers, or integrity-backed handoff metadata.
+---
+
+# Evidence Receipt Generation
+
+Use this skill to generate integrity-backed receipts that are portable across CI, tickets, and audit handoff.
+
+## Required Inputs
+
+- `source`: run id, runpack path, or pack path.
+- `out_path` (optional): destination file for JSON receipt output.
+
+## Workflow
+
+1. Verify integrity before receipt generation:
+   - `gait verify <source> --json`
+2. Generate receipt from source artifact:
+   - `gait run receipt --from <source> --json`
+3. Parse receipt fields for handoff:
+   - `ok`, `run_id`, `manifest_digest`, `ticket_footer`, `bundle`
+4. Return concise evidence block containing:
+   - source identifier
+   - manifest digest
+   - ticket footer text
+   - verification status
+
+## Safety And Portability Rules
+
+- Never invent digests, run ids, or receipt text.
+- Treat failed verification as a blocking state for receipt publication.
+- Keep receipt output machine-readable and transportable.
+- Avoid environment-specific absolute paths in final handoff.
+
+## Usage Example
+
+```bash
+gait verify ./artifacts/runpack.zip --json
+gait run receipt --from ./artifacts/runpack.zip --json
+```
+
+Expected result:
+- verify returns `ok=true` for intact artifacts
+- receipt returns a non-empty `ticket_footer` suitable for issue or PR evidence
+
+## Validation Example
+
+```bash
+gait run receipt --from ./artifacts/runpack.zip --json > ./artifacts/receipt.json
+python3 - <<'PY'
+import json
+from pathlib import Path
+p = json.loads(Path('./artifacts/receipt.json').read_text(encoding='utf-8'))
+assert p.get('ok') is True
+assert str(p.get('ticket_footer', '')).strip()
+print('validated receipt footer present')
+PY
+```
+
+Expected result:
+- script prints `validated receipt footer present`
+
+## Provider Notes (OpenAI Codex)
+
+- Invoke explicitly as `$evidence-receipt-generation` when asking Codex to run this workflow.
+- Keep outputs grounded in command results and `--json` payload fields.

--- a/.agents/submissions/openai/incident-to-regression/LICENSE.txt
+++ b/.agents/submissions/openai/incident-to-regression/LICENSE.txt
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied,
+   including, without limitation, any warranties or conditions of
+   TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/.agents/submissions/openai/incident-to-regression/SKILL.md
+++ b/.agents/submissions/openai/incident-to-regression/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: incident-to-regression
+description: Convert incident artifacts into deterministic regression fixtures and CI-ready outputs. Use when users ask to reproduce a failure, build repeatable graders, or emit junit evidence.
+---
+
+# Incident To Regression
+
+Use this skill to transform an observed incident into deterministic regression checks.
+
+## Required Inputs
+
+- `run_source`: run id, runpack path, or equivalent source accepted by `gait regress init`.
+- `workdir`: writable working directory where fixtures and outputs will be created.
+
+## Workflow
+
+1. Initialize deterministic fixture from the incident source:
+   - `gait regress init --from <run_source> --json`
+2. Parse fields from init output and record them:
+   - `ok`, `run_id`, `fixture_name`, `fixture_dir`, `config_path`, `next_commands`
+3. Execute regression graders:
+   - `gait regress run --json`
+4. If CI evidence is needed, rerun with JUnit output:
+   - `gait regress run --json --junit <junit_path>`
+5. Return a concise summary with:
+   - source identifier
+   - fixture directory and config path
+   - status and failed grader count
+   - evidence output paths
+
+## Safety And Portability Rules
+
+- Use CLI outputs only; do not infer grader results from config text.
+- Treat non-zero regress exit codes as actionable outcomes, not warnings.
+- Do not assume repository-specific fixture paths.
+- Keep paths relative to the active workspace unless the user explicitly asks for absolute paths.
+
+## Usage Example
+
+```bash
+gait regress init --from run_demo --json
+gait regress run --json --junit ./artifacts/junit.xml
+```
+
+Expected result:
+- init output includes `ok=true` and a `fixture_dir`
+- run output includes stable `status` and grader failure details
+- JUnit file exists at `./artifacts/junit.xml`
+
+## Validation Example
+
+```bash
+gait regress run --json > ./artifacts/regress_result.json
+python3 - <<'PY'
+import json
+from pathlib import Path
+p = json.loads(Path('./artifacts/regress_result.json').read_text(encoding='utf-8'))
+assert p.get('status') in {'pass', 'fail'}
+print('validated status:', p.get('status'))
+PY
+```
+
+Expected result:
+- script prints `validated status: pass` or `validated status: fail`
+
+## Provider Notes (OpenAI Codex)
+
+- Invoke explicitly as `$incident-to-regression` when asking Codex to run this workflow.
+- Keep outputs grounded in command results and `--json` payload fields.

--- a/scripts/export_skill_submissions.py
+++ b/scripts/export_skill_submissions.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Generate provider-specific submission copies from core repo skills."""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SKILLS_ROOT = REPO_ROOT / ".agents" / "skills"
+SUBMISSIONS_ROOT = REPO_ROOT / ".agents" / "submissions"
+LICENSE_SOURCE = REPO_ROOT / "LICENSE"
+
+SKILL_NAMES = [
+    "incident-to-regression",
+    "ci-failure-triage",
+    "evidence-receipt-generation",
+]
+
+
+def parse_skill(path: Path) -> tuple[dict[str, str], str]:
+    text = path.read_text(encoding="utf-8")
+    lines = text.splitlines()
+    if len(lines) < 3 or lines[0].strip() != "---":
+        raise ValueError(f"{path}: missing frontmatter start")
+    end = None
+    for index in range(1, len(lines)):
+        if lines[index].strip() == "---":
+            end = index
+            break
+    if end is None:
+        raise ValueError(f"{path}: missing frontmatter end")
+
+    frontmatter: dict[str, str] = {}
+    for line in lines[1:end]:
+        if not line.strip():
+            continue
+        if ":" not in line:
+            raise ValueError(f"{path}: invalid frontmatter line '{line}'")
+        key, value = line.split(":", 1)
+        frontmatter[key.strip()] = value.strip()
+
+    body = "\n".join(lines[end + 1 :]).strip() + "\n"
+    return frontmatter, body
+
+
+def render_frontmatter(frontmatter: dict[str, str], provider: str) -> str:
+    name = frontmatter["name"]
+    description = frontmatter["description"]
+    output = ["---", f"name: {name}", f"description: {description}"]
+    if provider == "anthropic":
+        output.append("license: Apache-2.0")
+    output.append("---")
+    return "\n".join(output) + "\n\n"
+
+
+def provider_note(name: str, provider: str) -> str:
+    if provider == "openai":
+        return (
+            "## Provider Notes (OpenAI Codex)\n\n"
+            f"- Invoke explicitly as `${name}` when asking Codex to run this workflow.\n"
+            "- Keep outputs grounded in command results and `--json` payload fields.\n"
+        )
+
+    return (
+        "## Provider Notes (Anthropic Claude)\n\n"
+        f"- Ask Claude to use the `{name}` skill by name when this workflow applies.\n"
+        "- Keep outputs grounded in command results and `--json` payload fields.\n"
+    )
+
+
+def emit_variant(name: str, provider: str) -> None:
+    skill_path = SKILLS_ROOT / name / "SKILL.md"
+    frontmatter, body = parse_skill(skill_path)
+
+    out_dir = SUBMISSIONS_ROOT / provider / name
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    rendered = render_frontmatter(frontmatter, provider)
+    rendered += body.rstrip() + "\n\n"
+    rendered += provider_note(name, provider)
+
+    (out_dir / "SKILL.md").write_text(rendered, encoding="utf-8")
+    shutil.copy2(LICENSE_SOURCE, out_dir / "LICENSE.txt")
+
+
+def main() -> int:
+    for provider in ("openai", "anthropic"):
+        provider_dir = SUBMISSIONS_ROOT / provider
+        provider_dir.mkdir(parents=True, exist_ok=True)
+        for name in SKILL_NAMES:
+            emit_variant(name, provider)
+
+    print(
+        f"generated {len(SKILL_NAMES)} skill variants for openai and anthropic under {SUBMISSIONS_ROOT}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_skill_supply_chain.sh
+++ b/scripts/test_skill_supply_chain.sh
@@ -69,7 +69,13 @@ if ! cmp -s "${tmp_root}/manifest_before.txt" "${tmp_root}/manifest_after.txt"; 
 fi
 
 for provider in codex claude; do
-  for skill in gait-capture-runpack gait-incident-to-regression gait-policy-test-rollout; do
+  for skill in \
+    gait-capture-runpack \
+    gait-incident-to-regression \
+    gait-policy-test-rollout \
+    incident-to-regression \
+    ci-failure-triage \
+    evidence-receipt-generation; do
     if [[ ! -f "${tmp_root}/${provider}/skills/${skill}/SKILL.md" ]]; then
       echo "missing installed skill file for provider=${provider} skill=${skill}" >&2
       exit 1


### PR DESCRIPTION
## Summary
Fixes the failing `contracts (windows-latest)` job from run `22039319396`.

Root cause:
- `scripts/test_pack_producer_kit.sh` used `shasum -a 256`, which is not available on GitHub Windows runners.

Change:
- Add a portable `sha256_file()` helper that uses:
  1. `sha256sum` if available
  2. `shasum` if available
  3. Python `hashlib.sha256` fallback otherwise

This keeps determinism checks identical while removing platform-specific tool assumptions.

## Validation
- `bash scripts/test_pack_producer_kit.sh`
- `bash scripts/test_contracts.sh`
