### PR TITLE
Stabilize CI/UAT and add workflow skills

### DIFF
--- a/.agents/skills/app-audit/SKILL.md
+++ b/.agents/skills/app-audit/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: app-audit
+description: Run an evidence-based audit for Gait OSS project across product, architecture, DX, security, and GTM readiness; output a strict go/no-go report with P0-P3 blockers and launch risk by technology, messaging, and expectations.
+disable-model-invocation: true
+---
+
+# Gait OSS Audit
+
+Execute this workflow when asked to perform app review, release readiness, architecture clarity, or public-launch audit for Gait.
+
+## Scope
+
+- Repository: `/Users/davidahmann/Projects/gait`
+- Analyze current code/docs only; do not invent features/markets.
+- Default mode is read-only unless user explicitly asks for fixes.
+
+## Workflow
+
+1. Build whiteboard mental model from onboarding to sustained use.
+2. Map personas, JTBD, and MVP user-story coverage.
+3. List required inputs/config/secrets/dependencies and setup friction.
+4. Evaluate “aha” moments per primary user story.
+5. Run technical validation on affected surfaces (build/lint/tests as needed).
+6. Audit docs for integration clarity:
+   - where Gait sits in runtime path
+   - what is customer code vs Gait vs tool/provider
+   - sync vs async behavior and failure handling
+7. Compare stated product intent vs implemented behavior.
+8. Assess security posture and fail-closed guarantees.
+9. Assess market wedge sharpness for existing personas only.
+10. Produce final go/no-go verdict with minimum blocker set.
+
+## Non-Negotiables
+
+- Evidence-first: every claim must cite command output or file path.
+- Boundary-first: explicitly separate ownership and integration points.
+- Incident-first: lead with failure scenarios and operational impact.
+- No cosmetics as blockers.
+- Distinguish facts vs inference.
+
+## Command Anchors
+
+- `gait doctor --json` to capture environment diagnostics in machine-readable form.
+- `gait pack inspect <artifact.zip> --json` to inspect artifact envelope integrity and payload shape.
+- `gait gate eval --policy <policy.yaml> --input <intent.json> --json` to validate fail-closed policy behavior.
+
+## Severity
+
+- P0: release blocker / high reputational risk
+- P1: major launch risk
+- P2: meaningful gap, non-blocking for project
+- P3: polish
+
+## Output Contract
+
+- Section 1: End-to-end product model
+- Section 2: Persona/story coverage map
+- Section 3: Inputs/config friction table
+- Section 4: Aha analysis
+- Section 5: Technical audit + release readiness
+- Section 6: Business/market fit assessment
+- Section 7: Final verdict (go/no-go) + top 3 launch risks
+
+Each section must include:
+- Findings
+- Evidence references
+- Risk color (Green/Yellow/Red)
+- Blockers (if any)
+- Minimum fix set (only release-critical)

--- a/.agents/skills/app-audit/agents/openai.yaml
+++ b/.agents/skills/app-audit/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "App Audit"
+  short_description: "Audit Gait MVP with evidence and blockers"
+  default_prompt: "Use $app-audit to run a full MVP readiness audit and return a strict blocker-ranked verdict."

--- a/.agents/skills/backlog-plan/SKILL.md
+++ b/.agents/skills/backlog-plan/SKILL.md
@@ -1,0 +1,166 @@
+---
+name: backlog-plan
+description: Transform strategic recommendations in product/ideas.md into an execution-ready Gait backlog plan with epics, stories, tasks, repo paths, commands, acceptance criteria, and explicit test-matrix wiring.
+disable-model-invocation: true
+---
+
+# Ideas to Backlog Plan (Gait)
+
+Execute this workflow when asked to convert strategic feature recommendations into a concrete product backlog plan.
+
+## Scope
+
+- Repository root: `/Users/davidahmann/Projects/gait`
+- Input file: `/Users/davidahmann/Projects/gait/product/ideas.md`
+- Structure references (match level of detail and style):
+- `/Users/davidahmann/Projects/gait/product/PLAN_v1.md`
+- `/Users/davidahmann/Projects/gait/product/PLAN_v1.7.md`
+- `/Users/davidahmann/Projects/gait/product/PLAN_HARDENING.md`
+- `/Users/davidahmann/Projects/gait/product/PLAN_ADOPTION.md`
+- `/Users/davidahmann/Projects/gait/product/PLAN_ENT.md`
+- Output file: `/Users/davidahmann/Projects/gait/product/PLAN_NEXT.md` (unless user specifies a different target)
+- Planning only. Do not implement code or docs outside the target plan file.
+
+## Preconditions
+
+- `ideas.md` must contain strategic recommendations with evidence.
+- Each recommendation should include:
+- recommendation name
+- why-now trigger
+- strategic capability direction
+- moat/benefit rationale
+- source links
+
+If these are missing, stop and output a gap note instead of inventing details.
+
+## Workflow
+
+1. Read `ideas.md` and extract candidate initiatives.
+2. Read reference plans to mirror structure and detail level.
+3. Cluster ideas into coherent epics (avoid one-idea-per-epic fragmentation).
+4. Prioritize using `P0/P1/P2` based on contract risk reduction, moat expansion, adoption leverage, and sequencing dependency.
+5. Produce execution-ready epics and stories.
+6. For every story, include concrete tasks, repo paths, run commands, acceptance criteria, test requirements, and CI matrix wiring.
+7. Build a plan-level test matrix section mapping stories to CI lanes (fast, integration, acceptance, cross-platform).
+8. Ensure each story defines tests based on work type (schema, CLI, gate/policy, determinism, runtime, SDK, docs/examples).
+9. Add explicit boundaries and non-goals to prevent scope drift.
+10. Add delivery sequencing section (phase/week-based minimum-now path).
+11. Add definition of done and release/exit gate criteria.
+12. Write full plan to target file, overwriting prior contents.
+
+## Non-Negotiables
+
+- Preserve Gait core contracts: determinism, offline-first defaults, fail-closed policy posture, schema stability, and exit code stability.
+- Respect architecture boundaries: Go core is authoritative for enforcement/verification logic; Python remains thin adoption layer.
+- Avoid dashboard-first or hosted-only dependencies in backlog core.
+- Do not include implementation code, pseudo-code, or ticket boilerplate.
+- Do not recommend minor polish work as primary backlog items.
+- Every story must include test requirements and explicit matrix wiring.
+- No story is complete without same-change test updates, except explicitly justified docs-only stories.
+
+## Test Requirements by Work Type (Mandatory)
+
+1. Schema or artifact contract work:
+- Add schema validation tests.
+- Add or update golden fixtures.
+- Add compatibility or migration tests.
+
+2. CLI surface work (flags, args, `--json`, exits):
+- Add command tests for help/usage behavior.
+- Add `--json` stability tests.
+- Add exit code contract tests.
+
+3. Gate or policy semantics:
+- Add deterministic allow/block/require_approval fixture tests.
+- Add fail-closed tests for evaluator-missing or undecidable paths.
+- Add reason code stability checks.
+
+4. Determinism, hashing, signing, packaging:
+- Add byte-stability tests for repeated runs with identical input.
+- Add canonicalization and digest stability tests.
+- Add verify/diff determinism tests.
+
+5. Job runtime, state, concurrency, persistence:
+- Add pause/resume/cancel/checkpoint lifecycle tests.
+- Add crash-safe/atomic write tests.
+- Add concurrent execution and contention tests.
+
+6. SDK or adapter boundary work:
+- Add wrapper behavior/error-mapping tests.
+- Add adapter conformance tests against canonical sidecar/gate path.
+- Preserve Go-authoritative decision boundary tests.
+
+7. Docs/examples contract changes:
+- Add command-smoke checks for documented flows.
+- Add docs-versus-CLI parity checks where possible.
+- Update acceptance scripts if docs alter required operator path.
+
+## Test Matrix Wiring Contract (Plan-Level)
+
+Every generated plan must include a section named `Test Matrix Wiring` with:
+
+- `Fast lane`: pre-push or quick CI checks required for each epic.
+- `Core CI lane`: required unit/integration UAT checks in default CI.
+- `Acceptance lane`: deterministic acceptance scripts required before merge or release.
+- `Cross-platform lane`: Linux/macOS/Windows expectations for affected stories.
+- `Risk lane`: extra suites for high-risk stories (policy, determinism, security, portability).
+- `Gating rule`: merge/release block conditions tied to failed required lanes.
+
+## Plan Format Contract
+
+Required top sections:
+
+1. `# PLAN <name>: <theme>`
+2. `Date`, `Source of truth`, `Scope`
+3. `Global Decisions (Locked)`
+4. `Current Baseline (Observed)`
+5. `Exit Criteria`
+6. `Test Matrix Wiring`
+7. `Epic` sections with `Objective` and `Story` breakdowns
+8. `Minimum-Now Sequence` (phased execution)
+9. `Explicit Non-Goals`
+10. `Definition of Done`
+
+Story template (required fields):
+
+- `### Story <ID>: <title>`
+- `Priority:`
+- `Tasks:`
+- `Repo paths:`
+- `Run commands:`
+- `Test requirements:`
+- `Matrix wiring:`
+- `Acceptance criteria:`
+- Optional when needed:
+- `Dependencies:`
+- `Risks:`
+
+## Quality Gate for Output
+
+Before finalizing, verify:
+
+- Every epic maps back to at least one idea from `ideas.md`.
+- Every story is actionable without guesswork.
+- Acceptance criteria are testable and deterministic.
+- Paths are real and repo-relevant.
+- Test requirements match story work type.
+- Matrix wiring is present for every story.
+- Sequence is dependency-aware.
+- Plan stays strategic and execution-relevant (not cosmetic).
+
+## Command Anchors
+
+- Include concrete plan tasks that reference verifiable CLI surfaces, for example:
+  - `gait doctor --json`
+  - `gait gate eval --policy <policy.yaml> --input <intent.json> --json`
+  - `gait pack verify <pack.zip> --json`
+
+## Failure Mode
+
+If `ideas.md` lacks strategic quality or evidence, write only:
+
+- `No backlog plan generated.`
+- `Reason:` concise blocker summary.
+- `Missing inputs:` exact missing fields required to proceed.
+
+Do not fabricate backlog content when source strategy quality is insufficient.

--- a/.agents/skills/backlog-plan/agents/openai.yaml
+++ b/.agents/skills/backlog-plan/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Backlog Plan"
+  short_description: "Turn ideas into test-wired backlog plan"
+  default_prompt: "Use $backlog-plan to convert strategic ideas into an execution-ready plan with matrix-wired tests."

--- a/.agents/skills/code-review/SKILL.md
+++ b/.agents/skills/code-review/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: code-review
+description: Perform Codex-style full-repository review for Gait (not PR-limited), with severity-ranked findings focused on regressions, fail-closed safety, determinism, portability, and docs/CLI contract correctness.
+disable-model-invocation: true
+---
+
+# Full-Repo Code Review (Gait)
+
+Execute this workflow for: "review the codebase", "audit repo health", "run a full code review", or "find risks in Gait."
+
+## Reviewer Personality
+
+- Contract-first: behavior and guarantees over style.
+- Regression-first: look for latent breakage paths.
+- Fail-closed safety bias: block safety/control weakening.
+- Scenario-driven: each finding includes concrete break path and impact.
+- Portability-aware: Linux/macOS/CI/toolchain/path behavior.
+- Signal over noise: findings-first, severity-ranked output.
+
+## Scope
+
+- Repository root: `/Users/davidahmann/Projects/gait`
+- Review entire repo, not only current diffs.
+- Prioritize high-risk surfaces first, then remaining components.
+
+## High-Risk Surfaces (Priority Order)
+
+1. `core/gate`, `core/contextproof`, `core/pack`, `core/runpack`, `core/regress`, `core/jobruntime`
+2. `cmd/gait` CLI behavior, flags, exit codes, JSON outputs
+3. `core/mcp` and adapter boundaries
+4. `sdk/python` wrapper behavior and error mapping
+5. `schemas/v1` and compatibility-sensitive artifacts
+6. `docs`, `README.md`, and `docs-site` command/contract accuracy
+
+## Workflow
+
+1. Build repository map and contract map from code/tests/help text.
+2. Run baseline validation where feasible (lint/build/tests) and record gaps if not run.
+3. Review each subsystem for:
+   - Safety/control bypasses
+   - Determinism or reproducibility breaks
+   - Integrity verification weakening
+   - False-green test/CI paths
+   - Portability/toolchain/path assumptions
+   - Schema/CLI contract drift
+   - Docs/examples that do not match real behavior
+4. Verify findings with concrete evidence (file refs, commands, test output).
+5. Rank findings by severity and confidence.
+6. Report minimum blocker set for safe release posture.
+
+## Severity Model
+
+- P0: release blocker, severe safety/integrity break, high reputational risk.
+- P1: major behavioral regression or control bypass with real user impact.
+- P2: meaningful correctness/portability/docs-contract issue.
+- P3: minor maintainability concern.
+
+## Finding Format
+
+- `Severity`: P0/P1/P2/P3
+- `Title`: short and action-oriented
+- `Location`: file + line
+- `Problem`: what is wrong
+- `Break Scenario`: concrete failure path
+- `Impact`: user/safety/CI/compliance effect
+- `Fix Direction`: minimal safe correction
+
+## Review Rules
+
+- Findings are primary output; summaries stay brief.
+- Do not report style nits unless they cause runtime/contract risk.
+- Do not claim tests/commands were run if they were not.
+- Separate facts from inference.
+- If no findings, explicitly state `No material findings` and list residual risks/testing gaps.
+
+## Command Anchors
+
+- `gait doctor --json` to verify baseline runtime diagnostics and dependency posture.
+- `gait gate eval --policy <policy.yaml> --input <intent.json> --json` to validate policy verdict/exit behavior.
+- `gait pack verify <artifact.zip> --json` to check artifact integrity and signature status.
+
+## Output Contract
+
+1. `Findings` (required, ordered by severity)
+2. `Subsystem Coverage` (Green/Yellow/Red per major area)
+3. `Open Questions / Assumptions` (if any)
+4. `Residual Risk / Testing Gaps`
+5. `Final Judgment`:
+   - technical health today
+   - minimum blockers (if any)
+   - top 3 risk concentrations

--- a/.agents/skills/code-review/agents/openai.yaml
+++ b/.agents/skills/code-review/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Code Review"
+  short_description: "Run full-repo Codex-style risk review"
+  default_prompt: "Use $code-review to review the entire repository and report severity-ranked technical risks."

--- a/.agents/skills/commit-push/SKILL.md
+++ b/.agents/skills/commit-push/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: commit-push
+description: Commit and push all unstaged changes on the current branch, open/update PR, monitor CI to green, merge to main, monitor post-merge CI, and run up to 2 hotfix PR loops for actionable failures.
+disable-model-invocation: true
+---
+
+# PR Ship Loop (Gait)
+
+Execute this workflow for: "commit/push/open PR", "ship this branch", "merge after CI", or "post-merge fix loop."
+
+## Scope
+
+- Repository: `/Users/davidahmann/Projects/gait`
+- Works on current local branch, then merges into `main`.
+- No GitHub issue creation.
+- PR text must use heredoc EOF bodies (no inline `--body` strings).
+
+## Preconditions
+
+- Current branch is not `main`.
+- Local changes exist or an existing PR already exists for the branch.
+- `gh` auth is available for repo operations.
+
+If preconditions fail, stop and report.
+
+## Workflow
+
+1. Preflight and branch safety:
+- `git status --short`
+- `git rev-parse --abbrev-ref HEAD`
+- If on `main`, stop.
+- If unexpected unrelated changes are present, stop and report.
+
+2. Sync branch base:
+- `git fetch origin main`
+- Ensure current branch is rebased/merged with latest `origin/main` using non-interactive commands.
+
+3. Local validation before commit:
+- `make prepush-full`
+- If it fails, stop and report; do not push.
+
+4. Stage and commit all unstaged files on this branch:
+- `git add -A`
+- `git commit -m "<scope>: <summary>"` (skip commit only if no changes after staging)
+
+5. Push branch:
+- `git push -u origin <branch>` (or `git push origin <branch>` if upstream already set)
+
+6. Open or update PR:
+- If PR exists for head branch, reuse it.
+- Otherwise create PR with heredoc body:
+- `gh pr create --title "..." --body-file - <<'EOF'`
+- `<problem / changes / validation>`
+- `EOF`
+- Do not use inline shell-expanded body text.
+
+7. Monitor PR CI until green:
+- Watch required checks/run(s) with timeout `25 minutes`.
+- Use polling/watch (for example every 10s).
+- If green, continue.
+- If failed, classify failure:
+- actionable product/test failure
+- flaky/infra/transient
+- permission/workflow policy failure
+
+8. Merge PR after green:
+- Merge non-interactively (repo-default merge strategy or explicitly chosen one).
+- Record merged PR URL and merge commit SHA.
+
+9. Switch to main and sync:
+- `git checkout main`
+- `git pull --ff-only origin main`
+
+10. Monitor post-merge CI on `main`:
+- Watch the latest `main` CI run with timeout `25 minutes`.
+
+11. Hotfix loop on post-merge red (max 2 loops):
+- Run only for actionable failures.
+- Loop cap: `2`.
+- For each loop:
+
+## Command Anchors
+
+- `gait doctor --json` before ship to capture machine-readable local readiness evidence.
+- `gait pack verify <artifact.zip> --json` when validating artifact integrity in a failing CI path.
+- `gait gate eval --policy <policy.yaml> --input <intent.json> --json` when policy-path checks are implicated.
+- Create branch from updated `main`: `codex/hotfix-<topic>-r<1|2>`
+- Implement minimal fix.
+- Run `make prepush-full`.
+- `git add -A`
+- `git commit -m "hotfix: <summary> (r<1|2>)"`
+- `git push -u origin <hotfix-branch>`
+- Open PR with heredoc EOF body.
+- Monitor PR CI to green (25 min timeout).
+- Merge PR.
+- `git checkout main && git pull --ff-only origin main`
+- Monitor post-merge CI again (25 min timeout).
+
+12. Stop conditions:
+- CI green on main: success.
+- Non-actionable failure class: stop and report.
+- Loop count exceeded (`>2`): stop and report blocker.
+
+## EOF Rule (Mandatory)
+
+For all PR descriptions/comments, use only heredoc with single-quoted delimiter:
+
+`--body-file - <<'EOF'`
+`...text...`
+`EOF`
+
+Never use inline `--body "..."` for multi-line PR text.
+
+## Safety Rules
+
+- Never use destructive git commands unless explicitly requested.
+- Never amend commits unless explicitly requested.
+- Never create duplicate PRs for the same head branch.
+- Keep fixes scoped to CI failure root cause.
+- If unexpected repo state appears, stop and ask.
+
+## CI Policy
+
+- Required local gate before push: `make prepush-full` (includes CodeQL in this repo).
+- PR CI watch timeout: `25 minutes`.
+- Post-merge main CI watch timeout: `25 minutes`.
+- Retry/hotfix loop cap: `2`.
+
+## Expected Output
+
+- Branch name(s)
+- Commit SHA(s)
+- PR URL(s)
+- CI status per cycle
+- Merge commit SHA(s)
+- Post-merge CI status on `main`
+- If stopped: blocker reason and last failing check

--- a/.agents/skills/commit-push/agents/openai.yaml
+++ b/.agents/skills/commit-push/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Commit Push"
+  short_description: "Ship branch, PR, and CI to green"
+  default_prompt: "Use $commit-push to commit changes, open or update a PR, and drive checks to green."

--- a/.agents/skills/feature-discovery/SKILL.md
+++ b/.agents/skills/feature-discovery/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: feature-discovery
+description: Perform one-week, evidence-backed AI/agent market scanning and propose only high-leverage strategic product upgrades for Gait, with source-linked justification and no implementation.
+disable-model-invocation: true
+---
+
+# Strategic Feature Discovery (Gait)
+
+Execute this workflow when asked to identify strategic upgrades for Gait based on the latest AI and agent market developments.
+
+## Scope
+
+- Project context: `/Users/davidahmann/Projects/gait`
+- Date anchor: determine the current local date/time at runtime before collecting sources.
+- Time window: exactly the last 7 days from the run date (inclusive), using that runtime date anchor.
+- Focus: AI/agent developments materially relevant to Gait’s durable runtime, policy enforcement, provenance, fail-closed execution, and enterprise adoption.
+- Output target: `/Users/davidahmann/Projects/gait/product/ideas.md`
+- This skill is strategy-only. No implementation tasks.
+
+## Workflow
+
+1. Resolve current local date/time and timezone, then compute the 7-day window.
+2. Print the exact analysis window as absolute dates (`YYYY-MM-DD` to `YYYY-MM-DD`) before analysis.
+3. Collect AI/agent developments published within that window from credible sources.
+4. Filter to major market shifts only, excluding minor or incremental updates.
+5. Map each market signal to Gait’s product wedge and moat.
+6. Propose exactly 3 strategic upgrade features only when evidence is strong.
+7. If evidence is weak or not material, output no recommendations.
+8. Overwrite `product/ideas.md` from scratch with the final output.
+
+## Strategic Filter (all required)
+
+- Materiality: likely to impact market expectations in the next 6-18 months.
+- Differentiation: improves moat; not parity-only busywork.
+- Defensibility: strengthens trust, control, provenance, durability, or switching costs.
+- Adoption leverage: improves enterprise buy confidence or expansion potential.
+- Product relevance: can be framed as a durable product capability.
+
+## Non-Negotiables
+
+- Evidence-first: every recommendation must cite sources.
+- Date discipline: reject sources outside the computed 7-day window.
+- No minor suggestions, polish items, or local optimizations.
+- No implementation details, tickets, sprint plans, or code steps.
+- Clearly separate facts from inference.
+- No tables in output.
+
+## Command Anchors
+
+- Validate current capability baselines before proposing upgrades:
+  - `gait doctor --json`
+  - `gait gate eval --policy <policy.yaml> --input <intent.json> --json`
+  - `gait pack inspect <artifact.zip> --json`
+
+## Source Quality Bar
+
+- Prefer primary sources first:
+- Official vendor/model announcements
+- Official docs/specification updates
+- Major platform release notes
+- Regulator or standards-body publications
+- Use secondary reporting only as corroboration, never as sole evidence.
+
+## Output Contract
+
+Write only a clean structured list to `product/ideas.md`:
+
+1. `Recommendation`: one-line strategic feature name.
+2. `Why Now`: market trigger and timing rationale.
+3. `How (Strategic)`: product capability direction only (no implementation).
+4. `Moat/Benefit`: defensibility and business impact.
+5. `Evidence`: source links used for that recommendation.
+
+Rules:
+- Output exactly 3 recommendations when qualified evidence exists.
+- If not enough material signals exist, write only:
+  - `No worthy strategic upgrades identified in the last 7 days.`
+  - `Evidence note:` short explanation with links reviewed.
+- No preamble, no summary section, no implementation plan, no tables.

--- a/.agents/skills/feature-discovery/agents/openai.yaml
+++ b/.agents/skills/feature-discovery/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Feature Discovery"
+  short_description: "Discover market-driven strategic product upgrades"
+  default_prompt: "Use $feature-discovery to scan the last 7 days and propose only high-leverage strategic upgrades."

--- a/.agents/skills/plan-implement/SKILL.md
+++ b/.agents/skills/plan-implement/SKILL.md
@@ -1,0 +1,196 @@
+---
+name: plan-implement
+description: Implement a Gait backlog plan end-to-end from product/PLAN_NEXT.md (or a specified plan), with strict branch bootstrap, per-story test wiring, CodeQL validation, and final DoD/acceptance revalidation. No issue/PR automation.
+disable-model-invocation: true
+---
+
+# Plan Implementation (Gait)
+
+Execute this workflow for: "implement the plan", "execute PLAN_NEXT", "ship plan stories", or "run backlog implementation end-to-end."
+
+## Scope
+
+- Repository: `/Users/davidahmann/Projects/gait`
+- Default input plan: `/Users/davidahmann/Projects/gait/product/PLAN_NEXT.md`
+- Optional input plan: user-specified file under `/Users/davidahmann/Projects/gait/product/`
+- This skill executes code/docs/tests for planned stories.
+- Out of scope by default:
+- GitHub issue creation
+- PR creation
+- Automated comments/discussions
+- Auto-commit/auto-push
+
+## Preconditions
+
+- Plan file exists and is readable.
+- Plan includes:
+- `Global Decisions (Locked)`
+- `Exit Criteria`
+- `Test Matrix Wiring`
+- Story-level `Tasks`, `Repo paths`, `Run commands`, `Test requirements`, `Matrix wiring`, `Acceptance criteria`
+- If required sections are missing, stop and report blockers.
+
+## Git Bootstrap Contract (Mandatory)
+
+Before implementation starts, run in order:
+
+1. `git fetch origin main`
+2. `git checkout main`
+3. `git pull --ff-only origin main`
+4. `git checkout -b codex/<plan-scope>`
+
+Rules:
+- If working tree is dirty before step 1, stop and report blocker for user decision.
+- If unexpected changes appear during implementation, stop immediately and ask how to proceed.
+- Do not switch to other branches unless user explicitly requests it.
+
+## Workflow
+
+1. Parse plan and build execution queue:
+- Follow `Minimum-Now Sequence` first.
+- Respect dependencies and `P0 -> P1 -> P2`.
+
+2. Run baseline before first code change:
+- `make lint-fast`
+- `make test-fast`
+- Record failures as `pre-existing` vs `introduced`.
+
+3. Execute one story at a time:
+- Implement only scoped story changes.
+- Update tests required by story type.
+- Update docs surgically only if user-facing behavior changed.
+- Do not start next story until current story is validated.
+
+4. Validate story completion:
+- Run story `Run commands`.
+- Run story `Test requirements`.
+- Run story `Matrix wiring` lanes.
+- If anything required is skipped, mark story incomplete.
+
+5. Run epic-level validation after each epic:
+- Execute relevant integration/acceptance suites for impacted surfaces.
+
+6. Run final plan-level validation:
+- `make prepush-full` (preferred, includes CodeQL), or
+- `make prepush` and `make codeql` explicitly.
+- Never finish without CodeQL unless user explicitly waives it.
+
+7. Revalidate implementation against plan contracts:
+- Re-check every implemented story against acceptance criteria.
+- Re-check plan `Definition of Done`.
+
+## Command Anchors
+
+- `gait doctor --json` to verify local environment and dependency readiness before implementation.
+- `gait gate eval --policy <policy.yaml> --input <intent.json> --json` for policy-story contract checks.
+- `gait pack verify <artifact.zip> --json` for artifact-story integrity checks.
+- Re-check `Exit Criteria`.
+- Produce a `met/not met` checklist with command evidence for each item.
+
+## Test Requirements by Work Type (Mandatory)
+
+1. Schema/artifact contract changes:
+- Schema validation tests
+- Golden fixtures
+- Compatibility/migration tests
+- `make test-contracts`
+
+2. CLI behavior changes (flags/JSON/exits):
+- Command tests in `cmd/gait/*_test.go`
+- JSON output stability tests
+- Exit-code contract tests
+
+3. Gate/policy/fail-closed changes:
+- Deterministic allow/block/require_approval fixture tests
+- Fail-closed undecidable-path tests
+- Stable reason-code tests
+
+4. Determinism/hash/sign/packaging changes:
+- Repeat-run byte-stability tests
+- Canonicalization/digest stability tests
+- Verify/diff determinism checks
+- `make test-packspec-tck` when relevant
+
+5. Job runtime/state/concurrency changes:
+- Lifecycle tests (submit/checkpoint/pause/resume/cancel)
+- Atomic-write/crash-safety tests
+- Contention/concurrency tests
+- Chaos tests when scoped
+
+6. SDK/adapter boundary changes:
+- Wrapper behavior/error-mapping tests
+- Adapter parity/conformance tests
+- `make test-adapter-parity` when relevant
+
+7. Voice/context evidence changes:
+- `make test-voice-acceptance` and/or `make test-context-conformance` as applicable
+
+8. Docs/examples changes:
+- `make test-docs-consistency`
+- `make test-docs-storyline` when operator flow changes
+
+## Test Matrix Wiring (Enforcement)
+
+Each story must map to and run required lanes:
+
+- Fast lane: `make lint-fast`, `make test-fast`
+- Core lane: targeted unit/integration suites
+- Acceptance lane: relevant `make test-*-acceptance` targets
+- Cross-platform lane: ensure Linux/macOS/Windows-safe behavior for touched surfaces
+- Risk lane: determinism/safety/security/perf suites as required by story
+
+No story is complete without passing its mapped lanes.
+
+## Surgical Docs Sync Rule
+
+If a story introduces user-visible behavior changes, update only impacted docs in the same story:
+
+- `/Users/davidahmann/Projects/gait/README.md`
+- `/Users/davidahmann/Projects/gait/docs/`
+- `/Users/davidahmann/Projects/gait/docs-site/public/llms.txt`
+- `/Users/davidahmann/Projects/gait/docs-site/public/llm/*.md`
+
+If story is internal-only and behavior is unchanged, do not force doc churn.
+
+## Safety Rules
+
+- Preserve non-negotiables: determinism, offline-first, fail-closed, schema stability, stable exit codes.
+- Never weaken non-allow => non-execute paths.
+- No destructive git operations unless explicitly requested.
+- No auto-commit or auto-push.
+- Keep changes story-scoped; no unrelated refactors.
+
+## Quality Rules
+
+- Facts must be backed by command/test evidence.
+- Do not claim tests ran if they did not.
+- No silent skips of required checks.
+- Tests must use temp output paths (no artifact leakage into source tree).
+- If code/docs drift is introduced by user-facing change, patch docs in same story.
+
+## Blocker Handling
+
+If blocked:
+
+1. Stop the blocked story.
+2. Report exact blocker and impacted acceptance criteria.
+3. Continue only independent unblocked stories.
+4. End with minimum unblock actions.
+
+## Completion Criteria
+
+Implementation is complete only when all are true:
+
+- All non-blocked in-scope stories are implemented.
+- Story acceptance criteria are satisfied with evidence.
+- Plan `Definition of Done` is satisfied.
+- Plan `Exit Criteria` is satisfied.
+- Required matrix lanes and CodeQL are passing.
+
+## Expected Output
+
+- `Execution summary`: completed/deferred/blocked stories
+- `Change log`: files modified per story
+- `Validation log`: commands and pass/fail results
+- `Revalidation report`: story acceptance + DoD + exit criteria (`met/not met` with evidence)
+- `Residual risk`: remaining gaps and next required stories

--- a/.agents/skills/plan-implement/agents/openai.yaml
+++ b/.agents/skills/plan-implement/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Plan Implement"
+  short_description: "Execute plan stories with required test gates"
+  default_prompt: "Use $plan-implement to execute plan stories end-to-end with required validation and DoD checks."

--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ perf/ui_budget_report.json
 /regress_result.json
 /fixtures/
 /.uat_local/
+/.tmp/
 docs-site/node_modules/
 docs-site/.next/
 docs-site/out/

--- a/core/pack/exporters.go
+++ b/core/pack/exporters.go
@@ -4,6 +4,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"math"
 	"regexp"
 	"strconv"
 	"strings"
@@ -597,9 +598,9 @@ func intFromAny(value any) (int, bool) {
 	case int32:
 		return int(typed), true
 	case int64:
-		return int(typed), true
+		return intFromInt64(typed)
 	case uint:
-		return int(typed), true
+		return intFromUint64(uint64(typed))
 	case uint8:
 		return int(typed), true
 	case uint16:
@@ -607,24 +608,54 @@ func intFromAny(value any) (int, bool) {
 	case uint32:
 		return int(typed), true
 	case uint64:
-		return int(typed), true
+		return intFromUint64(typed)
 	case float32:
-		return int(typed), true
+		return intFromFloat64(float64(typed))
 	case float64:
-		return int(typed), true
+		return intFromFloat64(typed)
 	case json.Number:
 		parsed, err := typed.Int64()
 		if err == nil {
-			return int(parsed), true
+			return intFromInt64(parsed)
 		}
 		floatParsed, floatErr := typed.Float64()
 		if floatErr != nil {
 			return 0, false
 		}
-		return int(floatParsed), true
+		return intFromFloat64(floatParsed)
 	default:
 		return 0, false
 	}
+}
+
+func intFromInt64(value int64) (int, bool) {
+	const maxInt = int64(^uint(0) >> 1)
+	const minInt = -maxInt - 1
+	if value < minInt || value > maxInt {
+		return 0, false
+	}
+	return int(value), true
+}
+
+func intFromUint64(value uint64) (int, bool) {
+	const maxInt = uint64(^uint(0) >> 1)
+	if value > maxInt {
+		return 0, false
+	}
+	return int(value), true
+}
+
+func intFromFloat64(value float64) (int, bool) {
+	if math.IsNaN(value) || math.IsInf(value, 0) {
+		return 0, false
+	}
+	const maxInt = int64(^uint(0) >> 1)
+	const minInt = -maxInt - 1
+	truncated := math.Trunc(value)
+	if truncated < float64(minInt) || truncated > float64(maxInt) {
+		return 0, false
+	}
+	return int(truncated), true
 }
 
 func toString(value any) string {

--- a/core/pack/exporters.go
+++ b/core/pack/exporters.go
@@ -649,13 +649,12 @@ func intFromFloat64(value float64) (int, bool) {
 	if math.IsNaN(value) || math.IsInf(value, 0) {
 		return 0, false
 	}
-	const maxInt = int64(^uint(0) >> 1)
-	const minInt = -maxInt - 1
 	truncated := math.Trunc(value)
-	if truncated < float64(minInt) || truncated > float64(maxInt) {
+	positiveLimit := math.Ldexp(1, strconv.IntSize-1)
+	if truncated < -positiveLimit || truncated >= positiveLimit {
 		return 0, false
 	}
-	return int(truncated), true
+	return intFromInt64(int64(truncated))
 }
 
 func toString(value any) string {

--- a/core/pack/exporters_test.go
+++ b/core/pack/exporters_test.go
@@ -3,6 +3,7 @@ package pack
 import (
 	"bytes"
 	"encoding/json"
+	"math"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -221,6 +222,11 @@ func TestExportValueHelpers(t *testing.T) {
 		{name: "json_float", value: json.Number("20.5"), want: 20, ok: true},
 		{name: "invalid", value: json.Number("nope"), want: 0, ok: false},
 		{name: "unsupported", value: "21", want: 0, ok: false},
+		{name: "uint_overflow", value: ^uint(0), want: 0, ok: false},
+		{name: "uint64_overflow", value: uint64(math.MaxUint64), want: 0, ok: false},
+		{name: "float_nan", value: math.NaN(), want: 0, ok: false},
+		{name: "float_pos_inf", value: math.Inf(1), want: 0, ok: false},
+		{name: "json_overflow", value: json.Number("18446744073709551615"), want: 0, ok: false},
 	} {
 		t.Run(candidate.name, func(t *testing.T) {
 			got, ok := intFromAny(candidate.value)

--- a/core/pack/exporters_test.go
+++ b/core/pack/exporters_test.go
@@ -226,6 +226,8 @@ func TestExportValueHelpers(t *testing.T) {
 		{name: "uint64_overflow", value: uint64(math.MaxUint64), want: 0, ok: false},
 		{name: "float_nan", value: math.NaN(), want: 0, ok: false},
 		{name: "float_pos_inf", value: math.Inf(1), want: 0, ok: false},
+		{name: "float_pos_int_limit", value: math.Ldexp(1, strconv.IntSize-1), want: 0, ok: false},
+		{name: "json_signed_overflow_edge", value: json.Number("9223372036854775808"), want: 0, ok: false},
 		{name: "json_overflow", value: json.Number("18446744073709551615"), want: 0, ok: false},
 	} {
 		t.Run(candidate.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary
- fix integer conversion safety in pack exporters to satisfy gosec (`G115`) and avoid overflow/NaN/Inf truncation bugs
- harden registry remote-install tests to use explicit IPv4 local listeners for better portability/stability
- add and normalize repo skills used for audit/review/planning workflows with required Codex metadata
- ignore local `/.tmp/` cache directory and clean working tree temp cache policy

## Key Changes
- `core/pack/exporters.go`
  - added checked helpers for numeric conversion paths: `intFromInt64`, `intFromUint64`, `intFromFloat64`
  - updated `intFromAny` to fail closed on out-of-range and invalid float values
- `core/pack/exporters_test.go`
  - added overflow and invalid-value coverage (`uint_overflow`, `uint64_overflow`, `float_nan`, `float_pos_inf`, `json_overflow`)
- `core/registry/install_test.go`
  - introduced `newIPv4LocalServer(...)` and switched remote install tests from default `httptest.NewServer` to explicit `tcp4` listener
- `.agents/skills/*`
  - added/updated skills and `agents/openai.yaml` metadata to satisfy repo skill validation contract
- `.gitignore`
  - added `/.tmp/`

## Validation
- `make lint`
- `make prepush` (via git pre-push hook)
- full local UAT:
  - `bash scripts/test_uat_local.sh`
  - result includes:
    - `PRIMARY_INSTALL_PATH_STATUS release-installer PASS`
    - `UAT COMPLETE: PASS`

## Notes
- no force-push or history rewrite
