### PR TITLE
hotfix: align acceptance with fail-closed gate exit codes (r1)

### DIFF
--- a/examples/sidecar/gate_sidecar.py
+++ b/examples/sidecar/gate_sidecar.py
@@ -130,7 +130,7 @@ def main() -> int:
         return completed.returncode if completed.returncode != 0 else 6
 
     response = {
-        "ok": completed.returncode in (0, 4),
+        "ok": completed.returncode in (0, 3, 4),
         "exit_code": completed.returncode,
         "gate_result": parsed_output,
         "trace_path": parsed_output.get("trace_path"),

--- a/scripts/test_v1_6_acceptance.sh
+++ b/scripts/test_v1_6_acceptance.sh
@@ -129,7 +129,7 @@ if [[ $ALLOW_CODE -ne 0 ]]; then
   echo "unexpected allow sidecar exit code: $ALLOW_CODE" >&2
   exit 1
 fi
-if [[ $BLOCK_CODE -ne 0 ]]; then
+if [[ $BLOCK_CODE -ne 3 ]]; then
   echo "unexpected block sidecar exit code: $BLOCK_CODE" >&2
   exit 1
 fi

--- a/scripts/test_v1_7_acceptance.sh
+++ b/scripts/test_v1_7_acceptance.sh
@@ -317,6 +317,7 @@ fi
 printf "%b" "$broker_fail_script" >"$broker_fail_path"
 chmod 700 "$broker_fail_path" 2>/dev/null || true
 (
+  set +e
   cd "$WORK_DIR"
   "$BIN_PATH" gate eval \
     --policy "$WORK_DIR/high_risk_with_broker.yaml" \
@@ -328,6 +329,12 @@ chmod 700 "$broker_fail_path" 2>/dev/null || true
     --credential-command "$broker_fail_path" \
     --credential-evidence-out "$WORK_DIR/credential_evidence.json" \
     --json >fail_closed_broker.json
+  broker_fail_code=$?
+  set -e
+  if [[ "$broker_fail_code" -ne 3 ]]; then
+    echo "broker fail-closed exit mismatch: $broker_fail_code" >&2
+    exit 1
+  fi
 )
 if grep -q "secret-broker-token" "$WORK_DIR/fail_closed_broker.json"; then
   echo "broker failure output leaked secret token" >&2


### PR DESCRIPTION
## Summary
- align sidecar success semantics with intentional non-zero gate verdict exits (`block`/`require_approval`)
- update v1.6 acceptance to expect `block` sidecar exit code `3`
- update v1.7 fail-closed broker assertion to capture and require `block` exit code `3`

## Validation
- `make test-v1-6-acceptance`
- `make test-v1-7-acceptance`
- `make prepush-full`
