### PR TITLE
fix(claude_code): wrap hook output in hookSpecificOutput envelope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - _No unreleased entries yet._
 
+### Fixed
+
+- Fixed Claude Code hook integration (`gait-gate.sh`) to wrap hook responses in
+  the `hookSpecificOutput` envelope required by Claude Code's PreToolUse
+  protocol. Without this wrapper, Claude Code silently ignores hook responses,
+  making all gait verdicts (allow, deny, ask) unenforceable.
+
 ### Changed
 
 - Gate intent normalization now treats omitted target `discovery_method` as `unknown` instead of empty so policies can deterministically match unknown/dynamic discovery paths.

--- a/examples/integrations/claude_code/gait-gate.sh
+++ b/examples/integrations/claude_code/gait-gate.sh
@@ -16,14 +16,15 @@ emit_response() {
 import json
 import os
 
-payload = {
+inner = {
+    "hookEventName": "PreToolUse",
     "permissionDecision": os.environ["DECISION"],
     "permissionDecisionReason": os.environ["REASON"],
 }
 trace_path = os.environ.get("TRACE_PATH", "").strip()
 if trace_path:
-    payload["tracePath"] = trace_path
-print(json.dumps(payload))
+    inner["tracePath"] = trace_path
+print(json.dumps({"hookSpecificOutput": inner}))
 PY
 }
 
@@ -60,13 +61,14 @@ strict_mode = os.environ.get("STRICT_MODE", "0").strip().lower() in {"1", "true"
 trace_path = os.environ.get("TRACE_PATH", "").strip()
 
 def emit(decision: str, reason: str) -> None:
-    payload = {
+    inner = {
+        "hookEventName": "PreToolUse",
         "permissionDecision": decision,
         "permissionDecisionReason": reason,
     }
     if trace_path:
-        payload["tracePath"] = trace_path
-    print(json.dumps(payload))
+        inner["tracePath"] = trace_path
+    print(json.dumps({"hookSpecificOutput": inner}))
 
 try:
     decoded = json.loads(proxy_output) if proxy_output.strip() else {}


### PR DESCRIPTION
## Summary

- `gait-gate.sh` outputs `{permissionDecision: "deny", ...}` at the top level, but Claude Code requires `{hookSpecificOutput: {hookEventName: "PreToolUse", permissionDecision: "deny", ...}}`
- Without the wrapper, Claude Code silently ignores the hook response and falls through to its default permission handling — making the hook appear advisory-only when it's actually being discarded
- Fix wraps both `emit_response()` and the inline `emit()` function in the required `hookSpecificOutput` envelope

## Detail

Claude Code's PreToolUse hook protocol expects stdout JSON in this shape:

```json
{
  "hookSpecificOutput": {
    "hookEventName": "PreToolUse",
    "permissionDecision": "allow|deny|ask",
    "permissionDecisionReason": "..."
  }
}
```

The current script outputs `permissionDecision` at the top level, which CC ignores without error. This affects all three verdict paths (allow, deny, ask).

## Test plan

Tested in Claude Code v2.1.47–v2.1.49 with a mixed-verdict policy (`allow` for reads, `require_approval` for exec, `block` for writes):

- [x] `Read` → gait maps to `tool.read` → allow → CC auto-runs (no prompt)
- [x] `Bash` (python3) → gait maps to `tool.exec` → require_approval → CC prompts user with gait reason
- [x] `Write` → gait maps to `tool.write` → block → CC blocks with gait reason
- [x] Empty payload → fail-open (allow)
- [x] Missing policy → fail-open (allow)

All paths verified in both manual pipe tests and live interactive CC sessions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)