### PR TITLE
Clarify scope in README title and description

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Gait — Signed Proof and Fail-Closed Control for AI Agent Tool Calls
+# Gait — Signed Proof and Fail-Closed Control for Production AI Agent Tool Calls
 
 ## Overview
 
@@ -6,7 +6,7 @@ Use Gait when an AI agent can cause real side effects and you need deterministic
 
 Gait is not an agent framework, not a model host, and not a dashboard. It is an offline-first Go CLI that sits at the tool boundary.
 
-Capture every agent tool call as a signed, offline-verifiable pack. Enforce fail-closed policy before high-risk actions execute. Turn incidents into CI regressions in one command.
+Capture every prod agent tool call as a signed, offline-verifiable pack. Enforce fail-closed policy before high-risk actions execute. Turn incidents into CI regressions in one command.
 
 Docs: [clyra-ai.github.io/gait](https://clyra-ai.github.io/gait/) | Install: [`docs/install.md`](docs/install.md) | Homebrew: [`docs/homebrew.md`](docs/homebrew.md)
 


### PR DESCRIPTION
Updated README to specify 'Production AI Agent Tool Calls'.

## Summary

## Testing

- [ ] `make fmt`
- [ ] `make lint`
- [ ] `make test`

## Hardening Review

- [ ] Failure classification impact reviewed (`error_category`, `error_code`, retryability)
- [ ] Exit code contract impact reviewed (no accidental contract break)
- [ ] Deterministic output impact reviewed (`--json`, artifacts, golden fixtures)
- [ ] Security/privacy impact reviewed (secrets redaction, key handling, fail-closed behavior)

## Operational Notes

- [ ] User-facing docs updated where behavior changed (`README.md`, `docs/hardening/*`, runbooks)
- [ ] Docs sync checked across onboarding surfaces (`README.md`, `docs/README.md`, `docs-site/public/llm/*`, `docs-site/public/llms.txt`)
- [ ] New docs pages added to discoverability surfaces (`docs-site/src/lib/navigation.ts`, `docs-site/src/app/docs/page.tsx`, `docs-site/public/sitemap.xml`)
- [ ] Terminology changes reconciled in canonical definition pages (tool boundary + capability taxonomy)
- [ ] If agent behavior touched production-like paths, attached runpack evidence (`If your agent touched prod, attach the runpack.`)
- [ ] Included ticket footer evidence line (`gait run receipt --from <run_id|path>`)
- [ ] For new/expanded official integration lane proposals, attached `gait-out/integration_lane_scorecard.json` evidence and decision outcome
