### PR TITLE
skills: add Gait context and align workflow inputs in skill docs

### DIFF
--- a/.agents/skills/ci-failure-triage/SKILL.md
+++ b/.agents/skills/ci-failure-triage/SKILL.md
@@ -7,6 +7,19 @@ disable-model-invocation: true
 
 Use this skill to isolate failing CI causes with deterministic artifact checks.
 
+## Gait Context
+
+Gait is an offline-first runtime for AI agents that enforces tool-boundary policy, emits signed and verifiable evidence artifacts, and supports deterministic regressions.
+
+Use this skill when:
+- incident triage requires artifact-first root-cause isolation
+- CI gate failures need deterministic reruns tied to a failing artifact
+- evidence outputs must be generated from Gait artifacts
+
+Do not use this skill when:
+- Gait CLI is unavailable in the environment
+- no Gait run/pack artifact or run identifier is available as input
+
 ## Required Inputs
 
 - `failure_target`: failing run id, runpack path, or pack path.
@@ -17,13 +30,16 @@ Use this skill to isolate failing CI causes with deterministic artifact checks.
 
 1. Verify the failing artifact first:
    - `gait verify <failure_target> --json`
-2. If failure came from regress grading, rerun deterministically:
+2. Enter an isolated triage workspace:
+   - `mkdir -p <workdir> && cd <workdir>`
+3. If failure came from regress grading, bind reruns to the requested target:
+   - `gait regress init --from <failure_target> --json`
    - `gait regress run --json`
-3. If baseline evidence exists, compute deterministic diff:
+4. If baseline evidence exists, compute deterministic diff:
    - `gait pack diff <baseline_target> <failure_target> --json`
-4. If environment health is uncertain, run diagnostics:
+5. If environment health is uncertain, run diagnostics:
    - `gait doctor --json`
-5. Return triage summary:
+6. Return triage summary:
    - integrity status
    - failing stage and reason codes
    - diff highlights (if provided)
@@ -40,12 +56,15 @@ Use this skill to isolate failing CI causes with deterministic artifact checks.
 
 ```bash
 gait verify ./artifacts/runpack_failed.zip --json
-gait doctor --json
+mkdir -p ./triage && cd ./triage
+gait regress init --from ../artifacts/runpack_failed.zip --json
 gait regress run --json
+gait doctor --json
 ```
 
 Expected result:
 - verify output reports integrity status for the target artifact
+- regress init output references the requested `failure_target`
 - doctor output reports actionable diagnostics
 - regress output reports stable pass/fail status and failures
 

--- a/.agents/skills/ci-failure-triage/SKILL.md
+++ b/.agents/skills/ci-failure-triage/SKILL.md
@@ -30,16 +30,22 @@ Do not use this skill when:
 
 1. Verify the failing artifact first:
    - `gait verify <failure_target> --json`
-2. Enter an isolated triage workspace:
+2. Resolve path-based targets before changing directories:
+   - keep identifiers unchanged (for example run ids)
+   - if `<failure_target>` is a relative file path, normalize to absolute path
+   - if `<baseline_target>` is provided as a relative file path, normalize to absolute path
+   - `failure_target_ref="$(python3 -c 'import os,sys; v=sys.argv[1]; print(os.path.abspath(v) if os.path.exists(v) else v)' <failure_target>)"`
+   - `baseline_target_ref="$(python3 -c 'import os,sys; v=sys.argv[1]; print(os.path.abspath(v) if os.path.exists(v) else v)' <baseline_target>)"` (only when provided)
+3. Enter an isolated triage workspace:
    - `mkdir -p <workdir> && cd <workdir>`
-3. If failure came from regress grading, bind reruns to the requested target:
-   - `gait regress init --from <failure_target> --json`
+4. If failure came from regress grading, bind reruns to the requested target:
+   - `gait regress init --from <failure_target_ref> --json`
    - `gait regress run --json`
-4. If baseline evidence exists, compute deterministic diff:
-   - `gait pack diff <baseline_target> <failure_target> --json`
-5. If environment health is uncertain, run diagnostics:
+5. If baseline evidence exists, compute deterministic diff:
+   - `gait pack diff <baseline_target_ref> <failure_target_ref> --json`
+6. If environment health is uncertain, run diagnostics:
    - `gait doctor --json`
-6. Return triage summary:
+7. Return triage summary:
    - integrity status
    - failing stage and reason codes
    - diff highlights (if provided)
@@ -55,9 +61,11 @@ Do not use this skill when:
 ## Usage Example
 
 ```bash
-gait verify ./artifacts/runpack_failed.zip --json
+gait demo --json
+gait verify run_demo --json
+failure_target_ref="$(python3 -c 'import os,sys; v=sys.argv[1]; print(os.path.abspath(v) if os.path.exists(v) else v)' run_demo)"
 mkdir -p ./triage && cd ./triage
-gait regress init --from ../artifacts/runpack_failed.zip --json
+gait regress init --from "${failure_target_ref}" --json
 gait regress run --json
 gait doctor --json
 ```
@@ -71,13 +79,15 @@ Expected result:
 ## Validation Example
 
 ```bash
-gait verify ./artifacts/runpack_failed.zip --json > ./artifacts/verify.json
+gait demo --json
+mkdir -p ./artifacts
+gait verify run_demo --json > ./artifacts/verify.json
 python3 - <<'PY'
 import json
 from pathlib import Path
 p = json.loads(Path('./artifacts/verify.json').read_text(encoding='utf-8'))
 assert 'ok' in p
-assert 'manifest_digest' in p
+assert 'run_id' in p or 'bundle' in p
 print('validated verify payload keys present')
 PY
 ```

--- a/.agents/skills/evidence-receipt-generation/SKILL.md
+++ b/.agents/skills/evidence-receipt-generation/SKILL.md
@@ -50,8 +50,10 @@ Do not use this skill when:
 ## Usage Example
 
 ```bash
-gait verify ./artifacts/runpack.zip --json
-gait run receipt --from ./artifacts/runpack.zip --json > ./artifacts/receipt.json
+gait demo --json
+mkdir -p ./artifacts
+gait verify run_demo --json
+gait run receipt --from run_demo --json > ./artifacts/receipt.json
 ```
 
 Expected result:
@@ -61,7 +63,9 @@ Expected result:
 ## Validation Example
 
 ```bash
-gait run receipt --from ./artifacts/runpack.zip --json > ./artifacts/receipt.json
+gait demo --json
+mkdir -p ./artifacts
+gait run receipt --from run_demo --json > ./artifacts/receipt.json
 python3 - <<'PY'
 import json
 from pathlib import Path

--- a/.agents/skills/evidence-receipt-generation/SKILL.md
+++ b/.agents/skills/evidence-receipt-generation/SKILL.md
@@ -7,6 +7,19 @@ disable-model-invocation: true
 
 Use this skill to generate integrity-backed receipts that are portable across CI, tickets, and audit handoff.
 
+## Gait Context
+
+Gait is an offline-first runtime for AI agents that enforces tool-boundary policy, emits signed and verifiable evidence artifacts, and supports deterministic regressions.
+
+Use this skill when:
+- incident triage needs portable receipt handoff proof
+- CI gate failures require receipt/evidence attachment
+- evidence outputs must be generated from Gait artifacts
+
+Do not use this skill when:
+- Gait CLI is unavailable in the environment
+- no Gait run/pack artifact or run identifier is available as input
+
 ## Required Inputs
 
 - `source`: run id, runpack path, or pack path.
@@ -17,8 +30,9 @@ Use this skill to generate integrity-backed receipts that are portable across CI
 1. Verify integrity before receipt generation:
    - `gait verify <source> --json`
 2. Generate receipt from source artifact:
-   - `gait run receipt --from <source> --json`
-3. Parse receipt fields for handoff:
+   - when `out_path` is provided: `gait run receipt --from <source> --json > <out_path>`
+   - when `out_path` is omitted: `gait run receipt --from <source> --json`
+3. Parse receipt fields for handoff from `out_path` (if set) or stdout:
    - `ok`, `run_id`, `manifest_digest`, `ticket_footer`, `bundle`
 4. Return concise evidence block containing:
    - source identifier
@@ -37,12 +51,12 @@ Use this skill to generate integrity-backed receipts that are portable across CI
 
 ```bash
 gait verify ./artifacts/runpack.zip --json
-gait run receipt --from ./artifacts/runpack.zip --json
+gait run receipt --from ./artifacts/runpack.zip --json > ./artifacts/receipt.json
 ```
 
 Expected result:
 - verify returns `ok=true` for intact artifacts
-- receipt returns a non-empty `ticket_footer` suitable for issue or PR evidence
+- receipt file contains a non-empty `ticket_footer` suitable for issue or PR evidence
 
 ## Validation Example
 

--- a/.agents/skills/gait-capture-runpack/SKILL.md
+++ b/.agents/skills/gait-capture-runpack/SKILL.md
@@ -7,6 +7,19 @@ disable-model-invocation: true
 
 Execute this workflow to record an artifact safely and deterministically.
 
+## Gait Context
+
+Gait is an offline-first runtime for AI agents that enforces tool-boundary policy, emits signed and verifiable evidence artifacts, and supports deterministic regressions.
+
+Use this skill when:
+- incident triage needs captured run artifacts for reproduction
+- CI gate failures need verifiable artifact identity and integrity
+- receipt/evidence generation depends on runpack metadata and digests
+
+Do not use this skill when:
+- Gait CLI is unavailable in the environment
+- no Gait run input or artifact source is available
+
 ## Workflow
 
 1. Validate required input path: `<run_record.json>`.

--- a/.agents/skills/gait-incident-to-regression/SKILL.md
+++ b/.agents/skills/gait-incident-to-regression/SKILL.md
@@ -7,6 +7,19 @@ disable-model-invocation: true
 
 Execute this workflow to transform an observed run into repeatable CI checks.
 
+## Gait Context
+
+Gait is an offline-first runtime for AI agents that enforces tool-boundary policy, emits signed and verifiable evidence artifacts, and supports deterministic regressions.
+
+Use this skill when:
+- incident triage needs repeatable fixture creation
+- CI gate failures require deterministic grader reruns
+- receipt/evidence generation depends on regression outputs
+
+Do not use this skill when:
+- Gait CLI is unavailable in the environment
+- no Gait run/pack artifact or run identifier is available as input
+
 ## Workflow
 
 1. Resolve source run artifact:

--- a/.agents/skills/gait-policy-test-rollout/SKILL.md
+++ b/.agents/skills/gait-policy-test-rollout/SKILL.md
@@ -7,6 +7,19 @@ disable-model-invocation: true
 
 Execute this workflow to validate policy behavior before enforcement.
 
+## Gait Context
+
+Gait is an offline-first runtime for AI agents that enforces tool-boundary policy, emits signed and verifiable evidence artifacts, and supports deterministic regressions.
+
+Use this skill when:
+- incident triage involves policy decision verification
+- CI gate failures require deterministic policy verdict checks
+- receipt/evidence generation needs policy verdict traceability
+
+Do not use this skill when:
+- Gait CLI is unavailable in the environment
+- no policy fixture inputs or Gait artifacts are available
+
 ## Workflow
 
 1. Require both files:

--- a/.agents/skills/incident-to-regression/SKILL.md
+++ b/.agents/skills/incident-to-regression/SKILL.md
@@ -7,6 +7,19 @@ disable-model-invocation: true
 
 Use this skill to transform an observed incident into deterministic regression checks.
 
+## Gait Context
+
+Gait is an offline-first runtime for AI agents that enforces tool-boundary policy, emits signed and verifiable evidence artifacts, and supports deterministic regressions.
+
+Use this skill when:
+- incident triage needs repeatable regression fixtures
+- CI gate failures need deterministic reproduction
+- evidence outputs must be generated from Gait artifacts
+
+Do not use this skill when:
+- Gait CLI is unavailable in the environment
+- no Gait run/pack artifact or run identifier is available as input
+
 ## Required Inputs
 
 - `run_source`: run id, runpack path, or equivalent source accepted by `gait regress init`.
@@ -14,15 +27,17 @@ Use this skill to transform an observed incident into deterministic regression c
 
 ## Workflow
 
-1. Initialize deterministic fixture from the incident source:
+1. Enter the declared working directory before generating artifacts:
+   - `mkdir -p <workdir> && cd <workdir>`
+2. Initialize deterministic fixture from the incident source:
    - `gait regress init --from <run_source> --json`
-2. Parse fields from init output and record them:
+3. Parse fields from init output and record them:
    - `ok`, `run_id`, `fixture_name`, `fixture_dir`, `config_path`, `next_commands`
-3. Execute regression graders:
+4. Execute regression graders:
    - `gait regress run --json`
-4. If CI evidence is needed, rerun with JUnit output:
+5. If CI evidence is needed, rerun with JUnit output:
    - `gait regress run --json --junit <junit_path>`
-5. Return a concise summary with:
+6. Return a concise summary with:
    - source identifier
    - fixture directory and config path
    - status and failed grader count
@@ -38,6 +53,7 @@ Use this skill to transform an observed incident into deterministic regression c
 ## Usage Example
 
 ```bash
+mkdir -p ./regress-workdir && cd ./regress-workdir
 gait regress init --from run_demo --json
 gait regress run --json --junit ./artifacts/junit.xml
 ```
@@ -50,6 +66,7 @@ Expected result:
 ## Validation Example
 
 ```bash
+mkdir -p ./regress-workdir && cd ./regress-workdir
 gait regress run --json > ./artifacts/regress_result.json
 python3 - <<'PY'
 import json

--- a/.agents/skills/incident-to-regression/SKILL.md
+++ b/.agents/skills/incident-to-regression/SKILL.md
@@ -27,17 +27,21 @@ Do not use this skill when:
 
 ## Workflow
 
-1. Enter the declared working directory before generating artifacts:
+1. Resolve `run_source` before changing directories:
+   - keep identifiers unchanged (for example run ids)
+   - if `run_source` is a relative file path, normalize to absolute path
+   - `run_source_ref="$(python3 -c 'import os,sys; v=sys.argv[1]; print(os.path.abspath(v) if os.path.exists(v) else v)' <run_source>)"`
+2. Enter the declared working directory before generating artifacts:
    - `mkdir -p <workdir> && cd <workdir>`
-2. Initialize deterministic fixture from the incident source:
-   - `gait regress init --from <run_source> --json`
-3. Parse fields from init output and record them:
+3. Initialize deterministic fixture from the incident source:
+   - `gait regress init --from <run_source_ref> --json`
+4. Parse fields from init output and record them:
    - `ok`, `run_id`, `fixture_name`, `fixture_dir`, `config_path`, `next_commands`
-4. Execute regression graders:
+5. Execute regression graders:
    - `gait regress run --json`
-5. If CI evidence is needed, rerun with JUnit output:
+6. If CI evidence is needed, rerun with JUnit output:
    - `gait regress run --json --junit <junit_path>`
-6. Return a concise summary with:
+7. Return a concise summary with:
    - source identifier
    - fixture directory and config path
    - status and failed grader count
@@ -53,8 +57,11 @@ Do not use this skill when:
 ## Usage Example
 
 ```bash
+run_source_ref="$(python3 -c 'import os,sys; v=sys.argv[1]; print(os.path.abspath(v) if os.path.exists(v) else v)' run_demo)"
 mkdir -p ./regress-workdir && cd ./regress-workdir
-gait regress init --from run_demo --json
+gait demo --json
+gait regress init --from "${run_source_ref}" --json
+mkdir -p ./artifacts
 gait regress run --json --junit ./artifacts/junit.xml
 ```
 
@@ -67,6 +74,9 @@ Expected result:
 
 ```bash
 mkdir -p ./regress-workdir && cd ./regress-workdir
+gait demo --json
+gait regress init --from run_demo --json
+mkdir -p ./artifacts
 gait regress run --json > ./artifacts/regress_result.json
 python3 - <<'PY'
 import json

--- a/.agents/submissions/anthropic/ci-failure-triage/SKILL.md
+++ b/.agents/submissions/anthropic/ci-failure-triage/SKILL.md
@@ -8,6 +8,19 @@ license: Apache-2.0
 
 Use this skill to isolate failing CI causes with deterministic artifact checks.
 
+## Gait Context
+
+Gait is an offline-first runtime for AI agents that enforces tool-boundary policy, emits signed and verifiable evidence artifacts, and supports deterministic regressions.
+
+Use this skill when:
+- incident triage requires artifact-first root-cause isolation
+- CI gate failures need deterministic reruns tied to a failing artifact
+- evidence outputs must be generated from Gait artifacts
+
+Do not use this skill when:
+- Gait CLI is unavailable in the environment
+- no Gait run/pack artifact or run identifier is available as input
+
 ## Required Inputs
 
 - `failure_target`: failing run id, runpack path, or pack path.
@@ -18,13 +31,16 @@ Use this skill to isolate failing CI causes with deterministic artifact checks.
 
 1. Verify the failing artifact first:
    - `gait verify <failure_target> --json`
-2. If failure came from regress grading, rerun deterministically:
+2. Enter an isolated triage workspace:
+   - `mkdir -p <workdir> && cd <workdir>`
+3. If failure came from regress grading, bind reruns to the requested target:
+   - `gait regress init --from <failure_target> --json`
    - `gait regress run --json`
-3. If baseline evidence exists, compute deterministic diff:
+4. If baseline evidence exists, compute deterministic diff:
    - `gait pack diff <baseline_target> <failure_target> --json`
-4. If environment health is uncertain, run diagnostics:
+5. If environment health is uncertain, run diagnostics:
    - `gait doctor --json`
-5. Return triage summary:
+6. Return triage summary:
    - integrity status
    - failing stage and reason codes
    - diff highlights (if provided)
@@ -41,12 +57,15 @@ Use this skill to isolate failing CI causes with deterministic artifact checks.
 
 ```bash
 gait verify ./artifacts/runpack_failed.zip --json
-gait doctor --json
+mkdir -p ./triage && cd ./triage
+gait regress init --from ../artifacts/runpack_failed.zip --json
 gait regress run --json
+gait doctor --json
 ```
 
 Expected result:
 - verify output reports integrity status for the target artifact
+- regress init output references the requested `failure_target`
 - doctor output reports actionable diagnostics
 - regress output reports stable pass/fail status and failures
 

--- a/.agents/submissions/anthropic/evidence-receipt-generation/SKILL.md
+++ b/.agents/submissions/anthropic/evidence-receipt-generation/SKILL.md
@@ -51,8 +51,10 @@ Do not use this skill when:
 ## Usage Example
 
 ```bash
-gait verify ./artifacts/runpack.zip --json
-gait run receipt --from ./artifacts/runpack.zip --json > ./artifacts/receipt.json
+gait demo --json
+mkdir -p ./artifacts
+gait verify run_demo --json
+gait run receipt --from run_demo --json > ./artifacts/receipt.json
 ```
 
 Expected result:
@@ -62,7 +64,9 @@ Expected result:
 ## Validation Example
 
 ```bash
-gait run receipt --from ./artifacts/runpack.zip --json > ./artifacts/receipt.json
+gait demo --json
+mkdir -p ./artifacts
+gait run receipt --from run_demo --json > ./artifacts/receipt.json
 python3 - <<'PY'
 import json
 from pathlib import Path

--- a/.agents/submissions/anthropic/evidence-receipt-generation/SKILL.md
+++ b/.agents/submissions/anthropic/evidence-receipt-generation/SKILL.md
@@ -8,6 +8,19 @@ license: Apache-2.0
 
 Use this skill to generate integrity-backed receipts that are portable across CI, tickets, and audit handoff.
 
+## Gait Context
+
+Gait is an offline-first runtime for AI agents that enforces tool-boundary policy, emits signed and verifiable evidence artifacts, and supports deterministic regressions.
+
+Use this skill when:
+- incident triage needs portable receipt handoff proof
+- CI gate failures require receipt/evidence attachment
+- evidence outputs must be generated from Gait artifacts
+
+Do not use this skill when:
+- Gait CLI is unavailable in the environment
+- no Gait run/pack artifact or run identifier is available as input
+
 ## Required Inputs
 
 - `source`: run id, runpack path, or pack path.
@@ -18,8 +31,9 @@ Use this skill to generate integrity-backed receipts that are portable across CI
 1. Verify integrity before receipt generation:
    - `gait verify <source> --json`
 2. Generate receipt from source artifact:
-   - `gait run receipt --from <source> --json`
-3. Parse receipt fields for handoff:
+   - when `out_path` is provided: `gait run receipt --from <source> --json > <out_path>`
+   - when `out_path` is omitted: `gait run receipt --from <source> --json`
+3. Parse receipt fields for handoff from `out_path` (if set) or stdout:
    - `ok`, `run_id`, `manifest_digest`, `ticket_footer`, `bundle`
 4. Return concise evidence block containing:
    - source identifier
@@ -38,12 +52,12 @@ Use this skill to generate integrity-backed receipts that are portable across CI
 
 ```bash
 gait verify ./artifacts/runpack.zip --json
-gait run receipt --from ./artifacts/runpack.zip --json
+gait run receipt --from ./artifacts/runpack.zip --json > ./artifacts/receipt.json
 ```
 
 Expected result:
 - verify returns `ok=true` for intact artifacts
-- receipt returns a non-empty `ticket_footer` suitable for issue or PR evidence
+- receipt file contains a non-empty `ticket_footer` suitable for issue or PR evidence
 
 ## Validation Example
 

--- a/.agents/submissions/anthropic/incident-to-regression/SKILL.md
+++ b/.agents/submissions/anthropic/incident-to-regression/SKILL.md
@@ -8,6 +8,19 @@ license: Apache-2.0
 
 Use this skill to transform an observed incident into deterministic regression checks.
 
+## Gait Context
+
+Gait is an offline-first runtime for AI agents that enforces tool-boundary policy, emits signed and verifiable evidence artifacts, and supports deterministic regressions.
+
+Use this skill when:
+- incident triage needs repeatable regression fixtures
+- CI gate failures need deterministic reproduction
+- evidence outputs must be generated from Gait artifacts
+
+Do not use this skill when:
+- Gait CLI is unavailable in the environment
+- no Gait run/pack artifact or run identifier is available as input
+
 ## Required Inputs
 
 - `run_source`: run id, runpack path, or equivalent source accepted by `gait regress init`.
@@ -15,15 +28,17 @@ Use this skill to transform an observed incident into deterministic regression c
 
 ## Workflow
 
-1. Initialize deterministic fixture from the incident source:
+1. Enter the declared working directory before generating artifacts:
+   - `mkdir -p <workdir> && cd <workdir>`
+2. Initialize deterministic fixture from the incident source:
    - `gait regress init --from <run_source> --json`
-2. Parse fields from init output and record them:
+3. Parse fields from init output and record them:
    - `ok`, `run_id`, `fixture_name`, `fixture_dir`, `config_path`, `next_commands`
-3. Execute regression graders:
+4. Execute regression graders:
    - `gait regress run --json`
-4. If CI evidence is needed, rerun with JUnit output:
+5. If CI evidence is needed, rerun with JUnit output:
    - `gait regress run --json --junit <junit_path>`
-5. Return a concise summary with:
+6. Return a concise summary with:
    - source identifier
    - fixture directory and config path
    - status and failed grader count
@@ -39,6 +54,7 @@ Use this skill to transform an observed incident into deterministic regression c
 ## Usage Example
 
 ```bash
+mkdir -p ./regress-workdir && cd ./regress-workdir
 gait regress init --from run_demo --json
 gait regress run --json --junit ./artifacts/junit.xml
 ```
@@ -51,6 +67,7 @@ Expected result:
 ## Validation Example
 
 ```bash
+mkdir -p ./regress-workdir && cd ./regress-workdir
 gait regress run --json > ./artifacts/regress_result.json
 python3 - <<'PY'
 import json

--- a/.agents/submissions/anthropic/incident-to-regression/SKILL.md
+++ b/.agents/submissions/anthropic/incident-to-regression/SKILL.md
@@ -28,17 +28,21 @@ Do not use this skill when:
 
 ## Workflow
 
-1. Enter the declared working directory before generating artifacts:
+1. Resolve `run_source` before changing directories:
+   - keep identifiers unchanged (for example run ids)
+   - if `run_source` is a relative file path, normalize to absolute path
+   - `run_source_ref="$(python3 -c 'import os,sys; v=sys.argv[1]; print(os.path.abspath(v) if os.path.exists(v) else v)' <run_source>)"`
+2. Enter the declared working directory before generating artifacts:
    - `mkdir -p <workdir> && cd <workdir>`
-2. Initialize deterministic fixture from the incident source:
-   - `gait regress init --from <run_source> --json`
-3. Parse fields from init output and record them:
+3. Initialize deterministic fixture from the incident source:
+   - `gait regress init --from <run_source_ref> --json`
+4. Parse fields from init output and record them:
    - `ok`, `run_id`, `fixture_name`, `fixture_dir`, `config_path`, `next_commands`
-4. Execute regression graders:
+5. Execute regression graders:
    - `gait regress run --json`
-5. If CI evidence is needed, rerun with JUnit output:
+6. If CI evidence is needed, rerun with JUnit output:
    - `gait regress run --json --junit <junit_path>`
-6. Return a concise summary with:
+7. Return a concise summary with:
    - source identifier
    - fixture directory and config path
    - status and failed grader count
@@ -54,8 +58,11 @@ Do not use this skill when:
 ## Usage Example
 
 ```bash
+run_source_ref="$(python3 -c 'import os,sys; v=sys.argv[1]; print(os.path.abspath(v) if os.path.exists(v) else v)' run_demo)"
 mkdir -p ./regress-workdir && cd ./regress-workdir
-gait regress init --from run_demo --json
+gait demo --json
+gait regress init --from "${run_source_ref}" --json
+mkdir -p ./artifacts
 gait regress run --json --junit ./artifacts/junit.xml
 ```
 
@@ -68,6 +75,9 @@ Expected result:
 
 ```bash
 mkdir -p ./regress-workdir && cd ./regress-workdir
+gait demo --json
+gait regress init --from run_demo --json
+mkdir -p ./artifacts
 gait regress run --json > ./artifacts/regress_result.json
 python3 - <<'PY'
 import json

--- a/.agents/submissions/openai/ci-failure-triage/SKILL.md
+++ b/.agents/submissions/openai/ci-failure-triage/SKILL.md
@@ -30,16 +30,22 @@ Do not use this skill when:
 
 1. Verify the failing artifact first:
    - `gait verify <failure_target> --json`
-2. Enter an isolated triage workspace:
+2. Resolve path-based targets before changing directories:
+   - keep identifiers unchanged (for example run ids)
+   - if `<failure_target>` is a relative file path, normalize to absolute path
+   - if `<baseline_target>` is provided as a relative file path, normalize to absolute path
+   - `failure_target_ref="$(python3 -c 'import os,sys; v=sys.argv[1]; print(os.path.abspath(v) if os.path.exists(v) else v)' <failure_target>)"`
+   - `baseline_target_ref="$(python3 -c 'import os,sys; v=sys.argv[1]; print(os.path.abspath(v) if os.path.exists(v) else v)' <baseline_target>)"` (only when provided)
+3. Enter an isolated triage workspace:
    - `mkdir -p <workdir> && cd <workdir>`
-3. If failure came from regress grading, bind reruns to the requested target:
-   - `gait regress init --from <failure_target> --json`
+4. If failure came from regress grading, bind reruns to the requested target:
+   - `gait regress init --from <failure_target_ref> --json`
    - `gait regress run --json`
-4. If baseline evidence exists, compute deterministic diff:
-   - `gait pack diff <baseline_target> <failure_target> --json`
-5. If environment health is uncertain, run diagnostics:
+5. If baseline evidence exists, compute deterministic diff:
+   - `gait pack diff <baseline_target_ref> <failure_target_ref> --json`
+6. If environment health is uncertain, run diagnostics:
    - `gait doctor --json`
-6. Return triage summary:
+7. Return triage summary:
    - integrity status
    - failing stage and reason codes
    - diff highlights (if provided)
@@ -55,9 +61,11 @@ Do not use this skill when:
 ## Usage Example
 
 ```bash
-gait verify ./artifacts/runpack_failed.zip --json
+gait demo --json
+gait verify run_demo --json
+failure_target_ref="$(python3 -c 'import os,sys; v=sys.argv[1]; print(os.path.abspath(v) if os.path.exists(v) else v)' run_demo)"
 mkdir -p ./triage && cd ./triage
-gait regress init --from ../artifacts/runpack_failed.zip --json
+gait regress init --from "${failure_target_ref}" --json
 gait regress run --json
 gait doctor --json
 ```
@@ -71,13 +79,15 @@ Expected result:
 ## Validation Example
 
 ```bash
-gait verify ./artifacts/runpack_failed.zip --json > ./artifacts/verify.json
+gait demo --json
+mkdir -p ./artifacts
+gait verify run_demo --json > ./artifacts/verify.json
 python3 - <<'PY'
 import json
 from pathlib import Path
 p = json.loads(Path('./artifacts/verify.json').read_text(encoding='utf-8'))
 assert 'ok' in p
-assert 'manifest_digest' in p
+assert 'run_id' in p or 'bundle' in p
 print('validated verify payload keys present')
 PY
 ```

--- a/.agents/submissions/openai/ci-failure-triage/SKILL.md
+++ b/.agents/submissions/openai/ci-failure-triage/SKILL.md
@@ -7,6 +7,19 @@ description: Triage CI failures using artifact-first checks. Use when users need
 
 Use this skill to isolate failing CI causes with deterministic artifact checks.
 
+## Gait Context
+
+Gait is an offline-first runtime for AI agents that enforces tool-boundary policy, emits signed and verifiable evidence artifacts, and supports deterministic regressions.
+
+Use this skill when:
+- incident triage requires artifact-first root-cause isolation
+- CI gate failures need deterministic reruns tied to a failing artifact
+- evidence outputs must be generated from Gait artifacts
+
+Do not use this skill when:
+- Gait CLI is unavailable in the environment
+- no Gait run/pack artifact or run identifier is available as input
+
 ## Required Inputs
 
 - `failure_target`: failing run id, runpack path, or pack path.
@@ -17,13 +30,16 @@ Use this skill to isolate failing CI causes with deterministic artifact checks.
 
 1. Verify the failing artifact first:
    - `gait verify <failure_target> --json`
-2. If failure came from regress grading, rerun deterministically:
+2. Enter an isolated triage workspace:
+   - `mkdir -p <workdir> && cd <workdir>`
+3. If failure came from regress grading, bind reruns to the requested target:
+   - `gait regress init --from <failure_target> --json`
    - `gait regress run --json`
-3. If baseline evidence exists, compute deterministic diff:
+4. If baseline evidence exists, compute deterministic diff:
    - `gait pack diff <baseline_target> <failure_target> --json`
-4. If environment health is uncertain, run diagnostics:
+5. If environment health is uncertain, run diagnostics:
    - `gait doctor --json`
-5. Return triage summary:
+6. Return triage summary:
    - integrity status
    - failing stage and reason codes
    - diff highlights (if provided)
@@ -40,12 +56,15 @@ Use this skill to isolate failing CI causes with deterministic artifact checks.
 
 ```bash
 gait verify ./artifacts/runpack_failed.zip --json
-gait doctor --json
+mkdir -p ./triage && cd ./triage
+gait regress init --from ../artifacts/runpack_failed.zip --json
 gait regress run --json
+gait doctor --json
 ```
 
 Expected result:
 - verify output reports integrity status for the target artifact
+- regress init output references the requested `failure_target`
 - doctor output reports actionable diagnostics
 - regress output reports stable pass/fail status and failures
 

--- a/.agents/submissions/openai/evidence-receipt-generation/SKILL.md
+++ b/.agents/submissions/openai/evidence-receipt-generation/SKILL.md
@@ -50,8 +50,10 @@ Do not use this skill when:
 ## Usage Example
 
 ```bash
-gait verify ./artifacts/runpack.zip --json
-gait run receipt --from ./artifacts/runpack.zip --json > ./artifacts/receipt.json
+gait demo --json
+mkdir -p ./artifacts
+gait verify run_demo --json
+gait run receipt --from run_demo --json > ./artifacts/receipt.json
 ```
 
 Expected result:
@@ -61,7 +63,9 @@ Expected result:
 ## Validation Example
 
 ```bash
-gait run receipt --from ./artifacts/runpack.zip --json > ./artifacts/receipt.json
+gait demo --json
+mkdir -p ./artifacts
+gait run receipt --from run_demo --json > ./artifacts/receipt.json
 python3 - <<'PY'
 import json
 from pathlib import Path

--- a/.agents/submissions/openai/evidence-receipt-generation/SKILL.md
+++ b/.agents/submissions/openai/evidence-receipt-generation/SKILL.md
@@ -7,6 +7,19 @@ description: Generate portable evidence receipts from run artifacts. Use when us
 
 Use this skill to generate integrity-backed receipts that are portable across CI, tickets, and audit handoff.
 
+## Gait Context
+
+Gait is an offline-first runtime for AI agents that enforces tool-boundary policy, emits signed and verifiable evidence artifacts, and supports deterministic regressions.
+
+Use this skill when:
+- incident triage needs portable receipt handoff proof
+- CI gate failures require receipt/evidence attachment
+- evidence outputs must be generated from Gait artifacts
+
+Do not use this skill when:
+- Gait CLI is unavailable in the environment
+- no Gait run/pack artifact or run identifier is available as input
+
 ## Required Inputs
 
 - `source`: run id, runpack path, or pack path.
@@ -17,8 +30,9 @@ Use this skill to generate integrity-backed receipts that are portable across CI
 1. Verify integrity before receipt generation:
    - `gait verify <source> --json`
 2. Generate receipt from source artifact:
-   - `gait run receipt --from <source> --json`
-3. Parse receipt fields for handoff:
+   - when `out_path` is provided: `gait run receipt --from <source> --json > <out_path>`
+   - when `out_path` is omitted: `gait run receipt --from <source> --json`
+3. Parse receipt fields for handoff from `out_path` (if set) or stdout:
    - `ok`, `run_id`, `manifest_digest`, `ticket_footer`, `bundle`
 4. Return concise evidence block containing:
    - source identifier
@@ -37,12 +51,12 @@ Use this skill to generate integrity-backed receipts that are portable across CI
 
 ```bash
 gait verify ./artifacts/runpack.zip --json
-gait run receipt --from ./artifacts/runpack.zip --json
+gait run receipt --from ./artifacts/runpack.zip --json > ./artifacts/receipt.json
 ```
 
 Expected result:
 - verify returns `ok=true` for intact artifacts
-- receipt returns a non-empty `ticket_footer` suitable for issue or PR evidence
+- receipt file contains a non-empty `ticket_footer` suitable for issue or PR evidence
 
 ## Validation Example
 

--- a/.agents/submissions/openai/incident-to-regression/SKILL.md
+++ b/.agents/submissions/openai/incident-to-regression/SKILL.md
@@ -27,17 +27,21 @@ Do not use this skill when:
 
 ## Workflow
 
-1. Enter the declared working directory before generating artifacts:
+1. Resolve `run_source` before changing directories:
+   - keep identifiers unchanged (for example run ids)
+   - if `run_source` is a relative file path, normalize to absolute path
+   - `run_source_ref="$(python3 -c 'import os,sys; v=sys.argv[1]; print(os.path.abspath(v) if os.path.exists(v) else v)' <run_source>)"`
+2. Enter the declared working directory before generating artifacts:
    - `mkdir -p <workdir> && cd <workdir>`
-2. Initialize deterministic fixture from the incident source:
-   - `gait regress init --from <run_source> --json`
-3. Parse fields from init output and record them:
+3. Initialize deterministic fixture from the incident source:
+   - `gait regress init --from <run_source_ref> --json`
+4. Parse fields from init output and record them:
    - `ok`, `run_id`, `fixture_name`, `fixture_dir`, `config_path`, `next_commands`
-4. Execute regression graders:
+5. Execute regression graders:
    - `gait regress run --json`
-5. If CI evidence is needed, rerun with JUnit output:
+6. If CI evidence is needed, rerun with JUnit output:
    - `gait regress run --json --junit <junit_path>`
-6. Return a concise summary with:
+7. Return a concise summary with:
    - source identifier
    - fixture directory and config path
    - status and failed grader count
@@ -53,8 +57,11 @@ Do not use this skill when:
 ## Usage Example
 
 ```bash
+run_source_ref="$(python3 -c 'import os,sys; v=sys.argv[1]; print(os.path.abspath(v) if os.path.exists(v) else v)' run_demo)"
 mkdir -p ./regress-workdir && cd ./regress-workdir
-gait regress init --from run_demo --json
+gait demo --json
+gait regress init --from "${run_source_ref}" --json
+mkdir -p ./artifacts
 gait regress run --json --junit ./artifacts/junit.xml
 ```
 
@@ -67,6 +74,9 @@ Expected result:
 
 ```bash
 mkdir -p ./regress-workdir && cd ./regress-workdir
+gait demo --json
+gait regress init --from run_demo --json
+mkdir -p ./artifacts
 gait regress run --json > ./artifacts/regress_result.json
 python3 - <<'PY'
 import json

--- a/.agents/submissions/openai/incident-to-regression/SKILL.md
+++ b/.agents/submissions/openai/incident-to-regression/SKILL.md
@@ -7,6 +7,19 @@ description: Convert incident artifacts into deterministic regression fixtures a
 
 Use this skill to transform an observed incident into deterministic regression checks.
 
+## Gait Context
+
+Gait is an offline-first runtime for AI agents that enforces tool-boundary policy, emits signed and verifiable evidence artifacts, and supports deterministic regressions.
+
+Use this skill when:
+- incident triage needs repeatable regression fixtures
+- CI gate failures need deterministic reproduction
+- evidence outputs must be generated from Gait artifacts
+
+Do not use this skill when:
+- Gait CLI is unavailable in the environment
+- no Gait run/pack artifact or run identifier is available as input
+
 ## Required Inputs
 
 - `run_source`: run id, runpack path, or equivalent source accepted by `gait regress init`.
@@ -14,15 +27,17 @@ Use this skill to transform an observed incident into deterministic regression c
 
 ## Workflow
 
-1. Initialize deterministic fixture from the incident source:
+1. Enter the declared working directory before generating artifacts:
+   - `mkdir -p <workdir> && cd <workdir>`
+2. Initialize deterministic fixture from the incident source:
    - `gait regress init --from <run_source> --json`
-2. Parse fields from init output and record them:
+3. Parse fields from init output and record them:
    - `ok`, `run_id`, `fixture_name`, `fixture_dir`, `config_path`, `next_commands`
-3. Execute regression graders:
+4. Execute regression graders:
    - `gait regress run --json`
-4. If CI evidence is needed, rerun with JUnit output:
+5. If CI evidence is needed, rerun with JUnit output:
    - `gait regress run --json --junit <junit_path>`
-5. Return a concise summary with:
+6. Return a concise summary with:
    - source identifier
    - fixture directory and config path
    - status and failed grader count
@@ -38,6 +53,7 @@ Use this skill to transform an observed incident into deterministic regression c
 ## Usage Example
 
 ```bash
+mkdir -p ./regress-workdir && cd ./regress-workdir
 gait regress init --from run_demo --json
 gait regress run --json --junit ./artifacts/junit.xml
 ```
@@ -50,6 +66,7 @@ Expected result:
 ## Validation Example
 
 ```bash
+mkdir -p ./regress-workdir && cd ./regress-workdir
 gait regress run --json > ./artifacts/regress_result.json
 python3 - <<'PY'
 import json


### PR DESCRIPTION
## Summary

## Testing

- [ ] `make fmt`
- [ ] `make lint`
- [ ] `make test`

## Hardening Review

- [ ] Failure classification impact reviewed (`error_category`, `error_code`, retryability)
- [ ] Exit code contract impact reviewed (no accidental contract break)
- [ ] Deterministic output impact reviewed (`--json`, artifacts, golden fixtures)
- [ ] Security/privacy impact reviewed (secrets redaction, key handling, fail-closed behavior)

## Operational Notes

- [ ] User-facing docs updated where behavior changed (`README.md`, `docs/hardening/*`, runbooks)
- [ ] If agent behavior touched production-like paths, attached runpack evidence (`If your agent touched prod, attach the runpack.`)
- [ ] Included ticket footer evidence line (`gait run receipt --from <run_id|path>`)
- [ ] For new/expanded official integration lane proposals, attached `gait-out/integration_lane_scorecard.json` evidence and decision outcome
