### PR TITLE
gate: harden envelope parsing and wrkr context parsing

### DIFF
--- a/core/gate/approved_scripts.go
+++ b/core/gate/approved_scripts.go
@@ -180,6 +180,9 @@ func ReadApprovedScriptRegistry(path string) ([]schemagate.ApprovedScriptEntry, 
 	var envelopeRaw map[string]json.RawMessage
 	if err := json.Unmarshal(content, &envelopeRaw); err == nil {
 		if rawEntries, ok := envelopeRaw["entries"]; ok {
+			if err := requireJSONArray(rawEntries, "entries"); err != nil {
+				return nil, fmt.Errorf("parse approved script registry: %w", err)
+			}
 			var envelope registryEnvelope
 			if err := json.Unmarshal(rawEntries, &envelope.Entries); err != nil {
 				return nil, fmt.Errorf("parse approved script registry: %w", err)

--- a/core/gate/approved_scripts_test.go
+++ b/core/gate/approved_scripts_test.go
@@ -153,6 +153,16 @@ func TestReadApprovedScriptRegistryVariants(t *testing.T) {
 		t.Fatalf("expected empty entries for empty envelope registry, got %#v", entries)
 	}
 
+	nullEnvelopePath := filepath.Join(t.TempDir(), "null_envelope.json")
+	if err := os.WriteFile(nullEnvelopePath, []byte(`{"entries":null}`), 0o600); err != nil {
+		t.Fatalf("write null envelope registry fixture: %v", err)
+	}
+	if _, err := ReadApprovedScriptRegistry(nullEnvelopePath); err == nil {
+		t.Fatalf("expected null entries envelope to fail")
+	} else if !strings.Contains(err.Error(), "entries must be an array") {
+		t.Fatalf("expected entries array validation error, got: %v", err)
+	}
+
 	nowUTC := time.Date(2026, time.February, 5, 0, 0, 0, 0, time.UTC)
 	legacyPath := filepath.Join(t.TempDir(), "legacy.json")
 	legacyJSON := []byte(`[

--- a/core/gate/context_wrkr.go
+++ b/core/gate/context_wrkr.go
@@ -97,6 +97,9 @@ func parseWrkrInventory(content []byte) (map[string]WrkrToolMetadata, error) {
 	var wrappedRaw map[string]json.RawMessage
 	if err := json.Unmarshal(content, &wrappedRaw); err == nil {
 		if rawItems, ok := wrappedRaw["items"]; ok {
+			if err := requireJSONArray(rawItems, "items"); err != nil {
+				return nil, fmt.Errorf("parse wrkr inventory: %w", err)
+			}
 			var wrapped envelope
 			if err := json.Unmarshal(rawItems, &wrapped.Items); err != nil {
 				return nil, fmt.Errorf("parse wrkr inventory: %w", err)
@@ -127,6 +130,17 @@ func parseWrkrInventory(content []byte) (map[string]WrkrToolMetadata, error) {
 		}
 	}
 	return tools, nil
+}
+
+func requireJSONArray(raw json.RawMessage, field string) error {
+	var parsed any
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		return err
+	}
+	if _, ok := parsed.([]any); !ok {
+		return fmt.Errorf("%s must be an array", field)
+	}
+	return nil
 }
 
 func ApplyWrkrContext(intent *schemagate.IntentRequest, toolName string, inventory map[string]WrkrToolMetadata) bool {

--- a/core/gate/context_wrkr_test.go
+++ b/core/gate/context_wrkr_test.go
@@ -102,6 +102,20 @@ func TestLoadWrkrInventoryAcceptsEmptyEnvelope(t *testing.T) {
 	}
 }
 
+func TestLoadWrkrInventoryRejectsNullItemsEnvelope(t *testing.T) {
+	workDir := t.TempDir()
+	path := filepath.Join(workDir, "wrkr_inventory.json")
+	mustWriteWrkrInventoryFile(t, path, `{"items":null}`)
+
+	_, err := LoadWrkrInventory(path)
+	if err == nil {
+		t.Fatalf("expected null items envelope to fail")
+	}
+	if !strings.Contains(err.Error(), "items must be an array") {
+		t.Fatalf("expected items array validation error, got: %v", err)
+	}
+}
+
 func TestApplyWrkrContextAddsMetadata(t *testing.T) {
 	intent := schemagate.IntentRequest{
 		Context: schemagate.IntentContext{},


### PR DESCRIPTION
## Problem
Recent gate fixes addressed script-step context leakage and envelope parsing for Wrkr inventory / approved script registries, but null envelope fields (`{"items":null}` and `{"entries":null}`) could still be treated as empty slices and bypass fail-closed error handling.

## Changes
- Ensure script-step context in policy evaluation is isolated per step so Wrkr enrichment cannot leak between steps.
- Accept valid empty envelope forms (`items: []`, `entries: []`) while rejecting malformed non-array and null envelope payloads.
- Add regression tests for:
  - Wrkr and approved-script envelope empty arrays
  - explicit null envelope fields returning parse errors
  - step-level context isolation behavior

## Validation
- `make prepush-full`
- `./gait doctor --json`
- pre-push hook: `make prepush`
