### PR TITLE
skills: fix command anchors and add branch/comment triage skills

### DIFF
--- a/.agents/skills/adhoc-plan/SKILL.md
+++ b/.agents/skills/adhoc-plan/SKILL.md
@@ -53,7 +53,7 @@ Validation rules:
 Use `gait` commands with `--json` whenever the plan needs machine-readable evidence, for example:
 
 - `gait doctor --json`
-- `gait regress bootstrap --runpack fixtures/run_demo/runpack.zip --json`
+- `gait regress bootstrap --from fixtures/run_demo/runpack.zip --json`
 
 ## Non-Negotiables
 

--- a/.agents/skills/app-audit/SKILL.md
+++ b/.agents/skills/app-audit/SKILL.md
@@ -42,7 +42,7 @@ Execute this workflow when asked to perform app review, release readiness, archi
 
 - `gait doctor --json` to capture environment diagnostics in machine-readable form.
 - `gait pack inspect <artifact.zip> --json` to inspect artifact envelope integrity and payload shape.
-- `gait gate eval --policy <policy.yaml> --input <intent.json> --json` to validate fail-closed policy behavior.
+- `gait gate eval --policy <policy.yaml> --intent <intent.json> --json` to validate fail-closed policy behavior.
 
 ## Severity
 

--- a/.agents/skills/backlog-plan/SKILL.md
+++ b/.agents/skills/backlog-plan/SKILL.md
@@ -152,7 +152,7 @@ Before finalizing, verify:
 
 - Include concrete plan tasks that reference verifiable CLI surfaces, for example:
   - `gait doctor --json`
-  - `gait gate eval --policy <policy.yaml> --input <intent.json> --json`
+  - `gait gate eval --policy <policy.yaml> --intent <intent.json> --json`
   - `gait pack verify <pack.zip> --json`
 
 ## Failure Mode

--- a/.agents/skills/branches-clean/SKILL.md
+++ b/.agents/skills/branches-clean/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: branches-clean
-description: Delete all non-main local and origin remote branches one-by-one with safety checks, dry-run support, and final prune/report.
+description: Delete all non-main local and configured-remote branches one-by-one with safety checks, dry-run support, and final prune/report.
 disable-model-invocation: true
 ---
 
 # Branches Clean (Gait)
 
-Execute this workflow when asked to clean up branches by deleting all non-`main` branches locally and on `origin`.
+Execute this workflow when asked to clean up branches by deleting all non-`main` branches locally and on a configured remote (default `origin`).
 
 ## Scope
 
@@ -15,7 +15,7 @@ Execute this workflow when asked to clean up branches by deleting all non-`main`
 - Deletion style: one-by-one only (no grouped delete commands)
 - Applies to:
 - local branches
-- remote `origin/*` branches
+- remote `<remote>/*` branches (default `origin`)
 
 ## Input Contract
 
@@ -31,9 +31,9 @@ If `mode` is missing, default to `dry-run`.
 - Never delete `main`.
 - Always switch to `main` before deletion.
 - Always sync main before deletion:
-- `git fetch origin main`
+- `git fetch <remote> main`
 - `git checkout main`
-- `git pull --ff-only origin main`
+- `git pull --ff-only <remote> main`
 - No grouped branch deletion commands.
 - Delete branches one-by-one only.
 - In `dry-run`, do not delete anything.
@@ -49,6 +49,7 @@ If `mode` is missing, default to `dry-run`.
 1. Preflight:
 - confirm repo is valid git repo
 - resolve current branch
+- verify `<remote>/main` exists
 - switch to `main` and sync fast-forward
 - fetch/prune remote refs (`git fetch --prune <remote>`)
 
@@ -88,7 +89,7 @@ Use one-by-one commands only, such as:
 
 - `git branch -d <name>`
 - `git branch -D <name>` (only if `force_local_delete=true`)
-- `git push origin --delete <name>`
+- `git push <remote> --delete <name>`
 
 Do not use batched deletion forms.
 
@@ -96,7 +97,7 @@ Do not use batched deletion forms.
 
 - Continue on per-branch failures; do not abort whole run.
 - Record each failure with command + stderr reason.
-- If cannot switch to `main` or cannot sync `main`, stop immediately.
+- If `<remote>/main` is missing, or if cannot switch/sync `main`, stop immediately.
 
 ## Expected Output
 

--- a/.agents/skills/branches-clean/SKILL.md
+++ b/.agents/skills/branches-clean/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: branches-clean
+description: Delete all non-main local and origin remote branches one-by-one with safety checks, dry-run support, and final prune/report.
+disable-model-invocation: true
+---
+
+# Branches Clean (Gait)
+
+Execute this workflow when asked to clean up branches by deleting all non-`main` branches locally and on `origin`.
+
+## Scope
+
+- Repository: `/Users/davidahmann/Projects/gait`
+- Target: all non-`main` branches
+- Deletion style: one-by-one only (no grouped delete commands)
+- Applies to:
+- local branches
+- remote `origin/*` branches
+
+## Input Contract
+
+- `mode`: `dry-run` or `execute`
+- Optional:
+- `force_local_delete`: `false` by default
+- `remote`: defaults to `origin`
+
+If `mode` is missing, default to `dry-run`.
+
+## Safety Rules
+
+- Never delete `main`.
+- Always switch to `main` before deletion.
+- Always sync main before deletion:
+- `git fetch origin main`
+- `git checkout main`
+- `git pull --ff-only origin main`
+- No grouped branch deletion commands.
+- Delete branches one-by-one only.
+- In `dry-run`, do not delete anything.
+
+## Command Anchors (JSON Required)
+
+- Capture machine-readable diagnostics before destructive actions:
+  - `gait doctor --json`
+  - `gait gate eval --policy <policy.yaml> --intent <intent.json> --json`
+
+## Workflow
+
+1. Preflight:
+- confirm repo is valid git repo
+- resolve current branch
+- switch to `main` and sync fast-forward
+- fetch/prune remote refs (`git fetch --prune <remote>`)
+
+2. Build delete candidates:
+- Local candidates: all local branches except `main`
+- Remote candidates: all `<remote>/<branch>` except `<remote>/main`
+- Exclude symbolic refs (`<remote>/HEAD`)
+
+3. Dry-run report (always):
+- print local branches that would be deleted
+- print remote branches that would be deleted
+- print counts for local/remote
+
+4. Execute deletion only if `mode=execute`:
+- Local deletion one-by-one:
+- try `git branch -d <branch>`
+- if fails and `force_local_delete=true`, retry `git branch -D <branch>`
+- otherwise record failure and continue
+- Remote deletion one-by-one:
+- `git push <remote> --delete <branch>`
+- if already deleted/not found, record as skipped and continue
+
+5. Final reconciliation:
+- `git fetch --prune <remote>`
+- list remaining local branches
+- list remaining `<remote>/*` branches
+
+6. Output summary:
+- deleted local branches
+- deleted remote branches
+- skipped/failed branches with reasons
+- final remaining branch lists
+
+## Command Discipline
+
+Use one-by-one commands only, such as:
+
+- `git branch -d <name>`
+- `git branch -D <name>` (only if `force_local_delete=true`)
+- `git push origin --delete <name>`
+
+Do not use batched deletion forms.
+
+## Failure Handling
+
+- Continue on per-branch failures; do not abort whole run.
+- Record each failure with command + stderr reason.
+- If cannot switch to `main` or cannot sync `main`, stop immediately.
+
+## Expected Output
+
+- `Mode`: dry-run or execute
+- `Local candidates`: list + count
+- `Remote candidates`: list + count
+- `Deleted local`: list
+- `Deleted remote`: list
+- `Skipped/failed`: list with reasons
+- `Remaining local`: list
+- `Remaining remote`: list

--- a/.agents/skills/branches-clean/agents/openai.yaml
+++ b/.agents/skills/branches-clean/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Branches Clean"
+  short_description: "Delete non-main branches safely, one by one"
+  default_prompt: "Use $branches-clean to dry-run or execute one-by-one deletion of all non-main branches."

--- a/.agents/skills/code-review/SKILL.md
+++ b/.agents/skills/code-review/SKILL.md
@@ -76,7 +76,7 @@ Execute this workflow for: "review the codebase", "audit repo health", "run a fu
 ## Command Anchors
 
 - `gait doctor --json` to verify baseline runtime diagnostics and dependency posture.
-- `gait gate eval --policy <policy.yaml> --input <intent.json> --json` to validate policy verdict/exit behavior.
+- `gait gate eval --policy <policy.yaml> --intent <intent.json> --json` to validate policy verdict/exit behavior.
 - `gait pack verify <artifact.zip> --json` to check artifact integrity and signature status.
 
 ## Output Contract

--- a/.agents/skills/commit-push/SKILL.md
+++ b/.agents/skills/commit-push/SKILL.md
@@ -78,12 +78,6 @@ If preconditions fail, stop and report.
 - Run only for actionable failures.
 - Loop cap: `2`.
 - For each loop:
-
-## Command Anchors
-
-- `gait doctor --json` before ship to capture machine-readable local readiness evidence.
-- `gait pack verify <artifact.zip> --json` when validating artifact integrity in a failing CI path.
-- `gait gate eval --policy <policy.yaml> --input <intent.json> --json` when policy-path checks are implicated.
 - Create branch from updated `main`: `codex/hotfix-<topic>-r<1|2>`
 - Implement minimal fix.
 - Run `make prepush-full`.
@@ -100,6 +94,12 @@ If preconditions fail, stop and report.
 - CI green on main: success.
 - Non-actionable failure class: stop and report.
 - Loop count exceeded (`>2`): stop and report blocker.
+
+## Command Anchors
+
+- `gait doctor --json` before ship to capture machine-readable local readiness evidence.
+- `gait pack verify <artifact.zip> --json` when validating artifact integrity in a failing CI path.
+- `gait gate eval --policy <policy.yaml> --intent <intent.json> --json` when policy-path checks are implicated.
 
 ## EOF Rule (Mandatory)
 

--- a/.agents/skills/cut-release/SKILL.md
+++ b/.agents/skills/cut-release/SKILL.md
@@ -21,7 +21,7 @@ Execute this workflow for: "cut release", "ship vX.Y.Z", "push tag and monitor r
 
 - Mandatory input argument: `release_version`
 - Normalize to `vX.Y.Z`
-- If missing prompt for missing version input
+- If missing, resolve silently from first semantic version token in user request; otherwise use latest tag + patch increment.
 
 ## Constants
 
@@ -49,8 +49,19 @@ Execute this workflow for: "cut release", "ship vX.Y.Z", "push tag and monitor r
 3. `git pull --ff-only origin main`
 4. Ensure clean worktree (`git status --porcelain` must be empty)
 5. Ensure target tag does not already exist locally/remotely
-6. Run local release preflight:
+6. Run local release preflight (mirror release workflow gate coverage):
 - `make prepush-full`
+- `make test-v2-3-acceptance`
+- `make test-v2-4-acceptance`
+- `make test-packspec-tck`
+- `make test-e2e`
+- `go test ./internal/integration -count=1`
+- `make test-chaos`
+- `make test-runtime-slo`
+- `make bench-check`
+- `make test-v2-5-acceptance`
+- `make test-context-conformance`
+- `make test-context-chaos`
 - `make test-release-smoke`
 
 If any step fails, stop and report blocker.
@@ -136,7 +147,7 @@ For loop `r1..r2`:
 Capture release diagnostics using `gait` commands with `--json`, for example:
 
 - `gait doctor --json`
-- `gait pack verify --path gait-out/pack_<id>.zip --json`
+- `gait pack verify gait-out/pack_<id>.zip --json`
 
 ## EOF Rule (Mandatory)
 

--- a/.agents/skills/feature-discovery/SKILL.md
+++ b/.agents/skills/feature-discovery/SKILL.md
@@ -24,7 +24,7 @@ Execute this workflow when asked to identify strategic upgrades for Gait based o
 3. Collect AI/agent developments published within that window from credible sources.
 4. Filter to major market shifts only, excluding minor or incremental updates.
 5. Map each market signal to Gait’s product wedge and moat.
-6. Propose exactly 3 strategic upgrade features only when evidence is strong.
+6. Propose exactly 5 strategic upgrade features only when evidence is strong.
 7. If evidence is weak or not material, output no recommendations.
 8. Overwrite `product/ideas.md` from scratch with the final output.
 
@@ -49,7 +49,7 @@ Execute this workflow when asked to identify strategic upgrades for Gait based o
 
 - Validate current capability baselines before proposing upgrades:
   - `gait doctor --json`
-  - `gait gate eval --policy <policy.yaml> --input <intent.json> --json`
+  - `gait gate eval --policy <policy.yaml> --intent <intent.json> --json`
   - `gait pack inspect <artifact.zip> --json`
 
 ## Source Quality Bar
@@ -72,7 +72,7 @@ Write only a clean structured list to `product/ideas.md`:
 5. `Evidence`: source links used for that recommendation.
 
 Rules:
-- Output exactly 3 recommendations when qualified evidence exists.
+- Output exactly 5 recommendations when qualified evidence exists.
 - If not enough material signals exist, write only:
   - `No worthy strategic upgrades identified in the last 7 days.`
   - `Evidence note:` short explanation with links reviewed.

--- a/.agents/skills/plan-implement/SKILL.md
+++ b/.agents/skills/plan-implement/SKILL.md
@@ -78,14 +78,14 @@ Rules:
 7. Revalidate implementation against plan contracts:
 - Re-check every implemented story against acceptance criteria.
 - Re-check plan `Definition of Done`.
+- Re-check plan `Exit Criteria`.
+- Produce a `met/not met` checklist with command evidence for each item.
 
 ## Command Anchors
 
 - `gait doctor --json` to verify local environment and dependency readiness before implementation.
-- `gait gate eval --policy <policy.yaml> --input <intent.json> --json` for policy-story contract checks.
+- `gait gate eval --policy <policy.yaml> --intent <intent.json> --json` for policy-story contract checks.
 - `gait pack verify <artifact.zip> --json` for artifact-story integrity checks.
-- Re-check `Exit Criteria`.
-- Produce a `met/not met` checklist with command evidence for each item.
 
 ## Test Requirements by Work Type (Mandatory)
 

--- a/.agents/skills/pr-comments/SKILL.md
+++ b/.agents/skills/pr-comments/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: pr-comments
+description: Analyze Codex/agent review comments on one or more PRs, triage what should be implemented, and provide a clear implementation recommendation list for the user.
+disable-model-invocation: true
+---
+
+# PR Comments Triage (Gait)
+
+Execute this workflow when asked to review PR comments from agents/Codex and recommend what should actually be implemented and how.
+
+## Scope
+
+- Repository context: `/Users/davidahmann/Projects/gait`
+- Input PRs: user-provided PR number(s)
+- Mode: analysis and recommendation only (read-only by default)
+- No code changes, commits, or pushes in this skill unless explicitly requested in a follow-up
+
+## Input Contract (Mandatory)
+
+- `pr_numbers`: one or more PR numbers
+- Optional:
+- `repo` (owner/name if not inferable from current git remote)
+- `include_non_agent_comments` (`false` by default)
+
+If `pr_numbers` is missing, stop and report blocker.
+
+## Workflow
+
+1. Resolve repository and PR targets from input.
+2. For each PR:
+- fetch PR metadata (state, base/head, latest head SHA)
+- fetch review comments, review summaries, and issue comments
+- collect inline comment context (file + line + diff hunk when available)
+3. Filter comments:
+- include agent/Codex comments by default
+- exclude outdated/stale comments not applicable to latest head SHA
+- collapse duplicates/near-duplicates
+4. Triage each comment into:
+- `implement`
+- `defer`
+- `reject`
+5. Score each triaged item:
+- severity (`P0/P1/P2/P3`)
+- confidence (`high/medium/low`)
+- impact area (`safety`, `determinism`, `contract`, `portability`, `docs`, `maintainability`)
+6. Produce implementation guidance for `implement` items:
+- what to change
+- why it matters
+- minimal safe fix direction
+- tests/validation required
+7. Produce rationale for `defer/reject`:
+- reason and conditions to revisit
+8. Generate final user-facing recommendation report.
+
+## Triage Rules (Gait-Specific)
+
+Prioritize comments that affect:
+
+1. Fail-closed behavior and enforcement boundaries.
+2. Determinism (verify/diff/replay/pack reproducibility).
+3. Schema and CLI contract stability (`--json`, exit codes, compatibility).
+4. Security/privacy controls (signing, secrets handling, unsafe interlocks).
+5. Cross-platform/CI portability issues.
+6. Docs drift where behavior has changed.
+
+Deprioritize or reject:
+
+- style-only nits with no runtime/contract impact
+- speculative refactors outside PR scope
+- stale comments already fixed on newer commits
+
+## Command Anchors
+
+- Use `gait` JSON outputs when validating recommendation risk:
+  - `gait doctor --json`
+  - `gait gate eval --policy <policy.yaml> --intent <intent.json> --json`
+  - `gait pack verify <pack.zip> --json`
+
+## Recommendation Format (Per Implement Item)
+
+- `PR`: number
+- `Comment ref`: reviewer + permalink (or comment id)
+- `Location`: file:line (if inline)
+- `Decision`: implement
+- `Severity`: P0/P1/P2/P3
+- `Why`: risk and concrete break scenario
+- `How`: concise implementation direction (no code unless asked)
+- `Validation`: exact tests/checks to run
+
+## Output Contract
+
+Return sections in this order:
+
+1. `Implement Now` (ordered by severity, then confidence)
+2. `Defer` (with trigger/condition for future action)
+3. `Reject` (with concise rationale)
+4. `Cross-PR Patterns` (optional: repeated root causes seen across PRs)
+5. `Validation Plan` (commands/checks required if user asks to implement)
+
+## Safety Rules
+
+- Read-only analysis by default.
+- Do not edit files or run git write operations in this skill.
+- Do not claim a comment is resolved unless verified against current head.
+- Keep recommendations scoped to actual comment evidence.
+
+## Quality Rules
+
+- Evidence-first: every recommendation must map to a real comment.
+- Distinguish facts from inference.
+- Avoid generic advice; tie guidance to exact files/contracts.
+- Prefer minimal-risk changes over broad refactors.
+
+## Failure Mode
+
+If comments cannot be fetched or are insufficient:
+
+- `No actionable PR comment triage produced.`
+- `Reason:` concise blocker
+- `Missing inputs/access:` exact requirement (PR numbers, repo, auth, permission)
+
+Do not fabricate recommendations.

--- a/.agents/skills/pr-comments/agents/openai.yaml
+++ b/.agents/skills/pr-comments/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "PR Comments"
+  short_description: "Triage PR comments into implement or defer"
+  default_prompt: "Use $pr-comments to analyze PR comments and recommend what should be implemented next."


### PR DESCRIPTION
## Problem
Several skill docs had inaccurate CLI command examples (notably `gate eval` flag usage), and two new skills were missing required metadata/hooks for repository skill validation.

## What Changed
- Corrected skill command anchors to match current CLI contract (`--intent` for `gait gate eval`, positional `gait pack verify <pack.zip>`, `gait regress bootstrap --from ...`).
- Fixed section ordering/clarity in `commit-push` and plan revalidation wording in `plan-implement`.
- Aligned `cut-release` preflight checks with release gate coverage and clarified version resolution behavior.
- Added two new skills with OpenAI metadata:
  - `branches-clean`
  - `pr-comments`

## Validation
- `python3 scripts/validate_repo_skills.py`
- pre-push hook (`make prepush`) passed on push:
  - `make lint-fast`
  - `make test-fast`
