### PR TITLE
docs: align branches-clean execute mode and AGENTS parity

### DIFF
--- a/.agents/skills/branches-clean/SKILL.md
+++ b/.agents/skills/branches-clean/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: branches-clean
-description: Delete all non-main local and configured-remote branches one-by-one with safety checks, dry-run support, and final prune/report.
+description: Delete all non-main local and configured-remote branches one-by-one with safety checks and final prune/report.
 disable-model-invocation: true
 ---
 
@@ -19,12 +19,10 @@ Execute this workflow when asked to clean up branches by deleting all non-`main`
 
 ## Input Contract
 
-- `mode`: `dry-run` or `execute`
+- `mode`: `execute` only
+- `force_local_delete`: always `true` for this skill
 - Optional:
-- `force_local_delete`: `false` by default
 - `remote`: defaults to `origin`
-
-If `mode` is missing, default to `dry-run`.
 
 ## Safety Rules
 
@@ -36,7 +34,6 @@ If `mode` is missing, default to `dry-run`.
 - `git pull --ff-only <remote> main`
 - No grouped branch deletion commands.
 - Delete branches one-by-one only.
-- In `dry-run`, do not delete anything.
 
 ## Command Anchors (JSON Required)
 
@@ -56,28 +53,21 @@ If `mode` is missing, default to `dry-run`.
 2. Build delete candidates:
 - Local candidates: all local branches except `main`
 - Remote candidates: all `<remote>/<branch>` except `<remote>/main`
-- Exclude symbolic refs (`<remote>/HEAD`)
+- Exclude symbolic refs (`<remote>/HEAD`) and `<remote>` root alias if present.
 
-3. Dry-run report (always):
-- print local branches that would be deleted
-- print remote branches that would be deleted
-- print counts for local/remote
-
-4. Execute deletion only if `mode=execute`:
+3. Execute deletion (always):
 - Local deletion one-by-one:
-- try `git branch -d <branch>`
-- if fails and `force_local_delete=true`, retry `git branch -D <branch>`
-- otherwise record failure and continue
+- `git branch -D <branch>`
 - Remote deletion one-by-one:
 - `git push <remote> --delete <branch>`
 - if already deleted/not found, record as skipped and continue
 
-5. Final reconciliation:
+4. Final reconciliation:
 - `git fetch --prune <remote>`
 - list remaining local branches
 - list remaining `<remote>/*` branches
 
-6. Output summary:
+5. Output summary:
 - deleted local branches
 - deleted remote branches
 - skipped/failed branches with reasons
@@ -87,8 +77,7 @@ If `mode` is missing, default to `dry-run`.
 
 Use one-by-one commands only, such as:
 
-- `git branch -d <name>`
-- `git branch -D <name>` (only if `force_local_delete=true`)
+- `git branch -D <name>`
 - `git push <remote> --delete <name>`
 
 Do not use batched deletion forms.
@@ -101,7 +90,7 @@ Do not use batched deletion forms.
 
 ## Expected Output
 
-- `Mode`: dry-run or execute
+- `Mode`: execute
 - `Local candidates`: list + count
 - `Remote candidates`: list + count
 - `Deleted local`: list

--- a/.agents/skills/branches-clean/agents/openai.yaml
+++ b/.agents/skills/branches-clean/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Branches Clean"
   short_description: "Delete non-main branches safely, one by one"
-  default_prompt: "Use $branches-clean to dry-run or execute one-by-one deletion of all non-main branches."
+  default_prompt: "Use $branches-clean to execute one-by-one deletion of all non-main local and remote branches."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,7 @@ The durable product contract is **artifacts and schemas**, not a hosted UI.
 - **Next.js docs site** (`docs-site/`): static export deployed to GitHub Pages. Reads markdown from `docs/` via gray-matter frontmatter. No runtime dependencies.
 - **Node/TypeScript**: limited to docs site and local UI shell (`ui/local/`). Not part of the core CLI path.
 
-Current reference adapter set (keep parity): `openai_agents`, `langchain`, `autogen`, `openclaw`, `autogpt`, and the canonical sidecar path.
+Current reference adapter set (keep parity): `openai_agents`, `langchain`, `autogen`, `openclaw`, `autogpt`, `gastown`, `voice_reference`, and the canonical sidecar path.
 
 ## Canonicalization, hashing, and artifacts
 
@@ -91,8 +91,11 @@ Current reference adapter set (keep parity): `openai_agents`, `langchain`, `auto
 - `core/pack/` — PackSpec v1 pack/verify/diff
 - `core/runpack/` — legacy runpack capture/verify/diff/replay
 - `core/contextproof/` — context evidence envelopes
+- `core/doctor/` — diagnostics and production-readiness checks
+- `core/guard/` — evidence retention, encryption, and incident pack handling
 - `core/regress/` — regression bootstrap and execution
 - `core/mcp/` — MCP proxy/bridge/serve adapters
+- `core/scout/` — drift snapshots, operational/adoption events, and signal reports
 - `schemas/v1/` — JSON schemas for all artifact types
 - `sdk/python/` — Python wrapper SDK
 - `docs/` — markdown docs (consumed by docs-site via gray-matter)


### PR DESCRIPTION
## Problem
- The `branches-clean` skill still described dry-run/safe-delete behavior while the intended operator behavior is execute-only full cleanup of non-main branches.
- `AGENTS.md` adapter and key-path references had minor drift from the current repo layout.

## Changes
- Updated `.agents/skills/branches-clean/SKILL.md` to execute-only flow, one-by-one deletion, and force local delete semantics.
- Updated `.agents/skills/branches-clean/agents/openai.yaml` prompt copy to match execute-only behavior.
- Applied a surgical `AGENTS.md` parity update for current adapter set and key core paths.

## Validation
- `python3 scripts/validate_repo_skills.py`
- `make prepush-full`
- pre-push hook run on push (`make prepush`) passed
