### PR TITLE
proof: add graph-ready relationship envelopes and policy lineage

### DIFF
--- a/cmd/gait/mcp_server.go
+++ b/cmd/gait/mcp_server.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/Clyra-AI/gait/core/jobruntime"
 	"github.com/Clyra-AI/gait/core/runpack"
+	schemacommon "github.com/Clyra-AI/gait/core/schema/v1/common"
 )
 
 type mcpServeConfig struct {
@@ -502,16 +503,24 @@ func evaluateMCPServeRequest(config mcpServeConfig, writer http.ResponseWriter, 
 				safetyInvariantHash = strings.TrimSpace(state.SafetyInvariantHash)
 			}
 		}
+		var agentChain []schemacommon.AgentLink
+		if output.Relationship != nil {
+			agentChain = append(agentChain, output.Relationship.AgentChain...)
+		}
 		event, err := runpack.AppendSessionEvent(journalPath, runpack.SessionAppendOptions{
-			ProducerVersion: version,
-			ToolName:        output.ToolName,
-			IntentDigest:    output.IntentDigest,
-			PolicyDigest:    output.PolicyDigest,
-			TraceID:         output.TraceID,
-			TracePath:       output.TracePath,
-			Verdict:         output.Verdict,
-			ReasonCodes:     output.ReasonCodes,
-			Violations:      output.Violations,
+			ProducerVersion:        version,
+			ToolName:               output.ToolName,
+			IntentDigest:           output.IntentDigest,
+			PolicyDigest:           output.PolicyDigest,
+			PolicyID:               output.PolicyID,
+			PolicyVersion:          output.PolicyVersion,
+			MatchedRuleIDs:         output.MatchedRuleIDs,
+			TraceID:                output.TraceID,
+			TracePath:              output.TracePath,
+			AgentChain:             agentChain,
+			Verdict:                output.Verdict,
+			ReasonCodes:            output.ReasonCodes,
+			Violations:             output.Violations,
 			SafetyInvariantVersion: safetyInvariantVersion,
 			SafetyInvariantHash:    safetyInvariantHash,
 		})

--- a/cmd/gait/voice.go
+++ b/cmd/gait/voice.go
@@ -175,10 +175,16 @@ func runVoiceTokenMint(arguments []string) int {
 		return writeVoiceTokenOutput(jsonOutput, voiceTokenOutput{OK: false, Operation: "mint", Error: err.Error()}, exitCodeForError(err, exitInvalidInput))
 	}
 	traceResult, traceErr := gate.EmitSignedTrace(policy, normalizedIntent, outcome.Result, gate.EmitTraceOptions{
-		ProducerVersion:   version,
-		CorrelationID:     currentCorrelationID(),
-		SigningPrivateKey: keyPair.Private,
-		TracePath:         strings.TrimSpace(tracePath),
+		ProducerVersion:    version,
+		CorrelationID:      currentCorrelationID(),
+		ContextSource:      outcome.ContextSource,
+		CompositeRiskClass: outcome.CompositeRiskClass,
+		StepVerdicts:       outcome.StepVerdicts,
+		PreApproved:        outcome.PreApproved,
+		PatternID:          outcome.PatternID,
+		RegistryReason:     outcome.RegistryReason,
+		SigningPrivateKey:  keyPair.Private,
+		TracePath:          strings.TrimSpace(tracePath),
 	})
 	if traceErr != nil {
 		return writeVoiceTokenOutput(jsonOutput, voiceTokenOutput{OK: false, Operation: "mint", Error: traceErr.Error()}, exitCodeForError(traceErr, exitInvalidInput))

--- a/core/doctor/doctor.go
+++ b/core/doctor/doctor.go
@@ -63,6 +63,7 @@ var requiredSchemaPaths = []string{
 	"schemas/v1/gate/approval_audit_record.schema.json",
 	"schemas/v1/gate/broker_credential_record.schema.json",
 	"schemas/v1/gate/approved_script_entry.schema.json",
+	"schemas/v1/common/relationship_envelope.schema.json",
 	"schemas/v1/context/envelope.schema.json",
 	"schemas/v1/context/reference_record.schema.json",
 	"schemas/v1/context/budget_report.schema.json",

--- a/core/gate/approval_audit.go
+++ b/core/gate/approval_audit.go
@@ -92,6 +92,7 @@ func BuildApprovalAuditRecord(opts BuildApprovalAuditOptions) schemagate.Approva
 		ValidApprovals:    validApprovals,
 		Approved:          validApprovals >= requiredApprovals,
 		Approvers:         uniqueSorted(approvers),
+		Relationship:      buildApprovalAuditRelationship(opts.TraceID, opts.ToolName, opts.PolicyDigest, approvers),
 		Entries:           entries,
 	}
 }

--- a/core/gate/approval_audit_test.go
+++ b/core/gate/approval_audit_test.go
@@ -49,6 +49,21 @@ func TestBuildApprovalAuditRecordDeterministic(t *testing.T) {
 	if len(record.Entries) != 2 || record.Entries[0].TokenID != "token_a" {
 		t.Fatalf("expected sorted entries, got %#v", record.Entries)
 	}
+	if record.Relationship == nil {
+		t.Fatalf("expected relationship envelope in approval audit record")
+	}
+	if record.Relationship.ParentRef == nil || record.Relationship.ParentRef.Kind != "trace" || record.Relationship.ParentRef.ID != "trace_1" {
+		t.Fatalf("unexpected relationship parent_ref: %#v", record.Relationship.ParentRef)
+	}
+	if record.Relationship.PolicyRef == nil || record.Relationship.PolicyRef.PolicyDigest != record.PolicyDigest {
+		t.Fatalf("expected policy_ref digest in relationship: %#v", record.Relationship.PolicyRef)
+	}
+	if len(record.Relationship.AgentChain) != 0 {
+		t.Fatalf("expected no approver agent chain role in relationship: %#v", record.Relationship.AgentChain)
+	}
+	if len(record.Relationship.Edges) != 1 || record.Relationship.Edges[0].Kind != "governed_by" {
+		t.Fatalf("expected governed_by relationship edge in approval audit record: %#v", record.Relationship.Edges)
+	}
 }
 
 func TestWriteApprovalAuditRecord(t *testing.T) {

--- a/core/gate/delegation_audit.go
+++ b/core/gate/delegation_audit.go
@@ -67,6 +67,7 @@ func BuildDelegationAuditRecord(opts BuildDelegationAuditOptions) schemagate.Del
 		ValidDelegations:   validDelegations,
 		Delegated:          validDelegations > 0,
 		DelegationRef:      strings.TrimSpace(opts.DelegationRef),
+		Relationship:       buildDelegationAuditRelationship(opts.TraceID, opts.ToolName, opts.PolicyDigest, entries),
 		Entries:            entries,
 	}
 }

--- a/core/gate/delegation_test.go
+++ b/core/gate/delegation_test.go
@@ -303,6 +303,18 @@ func TestDelegationAuditRecordBuildAndWrite(t *testing.T) {
 	if len(record.Entries) != 2 || record.Entries[0].DelegatorIdentity != "agent.a" {
 		t.Fatalf("expected sorted delegation audit entries, got %#v", record.Entries)
 	}
+	if record.Relationship == nil {
+		t.Fatalf("expected relationship envelope in delegation audit record")
+	}
+	if record.Relationship.ParentRef == nil || record.Relationship.ParentRef.Kind != "trace" || record.Relationship.ParentRef.ID != "trace_demo" {
+		t.Fatalf("unexpected relationship parent_ref: %#v", record.Relationship.ParentRef)
+	}
+	if record.Relationship.PolicyRef == nil || record.Relationship.PolicyRef.PolicyDigest != record.PolicyDigest {
+		t.Fatalf("expected policy_ref digest in relationship: %#v", record.Relationship.PolicyRef)
+	}
+	if len(record.Relationship.Edges) == 0 {
+		t.Fatalf("expected relationship edges in delegation audit record")
+	}
 
 	workDir := t.TempDir()
 	path := filepath.Join(workDir, "audit", "delegation_audit.json")

--- a/core/gate/intent.go
+++ b/core/gate/intent.go
@@ -119,6 +119,7 @@ func NormalizeIntent(input schemagate.IntentRequest) (schemagate.IntentRequest, 
 	output.ArgProvenance = normalized.ArgProvenance
 	output.SkillProvenance = normalized.SkillProvenance
 	output.Delegation = normalized.Delegation
+	output.Relationship = normalizeRelationshipEnvelope(input.Relationship)
 	output.Context = normalized.Context
 	return output, nil
 }

--- a/core/gate/relationship.go
+++ b/core/gate/relationship.go
@@ -1,0 +1,484 @@
+package gate
+
+import (
+	"sort"
+	"strings"
+
+	schemacommon "github.com/Clyra-AI/gait/core/schema/v1/common"
+	schemagate "github.com/Clyra-AI/gait/core/schema/v1/gate"
+)
+
+var (
+	allowedRelationshipParentKinds = map[string]struct{}{
+		"trace":    {},
+		"run":      {},
+		"session":  {},
+		"intent":   {},
+		"policy":   {},
+		"agent":    {},
+		"evidence": {},
+	}
+	allowedRelationshipEntityKinds = map[string]struct{}{
+		"agent":      {},
+		"tool":       {},
+		"resource":   {},
+		"policy":     {},
+		"run":        {},
+		"trace":      {},
+		"delegation": {},
+		"evidence":   {},
+	}
+	allowedRelationshipAgentRoles = map[string]struct{}{
+		"requester": {},
+		"delegator": {},
+		"delegate":  {},
+	}
+	allowedRelationshipEdgeKinds = map[string]struct{}{
+		"delegates_to": {},
+		"calls":        {},
+		"governed_by":  {},
+		"targets":      {},
+		"derived_from": {},
+		"emits_evidence": {},
+	}
+)
+
+func buildTraceRelationship(
+	intent schemagate.IntentRequest,
+	traceID string,
+	policyID string,
+	policyVersion string,
+	policyDigest string,
+	matchedRuleIDs []string,
+) *schemacommon.RelationshipEnvelope {
+	relationship := schemacommon.RelationshipEnvelope{}
+	if parentKind, parentID := parentRefFromIntent(intent.Context); parentID != "" {
+		relationship.ParentRef = &schemacommon.RelationshipNodeRef{Kind: parentKind, ID: parentID}
+	}
+
+	entityRefs := []schemacommon.RelationshipRef{}
+	if traceID = strings.TrimSpace(traceID); traceID != "" {
+		entityRefs = append(entityRefs, schemacommon.RelationshipRef{Kind: "trace", ID: traceID})
+	}
+	if toolName := strings.TrimSpace(intent.ToolName); toolName != "" {
+		entityRefs = append(entityRefs, schemacommon.RelationshipRef{Kind: "tool", ID: toolName})
+	}
+	if identity := strings.TrimSpace(intent.Context.Identity); identity != "" {
+		entityRefs = append(entityRefs, schemacommon.RelationshipRef{Kind: "agent", ID: identity})
+	}
+	if policyDigest = strings.ToLower(strings.TrimSpace(policyDigest)); policyDigest != "" {
+		entityRefs = append(entityRefs, schemacommon.RelationshipRef{Kind: "policy", ID: policyDigest})
+	}
+	relationship.EntityRefs = normalizeRelationshipRefs(entityRefs)
+	relationship.RelatedEntityIDs = relationshipRefIDs(relationship.EntityRefs)
+
+	policyID = strings.TrimSpace(policyID)
+	policyVersion = strings.TrimSpace(policyVersion)
+	matchedRuleIDs = uniqueSorted(matchedRuleIDs)
+	if policyID != "" || policyVersion != "" || policyDigest != "" || len(matchedRuleIDs) > 0 {
+		relationship.PolicyRef = &schemacommon.PolicyRef{
+			PolicyID:       policyID,
+			PolicyVersion:  policyVersion,
+			PolicyDigest:   policyDigest,
+			MatchedRuleIDs: matchedRuleIDs,
+		}
+	}
+
+	agentChain := []schemacommon.AgentLink{}
+	if intent.Delegation != nil {
+		if requester := strings.TrimSpace(intent.Delegation.RequesterIdentity); requester != "" {
+			agentChain = append(agentChain, schemacommon.AgentLink{Identity: requester, Role: "requester"})
+		}
+		for _, link := range intent.Delegation.Chain {
+			if delegator := strings.TrimSpace(link.DelegatorIdentity); delegator != "" {
+				agentChain = append(agentChain, schemacommon.AgentLink{Identity: delegator, Role: "delegator"})
+			}
+			if delegate := strings.TrimSpace(link.DelegateIdentity); delegate != "" {
+				agentChain = append(agentChain, schemacommon.AgentLink{Identity: delegate, Role: "delegate"})
+			}
+		}
+	} else if identity := strings.TrimSpace(intent.Context.Identity); identity != "" {
+		agentChain = append(agentChain, schemacommon.AgentLink{Identity: identity, Role: "requester"})
+	}
+	relationship.AgentChain = normalizeAgentChain(agentChain)
+
+	edges := []schemacommon.RelationshipEdge{}
+	if actor := strings.TrimSpace(intent.Context.Identity); actor != "" && strings.TrimSpace(intent.ToolName) != "" {
+		edges = append(edges, schemacommon.RelationshipEdge{
+			Kind: "calls",
+			From: schemacommon.RelationshipNodeRef{Kind: "agent", ID: actor},
+			To:   schemacommon.RelationshipNodeRef{Kind: "tool", ID: strings.TrimSpace(intent.ToolName)},
+		})
+	}
+	if strings.TrimSpace(intent.ToolName) != "" && policyDigest != "" {
+		edges = append(edges, schemacommon.RelationshipEdge{
+			Kind: "governed_by",
+			From: schemacommon.RelationshipNodeRef{Kind: "tool", ID: strings.TrimSpace(intent.ToolName)},
+			To:   schemacommon.RelationshipNodeRef{Kind: "policy", ID: policyDigest},
+		})
+	}
+	if intent.Delegation != nil {
+		for _, link := range intent.Delegation.Chain {
+			delegator := strings.TrimSpace(link.DelegatorIdentity)
+			delegate := strings.TrimSpace(link.DelegateIdentity)
+			if delegator == "" || delegate == "" {
+				continue
+			}
+			edges = append(edges, schemacommon.RelationshipEdge{
+				Kind: "delegates_to",
+				From: schemacommon.RelationshipNodeRef{Kind: "agent", ID: delegator},
+				To:   schemacommon.RelationshipNodeRef{Kind: "agent", ID: delegate},
+			})
+		}
+	}
+	relationship.Edges = normalizeRelationshipEdges(edges)
+	return normalizeRelationshipEnvelope(&relationship)
+}
+
+func buildApprovalAuditRelationship(traceID, toolName, policyDigest string, approvers []string) *schemacommon.RelationshipEnvelope {
+	traceID = strings.TrimSpace(traceID)
+	relationship := schemacommon.RelationshipEnvelope{
+		ParentRef: &schemacommon.RelationshipNodeRef{
+			Kind: "trace",
+			ID:   traceID,
+		},
+		ParentRecordID: traceID,
+	}
+	if relationship.ParentRef.ID == "" {
+		relationship.ParentRef = nil
+	}
+	toolName = strings.TrimSpace(toolName)
+	policyDigest = strings.ToLower(strings.TrimSpace(policyDigest))
+
+	entityRefs := []schemacommon.RelationshipRef{}
+	if traceID != "" {
+		entityRefs = append(entityRefs, schemacommon.RelationshipRef{Kind: "trace", ID: traceID})
+	}
+	if toolName != "" {
+		entityRefs = append(entityRefs, schemacommon.RelationshipRef{Kind: "tool", ID: toolName})
+	}
+	if policyDigest != "" {
+		entityRefs = append(entityRefs, schemacommon.RelationshipRef{Kind: "policy", ID: policyDigest})
+		relationship.PolicyRef = &schemacommon.PolicyRef{PolicyDigest: policyDigest}
+	}
+	approvers = uniqueSorted(approvers)
+	for _, approver := range approvers {
+		if approver = strings.TrimSpace(approver); approver != "" {
+			entityRefs = append(entityRefs, schemacommon.RelationshipRef{Kind: "agent", ID: approver})
+		}
+	}
+	relationship.EntityRefs = normalizeRelationshipRefs(entityRefs)
+	relationship.RelatedEntityIDs = relationshipRefIDs(relationship.EntityRefs)
+
+	edges := []schemacommon.RelationshipEdge{}
+	if toolName != "" && policyDigest != "" {
+		edges = append(edges, schemacommon.RelationshipEdge{
+			Kind: "governed_by",
+			From: schemacommon.RelationshipNodeRef{Kind: "tool", ID: toolName},
+			To:   schemacommon.RelationshipNodeRef{Kind: "policy", ID: policyDigest},
+		})
+	}
+	relationship.Edges = normalizeRelationshipEdges(edges)
+	return normalizeRelationshipEnvelope(&relationship)
+}
+
+func buildDelegationAuditRelationship(traceID, toolName, policyDigest string, entries []schemagate.DelegationAuditEntry) *schemacommon.RelationshipEnvelope {
+	traceID = strings.TrimSpace(traceID)
+	relationship := schemacommon.RelationshipEnvelope{
+		ParentRef: &schemacommon.RelationshipNodeRef{
+			Kind: "trace",
+			ID:   traceID,
+		},
+		ParentRecordID: traceID,
+	}
+	if relationship.ParentRef.ID == "" {
+		relationship.ParentRef = nil
+	}
+	toolName = strings.TrimSpace(toolName)
+	policyDigest = strings.ToLower(strings.TrimSpace(policyDigest))
+
+	entityRefs := []schemacommon.RelationshipRef{}
+	if traceID != "" {
+		entityRefs = append(entityRefs, schemacommon.RelationshipRef{Kind: "trace", ID: traceID})
+	}
+	if toolName != "" {
+		entityRefs = append(entityRefs, schemacommon.RelationshipRef{Kind: "tool", ID: toolName})
+	}
+	if policyDigest != "" {
+		entityRefs = append(entityRefs, schemacommon.RelationshipRef{Kind: "policy", ID: policyDigest})
+		relationship.PolicyRef = &schemacommon.PolicyRef{PolicyDigest: policyDigest}
+	}
+
+	agentChain := []schemacommon.AgentLink{}
+	edges := []schemacommon.RelationshipEdge{}
+	for _, entry := range entries {
+		delegator := strings.TrimSpace(entry.DelegatorIdentity)
+		delegate := strings.TrimSpace(entry.DelegateIdentity)
+		if delegator != "" {
+			entityRefs = append(entityRefs, schemacommon.RelationshipRef{Kind: "agent", ID: delegator})
+			agentChain = append(agentChain, schemacommon.AgentLink{Identity: delegator, Role: "delegator"})
+		}
+		if delegate != "" {
+			entityRefs = append(entityRefs, schemacommon.RelationshipRef{Kind: "agent", ID: delegate})
+			agentChain = append(agentChain, schemacommon.AgentLink{Identity: delegate, Role: "delegate"})
+		}
+		if delegator != "" && delegate != "" {
+			edges = append(edges, schemacommon.RelationshipEdge{
+				Kind: "delegates_to",
+				From: schemacommon.RelationshipNodeRef{Kind: "agent", ID: delegator},
+				To:   schemacommon.RelationshipNodeRef{Kind: "agent", ID: delegate},
+			})
+		}
+	}
+	if toolName != "" && policyDigest != "" {
+		edges = append(edges, schemacommon.RelationshipEdge{
+			Kind: "governed_by",
+			From: schemacommon.RelationshipNodeRef{Kind: "tool", ID: toolName},
+			To:   schemacommon.RelationshipNodeRef{Kind: "policy", ID: policyDigest},
+		})
+	}
+
+	relationship.EntityRefs = normalizeRelationshipRefs(entityRefs)
+	relationship.RelatedEntityIDs = relationshipRefIDs(relationship.EntityRefs)
+	relationship.AgentChain = normalizeAgentChain(agentChain)
+	relationship.Edges = normalizeRelationshipEdges(edges)
+	return normalizeRelationshipEnvelope(&relationship)
+}
+
+func normalizeRelationshipEnvelope(envelope *schemacommon.RelationshipEnvelope) *schemacommon.RelationshipEnvelope {
+	if envelope == nil {
+		return nil
+	}
+	normalized := *envelope
+	normalized.ParentRecordID = strings.TrimSpace(normalized.ParentRecordID)
+	normalized.RelatedRecordIDs = uniqueSorted(normalized.RelatedRecordIDs)
+	normalized.RelatedEntityIDs = uniqueSorted(normalized.RelatedEntityIDs)
+	normalized.ParentRef = normalizeParentRef(normalized.ParentRef)
+	normalized.EntityRefs = normalizeRelationshipRefs(normalized.EntityRefs)
+	normalized.AgentChain = normalizeAgentChain(normalized.AgentChain)
+	normalized.Edges = normalizeRelationshipEdges(normalized.Edges)
+	normalized.AgentLineage = normalizeAgentLineage(normalized.AgentLineage)
+	if normalized.PolicyRef != nil {
+		normalized.PolicyRef.PolicyID = strings.TrimSpace(normalized.PolicyRef.PolicyID)
+		normalized.PolicyRef.PolicyVersion = strings.TrimSpace(normalized.PolicyRef.PolicyVersion)
+		normalized.PolicyRef.PolicyDigest = strings.ToLower(strings.TrimSpace(normalized.PolicyRef.PolicyDigest))
+		normalized.PolicyRef.MatchedRuleIDs = uniqueSorted(normalized.PolicyRef.MatchedRuleIDs)
+		if normalized.PolicyRef.PolicyID == "" &&
+			normalized.PolicyRef.PolicyVersion == "" &&
+			normalized.PolicyRef.PolicyDigest == "" &&
+			len(normalized.PolicyRef.MatchedRuleIDs) == 0 {
+			normalized.PolicyRef = nil
+		}
+	}
+	if len(normalized.RelatedEntityIDs) == 0 {
+		normalized.RelatedEntityIDs = relationshipRefIDs(normalized.EntityRefs)
+	}
+	if isRelationshipEnvelopeEmpty(normalized) {
+		return nil
+	}
+	return &normalized
+}
+
+func normalizeParentRef(ref *schemacommon.RelationshipNodeRef) *schemacommon.RelationshipNodeRef {
+	if ref == nil {
+		return nil
+	}
+	kind := strings.ToLower(strings.TrimSpace(ref.Kind))
+	id := strings.TrimSpace(ref.ID)
+	if kind == "" || id == "" {
+		return nil
+	}
+	if _, ok := allowedRelationshipParentKinds[kind]; !ok {
+		return nil
+	}
+	return &schemacommon.RelationshipNodeRef{Kind: kind, ID: id}
+}
+
+func normalizeAgentLineage(values []schemacommon.AgentLineage) []schemacommon.AgentLineage {
+	if len(values) == 0 {
+		return nil
+	}
+	out := make([]schemacommon.AgentLineage, 0, len(values))
+	seen := map[string]struct{}{}
+	for _, value := range values {
+		agentID := strings.TrimSpace(value.AgentID)
+		delegatedBy := strings.TrimSpace(value.DelegatedBy)
+		delegationRecordID := strings.TrimSpace(value.DelegationRecordID)
+		if agentID == "" {
+			continue
+		}
+		key := agentID + "\x00" + delegatedBy + "\x00" + delegationRecordID
+		if _, exists := seen[key]; exists {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, schemacommon.AgentLineage{
+			AgentID:            agentID,
+			DelegatedBy:        delegatedBy,
+			DelegationRecordID: delegationRecordID,
+		})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].AgentID != out[j].AgentID {
+			return out[i].AgentID < out[j].AgentID
+		}
+		if out[i].DelegatedBy != out[j].DelegatedBy {
+			return out[i].DelegatedBy < out[j].DelegatedBy
+		}
+		return out[i].DelegationRecordID < out[j].DelegationRecordID
+	})
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func relationshipRefIDs(refs []schemacommon.RelationshipRef) []string {
+	if len(refs) == 0 {
+		return nil
+	}
+	ids := make([]string, 0, len(refs))
+	for _, ref := range refs {
+		if id := strings.TrimSpace(ref.ID); id != "" {
+			ids = append(ids, id)
+		}
+	}
+	return uniqueSorted(ids)
+}
+
+func parentRefFromIntent(context schemagate.IntentContext) (string, string) {
+	if sessionID := strings.TrimSpace(context.SessionID); sessionID != "" {
+		return "session", sessionID
+	}
+	return "", ""
+}
+
+func normalizeRelationshipRefs(refs []schemacommon.RelationshipRef) []schemacommon.RelationshipRef {
+	if len(refs) == 0 {
+		return nil
+	}
+	normalized := make([]schemacommon.RelationshipRef, 0, len(refs))
+	seen := map[string]struct{}{}
+	for _, ref := range refs {
+		kind := strings.ToLower(strings.TrimSpace(ref.Kind))
+		id := strings.TrimSpace(ref.ID)
+		if kind == "" || id == "" {
+			continue
+		}
+		if _, ok := allowedRelationshipEntityKinds[kind]; !ok {
+			continue
+		}
+		key := kind + "\x00" + id
+		if _, exists := seen[key]; exists {
+			continue
+		}
+		seen[key] = struct{}{}
+		normalized = append(normalized, schemacommon.RelationshipRef{Kind: kind, ID: id})
+	}
+	sort.Slice(normalized, func(i, j int) bool {
+		if normalized[i].Kind != normalized[j].Kind {
+			return normalized[i].Kind < normalized[j].Kind
+		}
+		return normalized[i].ID < normalized[j].ID
+	})
+	if len(normalized) == 0 {
+		return nil
+	}
+	return normalized
+}
+
+func normalizeAgentChain(chain []schemacommon.AgentLink) []schemacommon.AgentLink {
+	if len(chain) == 0 {
+		return nil
+	}
+	normalized := make([]schemacommon.AgentLink, 0, len(chain))
+	seen := map[string]struct{}{}
+	for _, link := range chain {
+		role := strings.ToLower(strings.TrimSpace(link.Role))
+		identity := strings.TrimSpace(link.Identity)
+		if role == "" || identity == "" {
+			continue
+		}
+		if _, ok := allowedRelationshipAgentRoles[role]; !ok {
+			continue
+		}
+		key := role + "\x00" + identity
+		if _, exists := seen[key]; exists {
+			continue
+		}
+		seen[key] = struct{}{}
+		normalized = append(normalized, schemacommon.AgentLink{Role: role, Identity: identity})
+	}
+	sort.Slice(normalized, func(i, j int) bool {
+		if normalized[i].Role != normalized[j].Role {
+			return normalized[i].Role < normalized[j].Role
+		}
+		return normalized[i].Identity < normalized[j].Identity
+	})
+	if len(normalized) == 0 {
+		return nil
+	}
+	return normalized
+}
+
+func normalizeRelationshipEdges(edges []schemacommon.RelationshipEdge) []schemacommon.RelationshipEdge {
+	if len(edges) == 0 {
+		return nil
+	}
+	normalized := make([]schemacommon.RelationshipEdge, 0, len(edges))
+	seen := map[string]struct{}{}
+	for _, edge := range edges {
+		kind := strings.ToLower(strings.TrimSpace(edge.Kind))
+		fromKind := strings.ToLower(strings.TrimSpace(edge.From.Kind))
+		fromID := strings.TrimSpace(edge.From.ID)
+		toKind := strings.ToLower(strings.TrimSpace(edge.To.Kind))
+		toID := strings.TrimSpace(edge.To.ID)
+		if kind == "" || fromKind == "" || fromID == "" || toKind == "" || toID == "" {
+			continue
+		}
+		if _, ok := allowedRelationshipEdgeKinds[kind]; !ok {
+			continue
+		}
+		key := kind + "\x00" + fromKind + "\x00" + fromID + "\x00" + toKind + "\x00" + toID
+		if _, exists := seen[key]; exists {
+			continue
+		}
+		seen[key] = struct{}{}
+		normalized = append(normalized, schemacommon.RelationshipEdge{
+			Kind: kind,
+			From: schemacommon.RelationshipNodeRef{Kind: fromKind, ID: fromID},
+			To:   schemacommon.RelationshipNodeRef{Kind: toKind, ID: toID},
+		})
+	}
+	sort.Slice(normalized, func(i, j int) bool {
+		if normalized[i].Kind != normalized[j].Kind {
+			return normalized[i].Kind < normalized[j].Kind
+		}
+		if normalized[i].From.Kind != normalized[j].From.Kind {
+			return normalized[i].From.Kind < normalized[j].From.Kind
+		}
+		if normalized[i].From.ID != normalized[j].From.ID {
+			return normalized[i].From.ID < normalized[j].From.ID
+		}
+		if normalized[i].To.Kind != normalized[j].To.Kind {
+			return normalized[i].To.Kind < normalized[j].To.Kind
+		}
+		return normalized[i].To.ID < normalized[j].To.ID
+	})
+	if len(normalized) == 0 {
+		return nil
+	}
+	return normalized
+}
+
+func isRelationshipEnvelopeEmpty(envelope schemacommon.RelationshipEnvelope) bool {
+	return envelope.ParentRef == nil &&
+		len(envelope.EntityRefs) == 0 &&
+		envelope.PolicyRef == nil &&
+		len(envelope.AgentChain) == 0 &&
+		len(envelope.Edges) == 0 &&
+		strings.TrimSpace(envelope.ParentRecordID) == "" &&
+		len(envelope.RelatedRecordIDs) == 0 &&
+		len(envelope.RelatedEntityIDs) == 0 &&
+		len(envelope.AgentLineage) == 0
+}

--- a/core/gateway/ingest_test.go
+++ b/core/gateway/ingest_test.go
@@ -66,6 +66,10 @@ func TestIngestLogsKongProducesSignedPolicyEnforcementRecords(t *testing.T) {
 		if strings.TrimSpace(recordItem.Integrity.Signature) == "" || strings.TrimSpace(recordItem.Integrity.SigningKeyID) == "" {
 			t.Fatalf("expected signed record integrity payload, got %#v", recordItem.Integrity)
 		}
+		policyDigest, _ := recordItem.Event["policy_digest"].(string)
+		if strings.TrimSpace(policyDigest) == "" {
+			t.Fatalf("expected non-empty policy_digest in event payload, got %#v", recordItem.Event)
+		}
 		ok, verifyErr := sign.VerifyBytes(keyPair.Public, sign.Signature{
 			Alg:   sign.AlgEd25519,
 			KeyID: recordItem.Integrity.SigningKeyID,

--- a/core/runpack/session.go
+++ b/core/runpack/session.go
@@ -1481,7 +1481,7 @@ func selectRunpackEventActor(explicitActor string, agentChain []schemacommon.Age
 		if identity == "" {
 			continue
 		}
-		priority := 100
+		var priority int
 		switch role {
 		case "delegate":
 			priority = 0

--- a/core/schema/relationship_fixture_test.go
+++ b/core/schema/relationship_fixture_test.go
@@ -1,0 +1,294 @@
+package schema_test
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	schemagate "github.com/Clyra-AI/gait/core/schema/v1/gate"
+	schemarunpack "github.com/Clyra-AI/gait/core/schema/v1/runpack"
+	validate "github.com/Clyra-AI/proof/schema"
+)
+
+func TestRelationshipFixturesValidateAgainstSchemas(t *testing.T) {
+	repoRoot := resolveRepoRoot(t)
+	testCases := []struct {
+		name      string
+		schema    string
+		fixture   string
+		shouldErr bool
+	}{
+		{
+			name:    "intent_without_relationship",
+			schema:  "schemas/v1/gate/intent_request.schema.json",
+			fixture: "core/schema/testdata/gate_intent_request_valid.json",
+		},
+		{
+			name:    "intent_with_relationship",
+			schema:  "schemas/v1/gate/intent_request.schema.json",
+			fixture: "core/schema/testdata/gate_intent_request_relationship_valid.json",
+		},
+		{
+			name:    "trace_without_relationship",
+			schema:  "schemas/v1/gate/trace_record.schema.json",
+			fixture: "core/schema/testdata/gate_trace_record_valid.json",
+		},
+		{
+			name:    "trace_with_relationship",
+			schema:  "schemas/v1/gate/trace_record.schema.json",
+			fixture: "core/schema/testdata/gate_trace_record_relationship_valid.json",
+		},
+		{
+			name:      "trace_invalid_relationship",
+			schema:    "schemas/v1/gate/trace_record.schema.json",
+			fixture:   "core/schema/testdata/gate_trace_record_relationship_invalid.json",
+			shouldErr: true,
+		},
+		{
+			name:    "approval_audit_without_relationship",
+			schema:  "schemas/v1/gate/approval_audit_record.schema.json",
+			fixture: "core/schema/testdata/gate_approval_audit_record_valid.json",
+		},
+		{
+			name:    "approval_audit_with_relationship",
+			schema:  "schemas/v1/gate/approval_audit_record.schema.json",
+			fixture: "core/schema/testdata/gate_approval_audit_record_relationship_valid.json",
+		},
+		{
+			name:    "delegation_audit_without_relationship",
+			schema:  "schemas/v1/gate/delegation_audit_record.schema.json",
+			fixture: "core/schema/testdata/gate_delegation_audit_record_valid.json",
+		},
+		{
+			name:    "delegation_audit_with_relationship",
+			schema:  "schemas/v1/gate/delegation_audit_record.schema.json",
+			fixture: "core/schema/testdata/gate_delegation_audit_record_relationship_valid.json",
+		},
+		{
+			name:    "inventory_without_relationship",
+			schema:  "schemas/v1/scout/inventory_snapshot.schema.json",
+			fixture: "core/schema/testdata/scout_inventory_snapshot_valid.json",
+		},
+		{
+			name:    "inventory_with_relationship",
+			schema:  "schemas/v1/scout/inventory_snapshot.schema.json",
+			fixture: "core/schema/testdata/scout_inventory_snapshot_relationship_valid.json",
+		},
+		{
+			name:    "run_without_relationship",
+			schema:  "schemas/v1/runpack/run.schema.json",
+			fixture: "core/schema/testdata/run_valid.json",
+		},
+		{
+			name:    "run_with_relationship",
+			schema:  "schemas/v1/runpack/run.schema.json",
+			fixture: "core/schema/testdata/run_relationship_valid.json",
+		},
+		{
+			name:    "session_journal_without_relationship",
+			schema:  "schemas/v1/runpack/session_journal.schema.json",
+			fixture: "core/schema/testdata/session_journal_valid.json",
+		},
+		{
+			name:    "session_journal_with_relationship",
+			schema:  "schemas/v1/runpack/session_journal.schema.json",
+			fixture: "core/schema/testdata/session_journal_relationship_valid.json",
+		},
+		{
+			name:    "session_checkpoint_without_relationship",
+			schema:  "schemas/v1/runpack/session_checkpoint.schema.json",
+			fixture: "core/schema/testdata/session_checkpoint_valid.json",
+		},
+		{
+			name:    "session_checkpoint_with_relationship",
+			schema:  "schemas/v1/runpack/session_checkpoint.schema.json",
+			fixture: "core/schema/testdata/session_checkpoint_relationship_valid.json",
+		},
+		{
+			name:    "session_chain_without_relationship",
+			schema:  "schemas/v1/runpack/session_chain.schema.json",
+			fixture: "core/schema/testdata/session_chain_valid.json",
+		},
+		{
+			name:    "session_chain_with_relationship",
+			schema:  "schemas/v1/runpack/session_chain.schema.json",
+			fixture: "core/schema/testdata/session_chain_relationship_valid.json",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			schemaPath := filepath.Join(repoRoot, testCase.schema)
+			fixturePath := filepath.Join(repoRoot, testCase.fixture)
+			// #nosec G304 -- paths are repository-local constants in test table.
+			data, err := os.ReadFile(fixturePath)
+			if err != nil {
+				t.Fatalf("read fixture: %v", err)
+			}
+			err = validate.ValidateJSON(schemaPath, data)
+			if testCase.shouldErr {
+				if err == nil {
+					t.Fatalf("expected schema validation error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("validate fixture: %v", err)
+			}
+		})
+	}
+}
+
+func TestTraceRelationshipFixturePreservesDeterministicFields(t *testing.T) {
+	repoRoot := resolveRepoRoot(t)
+	baseFixture := filepath.Join(repoRoot, "core/schema/testdata/gate_trace_record_valid.json")
+	relationshipFixture := filepath.Join(repoRoot, "core/schema/testdata/gate_trace_record_relationship_valid.json")
+	base := map[string]any{}
+	withRelationship := map[string]any{}
+
+	// #nosec G304 -- paths are fixed repository-local fixtures.
+	baseRaw, err := os.ReadFile(baseFixture)
+	if err != nil {
+		t.Fatalf("read base fixture: %v", err)
+	}
+	// #nosec G304 -- paths are fixed repository-local fixtures.
+	relationshipRaw, err := os.ReadFile(relationshipFixture)
+	if err != nil {
+		t.Fatalf("read relationship fixture: %v", err)
+	}
+	if err := json.Unmarshal(baseRaw, &base); err != nil {
+		t.Fatalf("parse base fixture: %v", err)
+	}
+	if err := json.Unmarshal(relationshipRaw, &withRelationship); err != nil {
+		t.Fatalf("parse relationship fixture: %v", err)
+	}
+
+	keys := []string{"trace_id", "intent_digest", "policy_digest", "verdict"}
+	for _, key := range keys {
+		if base[key] != withRelationship[key] {
+			t.Fatalf("expected %s to remain stable, base=%v relationship=%v", key, base[key], withRelationship[key])
+		}
+	}
+}
+
+func TestBaseFixturesHaveStableByteDigests(t *testing.T) {
+	repoRoot := resolveRepoRoot(t)
+	testCases := []struct {
+		fixture        string
+		expectedSHA256 string
+	}{
+		{
+			fixture:        "core/schema/testdata/gate_trace_record_valid.json",
+			expectedSHA256: "dbf1ff6fe53e2df77c3a6846a3e76e63c97c8fee1f5706ea3fb908e34c423a3b",
+		},
+		{
+			fixture:        "core/schema/testdata/gate_intent_request_valid.json",
+			expectedSHA256: "7fc28ca4e27eb77b5a3f5e0d21ea8e97ec626388355f7139612ad2723585f7b9",
+		},
+		{
+			fixture:        "core/schema/testdata/run_valid.json",
+			expectedSHA256: "de76b8f9595d3a7df632868d0e2743202d1d102dab9eb43da5855d4196150b6d",
+		},
+		{
+			fixture:        "core/schema/testdata/session_journal_valid.json",
+			expectedSHA256: "002b158b8b8cc822555675998ae8eb97890a95b4f372dcd466c81a71c3401b43",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.fixture, func(t *testing.T) {
+			fixturePath := filepath.Join(repoRoot, testCase.fixture)
+			// #nosec G304 -- fixture path is repository-local in test table.
+			content, err := os.ReadFile(fixturePath)
+			if err != nil {
+				t.Fatalf("read fixture: %v", err)
+			}
+			digest := sha256.Sum256(content)
+			if got := hex.EncodeToString(digest[:]); got != testCase.expectedSHA256 {
+				t.Fatalf("fixture digest changed: got %s want %s", got, testCase.expectedSHA256)
+			}
+		})
+	}
+}
+
+func TestReadersTolerateUnknownAdditiveFields(t *testing.T) {
+	repoRoot := resolveRepoRoot(t)
+	testCases := []struct {
+		name    string
+		fixture string
+		decode  func([]byte) error
+	}{
+		{
+			name:    "trace_reader",
+			fixture: "core/schema/testdata/gate_trace_record_relationship_valid.json",
+			decode: func(data []byte) error {
+				var record schemagate.TraceRecord
+				return json.Unmarshal(data, &record)
+			},
+		},
+		{
+			name:    "intent_reader",
+			fixture: "core/schema/testdata/gate_intent_request_relationship_valid.json",
+			decode: func(data []byte) error {
+				var record schemagate.IntentRequest
+				return json.Unmarshal(data, &record)
+			},
+		},
+		{
+			name:    "run_reader",
+			fixture: "core/schema/testdata/run_relationship_valid.json",
+			decode: func(data []byte) error {
+				var record schemarunpack.Run
+				return json.Unmarshal(data, &record)
+			},
+		},
+		{
+			name:    "session_journal_reader",
+			fixture: "core/schema/testdata/session_journal_relationship_valid.json",
+			decode: func(data []byte) error {
+				var record schemarunpack.SessionJournal
+				return json.Unmarshal(data, &record)
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			fixturePath := filepath.Join(repoRoot, testCase.fixture)
+			// #nosec G304 -- fixture path is repository-local in test table.
+			raw, err := os.ReadFile(fixturePath)
+			if err != nil {
+				t.Fatalf("read fixture: %v", err)
+			}
+			var payload map[string]any
+			if err := json.Unmarshal(raw, &payload); err != nil {
+				t.Fatalf("parse fixture: %v", err)
+			}
+			payload["unknown_top_level"] = "additive"
+			if relationship, ok := payload["relationship"].(map[string]any); ok {
+				relationship["unknown_relationship_field"] = true
+				payload["relationship"] = relationship
+			}
+			encoded, err := json.Marshal(payload)
+			if err != nil {
+				t.Fatalf("marshal fixture: %v", err)
+			}
+			if err := testCase.decode(encoded); err != nil {
+				t.Fatalf("decode with additive fields: %v", err)
+			}
+		})
+	}
+}
+
+func resolveRepoRoot(t *testing.T) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatalf("resolve caller path")
+	}
+	return filepath.Clean(filepath.Join(filepath.Dir(file), "..", ".."))
+}

--- a/core/schema/relationship_fixture_test.go
+++ b/core/schema/relationship_fixture_test.go
@@ -1,6 +1,7 @@
 package schema_test
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -207,7 +208,7 @@ func TestBaseFixturesHaveStableByteDigests(t *testing.T) {
 			if err != nil {
 				t.Fatalf("read fixture: %v", err)
 			}
-			digest := sha256.Sum256(content)
+			digest := sha256.Sum256(normalizeFixtureLineEndings(content))
 			if got := hex.EncodeToString(digest[:]); got != testCase.expectedSHA256 {
 				t.Fatalf("fixture digest changed: got %s want %s", got, testCase.expectedSHA256)
 			}
@@ -291,4 +292,9 @@ func resolveRepoRoot(t *testing.T) string {
 		t.Fatalf("resolve caller path")
 	}
 	return filepath.Clean(filepath.Join(filepath.Dir(file), "..", ".."))
+}
+
+func normalizeFixtureLineEndings(content []byte) []byte {
+	// Keep digest checks stable across Git checkout EOL conversion on Windows.
+	return bytes.ReplaceAll(content, []byte("\r\n"), []byte("\n"))
 }

--- a/core/schema/testdata/gate_approval_audit_record_relationship_valid.json
+++ b/core/schema/testdata/gate_approval_audit_record_relationship_valid.json
@@ -1,0 +1,53 @@
+{
+  "schema_id": "gait.gate.approval_audit_record",
+  "schema_version": "1.0.0",
+  "created_at": "2026-02-05T00:00:00Z",
+  "producer_version": "0.0.0-dev",
+  "trace_id": "trace_abc123",
+  "tool_name": "tool.write",
+  "intent_digest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "policy_digest": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "required_approvals": 1,
+  "valid_approvals": 1,
+  "approved": true,
+  "approvers": ["alice"],
+  "relationship": {
+    "parent_ref": {"kind": "trace", "id": "trace_abc123"},
+    "entity_refs": [
+      {"kind": "agent", "id": "alice"},
+      {"kind": "policy", "id": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"},
+      {"kind": "tool", "id": "tool.write"},
+      {"kind": "trace", "id": "trace_abc123"}
+    ],
+    "policy_ref": {
+      "policy_id": "gait.gate.policy",
+      "policy_version": "1.0.0",
+      "policy_digest": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "matched_rule_ids": ["allow-writer"]
+    },
+    "edges": [
+      {
+        "kind": "governed_by",
+        "from": {"kind": "tool", "id": "tool.write"},
+        "to": {"kind": "policy", "id": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"}
+      }
+    ],
+    "parent_record_id": "trace_abc123",
+    "related_entity_ids": [
+      "alice",
+      "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "tool.write",
+      "trace_abc123"
+    ]
+  },
+  "entries": [
+    {
+      "token_id": "token_a",
+      "approver_identity": "alice",
+      "reason_code": "ticket-123",
+      "scope": ["tool:tool.write"],
+      "expires_at": "2026-02-05T01:00:00Z",
+      "valid": true
+    }
+  ]
+}

--- a/core/schema/testdata/gate_delegation_audit_record_relationship_valid.json
+++ b/core/schema/testdata/gate_delegation_audit_record_relationship_valid.json
@@ -1,0 +1,46 @@
+{
+  "schema_id": "gait.gate.delegation_audit_record",
+  "schema_version": "1.0.0",
+  "created_at": "2026-02-05T00:00:00Z",
+  "producer_version": "0.0.0-dev",
+  "trace_id": "trace_demo",
+  "tool_name": "tool.write",
+  "intent_digest": "1111111111111111111111111111111111111111111111111111111111111111",
+  "policy_digest": "2222222222222222222222222222222222222222222222222222222222222222",
+  "delegation_required": true,
+  "valid_delegations": 1,
+  "delegated": true,
+  "delegation_ref": "delegation_demo",
+  "relationship": {
+    "parent_ref": {"kind": "trace", "id": "trace_demo"},
+    "entity_refs": [
+      {"kind": "agent", "id": "agent.lead"},
+      {"kind": "agent", "id": "agent.specialist"},
+      {"kind": "policy", "id": "2222222222222222222222222222222222222222222222222222222222222222"},
+      {"kind": "tool", "id": "tool.write"},
+      {"kind": "trace", "id": "trace_demo"}
+    ],
+    "policy_ref": {"policy_digest": "2222222222222222222222222222222222222222222222222222222222222222"},
+    "agent_chain": [
+      {"identity": "agent.lead", "role": "delegator"},
+      {"identity": "agent.specialist", "role": "delegate"}
+    ],
+    "edges": [
+      {
+        "kind": "delegates_to",
+        "from": {"kind": "agent", "id": "agent.lead"},
+        "to": {"kind": "agent", "id": "agent.specialist"}
+      }
+    ]
+  },
+  "entries": [
+    {
+      "token_id": "delegation_demo",
+      "delegator_identity": "agent.lead",
+      "delegate_identity": "agent.specialist",
+      "scope": ["tool:tool.write"],
+      "expires_at": "2026-02-05T01:00:00Z",
+      "valid": true
+    }
+  ]
+}

--- a/core/schema/testdata/gate_intent_request_relationship_valid.json
+++ b/core/schema/testdata/gate_intent_request_relationship_valid.json
@@ -1,0 +1,42 @@
+{
+  "schema_id": "gait.gate.intent_request",
+  "schema_version": "1.0.0",
+  "created_at": "2026-02-05T00:00:00Z",
+  "producer_version": "0.0.0-dev",
+  "tool_name": "tool.demo",
+  "args": { "foo": "bar" },
+  "args_digest": "2222222222222222222222222222222222222222222222222222222222222222",
+  "targets": [
+    { "kind": "path", "value": "/tmp/out.txt" }
+  ],
+  "arg_provenance": [
+    { "arg_path": "args.foo", "source": "user" }
+  ],
+  "relationship": {
+    "parent_ref": { "kind": "session", "id": "sess_demo" },
+    "entity_refs": [
+      { "kind": "agent", "id": "agent.demo" },
+      { "kind": "tool", "id": "tool.demo" }
+    ],
+    "policy_ref": {
+      "policy_id": "gait.gate.policy",
+      "policy_version": "1.0.0",
+      "policy_digest": "3333333333333333333333333333333333333333333333333333333333333333"
+    },
+    "agent_chain": [
+      { "identity": "agent.demo", "role": "requester" }
+    ],
+    "edges": [
+      {
+        "kind": "calls",
+        "from": { "kind": "agent", "id": "agent.demo" },
+        "to": { "kind": "tool", "id": "tool.demo" }
+      }
+    ]
+  },
+  "context": {
+    "identity": "user",
+    "workspace": "/tmp/work",
+    "risk_class": "low"
+  }
+}

--- a/core/schema/testdata/gate_trace_record_relationship_invalid.json
+++ b/core/schema/testdata/gate_trace_record_relationship_invalid.json
@@ -1,0 +1,17 @@
+{
+  "schema_id": "gait.gate.trace",
+  "schema_version": "1.0.0",
+  "created_at": "2026-02-05T00:00:00Z",
+  "producer_version": "0.0.0-dev",
+  "trace_id": "trace_1",
+  "tool_name": "tool.demo",
+  "args_digest": "2222222222222222222222222222222222222222222222222222222222222222",
+  "intent_digest": "1111111111111111111111111111111111111111111111111111111111111111",
+  "policy_digest": "3333333333333333333333333333333333333333333333333333333333333333",
+  "verdict": "allow",
+  "relationship": {
+    "entity_refs": [
+      {"kind": "not_allowed", "id": "agent.demo"}
+    ]
+  }
+}

--- a/core/schema/testdata/gate_trace_record_relationship_valid.json
+++ b/core/schema/testdata/gate_trace_record_relationship_valid.json
@@ -1,0 +1,44 @@
+{
+  "schema_id": "gait.gate.trace",
+  "schema_version": "1.0.0",
+  "created_at": "2026-02-05T00:00:00Z",
+  "producer_version": "0.0.0-dev",
+  "trace_id": "trace_1",
+  "tool_name": "tool.demo",
+  "args_digest": "2222222222222222222222222222222222222222222222222222222222222222",
+  "intent_digest": "1111111111111111111111111111111111111111111111111111111111111111",
+  "policy_digest": "3333333333333333333333333333333333333333333333333333333333333333",
+  "policy_id": "gait.gate.policy",
+  "policy_version": "1.0.0",
+  "matched_rule_ids": ["allow-demo"],
+  "verdict": "allow",
+  "relationship": {
+    "parent_ref": {"kind": "session", "id": "sess_demo"},
+    "entity_refs": [
+      {"kind": "agent", "id": "agent.demo"},
+      {"kind": "tool", "id": "tool.demo"},
+      {"kind": "trace", "id": "trace_1"}
+    ],
+    "policy_ref": {
+      "policy_id": "gait.gate.policy",
+      "policy_version": "1.0.0",
+      "policy_digest": "3333333333333333333333333333333333333333333333333333333333333333",
+      "matched_rule_ids": ["allow-demo"]
+    },
+    "agent_chain": [
+      {"identity": "agent.demo", "role": "requester"}
+    ],
+    "edges": [
+      {
+        "kind": "calls",
+        "from": {"kind": "agent", "id": "agent.demo"},
+        "to": {"kind": "tool", "id": "tool.demo"}
+      },
+      {
+        "kind": "governed_by",
+        "from": {"kind": "tool", "id": "tool.demo"},
+        "to": {"kind": "policy", "id": "3333333333333333333333333333333333333333333333333333333333333333"}
+      }
+    ]
+  }
+}

--- a/core/schema/testdata/run_relationship_valid.json
+++ b/core/schema/testdata/run_relationship_valid.json
@@ -1,0 +1,29 @@
+{
+  "schema_id": "gait.runpack.run",
+  "schema_version": "1.0.0",
+  "created_at": "2026-02-05T00:00:00Z",
+  "producer_version": "0.0.0-dev",
+  "run_id": "run_demo",
+  "env": { "os": "linux", "arch": "amd64", "runtime": "go" },
+  "timeline": [
+    {
+      "event": "session_event",
+      "ts": "2026-02-05T00:00:00Z",
+      "ref": "trace_demo",
+      "relationship": {
+        "parent_ref": { "kind": "run", "id": "run_demo" },
+        "entity_refs": [
+          { "kind": "trace", "id": "trace_demo" },
+          { "kind": "tool", "id": "tool.write" }
+        ],
+        "edges": [
+          {
+            "kind": "derived_from",
+            "from": { "kind": "trace", "id": "trace_demo" },
+            "to": { "kind": "run", "id": "run_demo" }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/core/schema/testdata/scout_inventory_snapshot_relationship_valid.json
+++ b/core/schema/testdata/scout_inventory_snapshot_relationship_valid.json
@@ -1,0 +1,33 @@
+{
+  "schema_id": "gait.scout.inventory_snapshot",
+  "schema_version": "1.0.0",
+  "created_at": "2026-02-05T00:00:00Z",
+  "producer_version": "0.0.0-dev",
+  "snapshot_id": "snapshot_001",
+  "workspace": "/tmp/workspace",
+  "items": [
+    {
+      "id": "tool_1",
+      "kind": "tool",
+      "name": "tool.write",
+      "locator": "adapter://tool.write",
+      "risk_level": "high",
+      "tags": ["prod", "write"],
+      "last_seen_run": "run_demo",
+      "relationship": {
+        "parent_ref": {"kind": "evidence", "id": "snapshot_001"},
+        "entity_refs": [
+          {"kind": "resource", "id": "adapter://tool.write"},
+          {"kind": "tool", "id": "tool_1"}
+        ],
+        "edges": [
+          {
+            "kind": "derived_from",
+            "from": {"kind": "tool", "id": "tool_1"},
+            "to": {"kind": "resource", "id": "adapter://tool.write"}
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/core/schema/testdata/session_chain_relationship_valid.json
+++ b/core/schema/testdata/session_chain_relationship_valid.json
@@ -1,0 +1,31 @@
+{
+  "schema_id": "gait.runpack.session_chain",
+  "schema_version": "1.0.0",
+  "created_at": "2026-02-05T00:10:00Z",
+  "producer_version": "0.0.0-dev",
+  "session_id": "sess_demo",
+  "run_id": "run_demo",
+  "checkpoints": [
+    {
+      "schema_id": "gait.runpack.session_checkpoint",
+      "schema_version": "1.0.0",
+      "created_at": "2026-02-05T00:10:00Z",
+      "producer_version": "0.0.0-dev",
+      "session_id": "sess_demo",
+      "run_id": "run_demo",
+      "checkpoint_index": 1,
+      "sequence_start": 1,
+      "sequence_end": 5,
+      "runpack_path": "gait-out/runpack_run_demo_cp_0001.zip",
+      "manifest_digest": "3333333333333333333333333333333333333333333333333333333333333333",
+      "checkpoint_digest": "4444444444444444444444444444444444444444444444444444444444444444",
+      "relationship": {
+        "parent_ref": { "kind": "session", "id": "sess_demo" },
+        "entity_refs": [
+          { "kind": "run", "id": "run_demo" },
+          { "kind": "evidence", "id": "4444444444444444444444444444444444444444444444444444444444444444" }
+        ]
+      }
+    }
+  ]
+}

--- a/core/schema/testdata/session_checkpoint_relationship_valid.json
+++ b/core/schema/testdata/session_checkpoint_relationship_valid.json
@@ -1,0 +1,28 @@
+{
+  "schema_id": "gait.runpack.session_checkpoint",
+  "schema_version": "1.0.0",
+  "created_at": "2026-02-05T00:10:00Z",
+  "producer_version": "0.0.0-dev",
+  "session_id": "sess_demo",
+  "run_id": "run_demo",
+  "checkpoint_index": 1,
+  "sequence_start": 1,
+  "sequence_end": 5,
+  "runpack_path": "gait-out/runpack_run_demo_cp_0001.zip",
+  "manifest_digest": "3333333333333333333333333333333333333333333333333333333333333333",
+  "checkpoint_digest": "4444444444444444444444444444444444444444444444444444444444444444",
+  "relationship": {
+    "parent_ref": { "kind": "session", "id": "sess_demo" },
+    "entity_refs": [
+      { "kind": "run", "id": "run_demo" },
+      { "kind": "evidence", "id": "4444444444444444444444444444444444444444444444444444444444444444" }
+    ],
+    "edges": [
+      {
+        "kind": "derived_from",
+        "from": { "kind": "evidence", "id": "4444444444444444444444444444444444444444444444444444444444444444" },
+        "to": { "kind": "run", "id": "run_demo" }
+      }
+    ]
+  }
+}

--- a/core/schema/testdata/session_journal_relationship_valid.json
+++ b/core/schema/testdata/session_journal_relationship_valid.json
@@ -1,0 +1,81 @@
+{
+  "schema_id": "gait.runpack.session_journal",
+  "schema_version": "1.0.0",
+  "created_at": "2026-02-05T00:00:00Z",
+  "producer_version": "0.0.0-dev",
+  "session_id": "sess_demo",
+  "run_id": "run_demo",
+  "started_at": "2026-02-05T00:00:00Z",
+  "events": [
+    {
+      "schema_id": "gait.runpack.session_event",
+      "schema_version": "1.0.0",
+      "created_at": "2026-02-05T00:00:01Z",
+      "producer_version": "0.0.0-dev",
+      "session_id": "sess_demo",
+      "run_id": "run_demo",
+      "sequence": 1,
+      "tool_name": "tool.write",
+      "intent_digest": "1111111111111111111111111111111111111111111111111111111111111111",
+      "policy_digest": "2222222222222222222222222222222222222222222222222222222222222222",
+      "policy_id": "gait.gate.policy",
+      "policy_version": "1.0.0",
+      "matched_rule_ids": ["allow-writer"],
+      "verdict": "allow",
+      "relationship": {
+        "parent_ref": { "kind": "session", "id": "sess_demo" },
+        "entity_refs": [
+          { "kind": "run", "id": "run_demo" },
+          { "kind": "tool", "id": "tool.write" },
+          { "kind": "policy", "id": "2222222222222222222222222222222222222222222222222222222222222222" }
+        ],
+        "policy_ref": {
+          "policy_id": "gait.gate.policy",
+          "policy_version": "1.0.0",
+          "policy_digest": "2222222222222222222222222222222222222222222222222222222222222222",
+          "matched_rule_ids": ["allow-writer"]
+        },
+        "agent_chain": [
+          { "identity": "agent.demo", "role": "requester" }
+        ],
+        "edges": [
+          {
+            "kind": "governed_by",
+            "from": { "kind": "tool", "id": "tool.write" },
+            "to": { "kind": "policy", "id": "2222222222222222222222222222222222222222222222222222222222222222" }
+          }
+        ]
+      }
+    }
+  ],
+  "checkpoints": [
+    {
+      "schema_id": "gait.runpack.session_checkpoint",
+      "schema_version": "1.0.0",
+      "created_at": "2026-02-05T00:10:00Z",
+      "producer_version": "0.0.0-dev",
+      "session_id": "sess_demo",
+      "run_id": "run_demo",
+      "checkpoint_index": 1,
+      "sequence_start": 1,
+      "sequence_end": 1,
+      "runpack_path": "gait-out/runpack_run_demo_cp_0001.zip",
+      "manifest_digest": "3333333333333333333333333333333333333333333333333333333333333333",
+      "checkpoint_digest": "4444444444444444444444444444444444444444444444444444444444444444",
+      "relationship": {
+        "parent_ref": { "kind": "session", "id": "sess_demo" },
+        "entity_refs": [
+          { "kind": "run", "id": "run_demo" },
+          { "kind": "evidence", "id": "4444444444444444444444444444444444444444444444444444444444444444" }
+        ],
+        "edges": [
+          {
+            "kind": "derived_from",
+            "from": { "kind": "evidence", "id": "4444444444444444444444444444444444444444444444444444444444444444" },
+            "to": { "kind": "run", "id": "run_demo_cp_0001" }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/core/schema/v1/common/types.go
+++ b/core/schema/v1/common/types.go
@@ -1,0 +1,47 @@
+package common
+
+type RelationshipEnvelope struct {
+	ParentRef       *RelationshipNodeRef `json:"parent_ref,omitempty"`
+	EntityRefs      []RelationshipRef    `json:"entity_refs,omitempty"`
+	PolicyRef       *PolicyRef           `json:"policy_ref,omitempty"`
+	AgentChain      []AgentLink          `json:"agent_chain,omitempty"`
+	Edges           []RelationshipEdge   `json:"edges,omitempty"`
+	ParentRecordID  string               `json:"parent_record_id,omitempty"`
+	RelatedRecordIDs []string            `json:"related_record_ids,omitempty"`
+	RelatedEntityIDs []string            `json:"related_entity_ids,omitempty"`
+	AgentLineage    []AgentLineage       `json:"agent_lineage,omitempty"`
+}
+
+type RelationshipNodeRef struct {
+	Kind string `json:"kind"`
+	ID   string `json:"id"`
+}
+
+type RelationshipRef struct {
+	Kind string `json:"kind"`
+	ID   string `json:"id"`
+}
+
+type PolicyRef struct {
+	PolicyID       string   `json:"policy_id,omitempty"`
+	PolicyVersion  string   `json:"policy_version,omitempty"`
+	PolicyDigest   string   `json:"policy_digest,omitempty"`
+	MatchedRuleIDs []string `json:"matched_rule_ids,omitempty"`
+}
+
+type AgentLink struct {
+	Identity string `json:"identity"`
+	Role     string `json:"role"`
+}
+
+type RelationshipEdge struct {
+	Kind string              `json:"kind"`
+	From RelationshipNodeRef `json:"from"`
+	To   RelationshipNodeRef `json:"to"`
+}
+
+type AgentLineage struct {
+	AgentID            string `json:"agent_id"`
+	DelegatedBy        string `json:"delegated_by,omitempty"`
+	DelegationRecordID string `json:"delegation_record_id,omitempty"`
+}

--- a/core/schema/v1/gate/types.go
+++ b/core/schema/v1/gate/types.go
@@ -1,39 +1,47 @@
 package gate
 
-import "time"
+import (
+	"time"
+
+	schemacommon "github.com/Clyra-AI/gait/core/schema/v1/common"
+)
 
 type TraceRecord struct {
-	SchemaID            string             `json:"schema_id"`
-	SchemaVersion       string             `json:"schema_version"`
-	CreatedAt           time.Time          `json:"created_at"`
-	ObservedAt          time.Time          `json:"observed_at,omitempty"`
-	ProducerVersion     string             `json:"producer_version"`
-	TraceID             string             `json:"trace_id"`
-	EventID             string             `json:"event_id,omitempty"`
-	CorrelationID       string             `json:"correlation_id,omitempty"`
-	ToolName            string             `json:"tool_name"`
-	ArgsDigest          string             `json:"args_digest"`
-	IntentDigest        string             `json:"intent_digest"`
-	PolicyDigest        string             `json:"policy_digest"`
-	Verdict             string             `json:"verdict"`
-	ContextSetDigest    string             `json:"context_set_digest,omitempty"`
-	ContextEvidenceMode string             `json:"context_evidence_mode,omitempty"`
-	ContextRefCount     int                `json:"context_ref_count,omitempty"`
-	ContextSource       string             `json:"context_source,omitempty"`
-	Script              bool               `json:"script,omitempty"`
-	StepCount           int                `json:"step_count,omitempty"`
-	ScriptHash          string             `json:"script_hash,omitempty"`
-	CompositeRiskClass  string             `json:"composite_risk_class,omitempty"`
-	StepVerdicts        []TraceStepVerdict `json:"step_verdicts,omitempty"`
-	PreApproved         bool               `json:"pre_approved,omitempty"`
-	PatternID           string             `json:"pattern_id,omitempty"`
-	RegistryReason      string             `json:"registry_reason,omitempty"`
-	Violations          []string           `json:"violations,omitempty"`
-	LatencyMS           float64            `json:"latency_ms,omitempty"`
-	ApprovalTokenRef    string             `json:"approval_token_ref,omitempty"`
-	DelegationRef       *DelegationRef     `json:"delegation_ref,omitempty"`
-	SkillProvenance     *SkillProvenance   `json:"skill_provenance,omitempty"`
-	Signature           *Signature         `json:"signature,omitempty"`
+	SchemaID            string                             `json:"schema_id"`
+	SchemaVersion       string                             `json:"schema_version"`
+	CreatedAt           time.Time                          `json:"created_at"`
+	ObservedAt          time.Time                          `json:"observed_at,omitempty"`
+	ProducerVersion     string                             `json:"producer_version"`
+	TraceID             string                             `json:"trace_id"`
+	EventID             string                             `json:"event_id,omitempty"`
+	CorrelationID       string                             `json:"correlation_id,omitempty"`
+	ToolName            string                             `json:"tool_name"`
+	ArgsDigest          string                             `json:"args_digest"`
+	IntentDigest        string                             `json:"intent_digest"`
+	PolicyDigest        string                             `json:"policy_digest"`
+	PolicyID            string                             `json:"policy_id,omitempty"`
+	PolicyVersion       string                             `json:"policy_version,omitempty"`
+	MatchedRuleIDs      []string                           `json:"matched_rule_ids,omitempty"`
+	Verdict             string                             `json:"verdict"`
+	ContextSetDigest    string                             `json:"context_set_digest,omitempty"`
+	ContextEvidenceMode string                             `json:"context_evidence_mode,omitempty"`
+	ContextRefCount     int                                `json:"context_ref_count,omitempty"`
+	ContextSource       string                             `json:"context_source,omitempty"`
+	Script              bool                               `json:"script,omitempty"`
+	StepCount           int                                `json:"step_count,omitempty"`
+	ScriptHash          string                             `json:"script_hash,omitempty"`
+	CompositeRiskClass  string                             `json:"composite_risk_class,omitempty"`
+	StepVerdicts        []TraceStepVerdict                 `json:"step_verdicts,omitempty"`
+	PreApproved         bool                               `json:"pre_approved,omitempty"`
+	PatternID           string                             `json:"pattern_id,omitempty"`
+	RegistryReason      string                             `json:"registry_reason,omitempty"`
+	Violations          []string                           `json:"violations,omitempty"`
+	LatencyMS           float64                            `json:"latency_ms,omitempty"`
+	ApprovalTokenRef    string                             `json:"approval_token_ref,omitempty"`
+	DelegationRef       *DelegationRef                     `json:"delegation_ref,omitempty"`
+	Relationship        *schemacommon.RelationshipEnvelope `json:"relationship,omitempty"`
+	SkillProvenance     *SkillProvenance                   `json:"skill_provenance,omitempty"`
+	Signature           *Signature                         `json:"signature,omitempty"`
 }
 
 type TraceStepVerdict struct {
@@ -53,21 +61,22 @@ type Signature struct {
 }
 
 type IntentRequest struct {
-	SchemaID        string                `json:"schema_id"`
-	SchemaVersion   string                `json:"schema_version"`
-	CreatedAt       time.Time             `json:"created_at"`
-	ProducerVersion string                `json:"producer_version"`
-	ToolName        string                `json:"tool_name"`
-	Args            map[string]any        `json:"args"`
-	ArgsDigest      string                `json:"args_digest,omitempty"`
-	IntentDigest    string                `json:"intent_digest,omitempty"`
-	ScriptHash      string                `json:"script_hash,omitempty"`
-	Script          *IntentScript         `json:"script,omitempty"`
-	Targets         []IntentTarget        `json:"targets"`
-	ArgProvenance   []IntentArgProvenance `json:"arg_provenance,omitempty"`
-	SkillProvenance *SkillProvenance      `json:"skill_provenance,omitempty"`
-	Delegation      *IntentDelegation     `json:"delegation,omitempty"`
-	Context         IntentContext         `json:"context"`
+	SchemaID        string                             `json:"schema_id"`
+	SchemaVersion   string                             `json:"schema_version"`
+	CreatedAt       time.Time                          `json:"created_at"`
+	ProducerVersion string                             `json:"producer_version"`
+	ToolName        string                             `json:"tool_name"`
+	Args            map[string]any                     `json:"args"`
+	ArgsDigest      string                             `json:"args_digest,omitempty"`
+	IntentDigest    string                             `json:"intent_digest,omitempty"`
+	ScriptHash      string                             `json:"script_hash,omitempty"`
+	Script          *IntentScript                      `json:"script,omitempty"`
+	Targets         []IntentTarget                     `json:"targets"`
+	ArgProvenance   []IntentArgProvenance              `json:"arg_provenance,omitempty"`
+	SkillProvenance *SkillProvenance                   `json:"skill_provenance,omitempty"`
+	Delegation      *IntentDelegation                  `json:"delegation,omitempty"`
+	Relationship    *schemacommon.RelationshipEnvelope `json:"relationship,omitempty"`
+	Context         IntentContext                      `json:"context"`
 }
 
 type IntentScript struct {
@@ -210,19 +219,20 @@ type DelegationAuditEntry struct {
 }
 
 type DelegationAuditRecord struct {
-	SchemaID           string                 `json:"schema_id"`
-	SchemaVersion      string                 `json:"schema_version"`
-	CreatedAt          time.Time              `json:"created_at"`
-	ProducerVersion    string                 `json:"producer_version"`
-	TraceID            string                 `json:"trace_id"`
-	ToolName           string                 `json:"tool_name"`
-	IntentDigest       string                 `json:"intent_digest"`
-	PolicyDigest       string                 `json:"policy_digest"`
-	DelegationRequired bool                   `json:"delegation_required"`
-	ValidDelegations   int                    `json:"valid_delegations"`
-	Delegated          bool                   `json:"delegated"`
-	DelegationRef      string                 `json:"delegation_ref,omitempty"`
-	Entries            []DelegationAuditEntry `json:"entries"`
+	SchemaID           string                             `json:"schema_id"`
+	SchemaVersion      string                             `json:"schema_version"`
+	CreatedAt          time.Time                          `json:"created_at"`
+	ProducerVersion    string                             `json:"producer_version"`
+	TraceID            string                             `json:"trace_id"`
+	ToolName           string                             `json:"tool_name"`
+	IntentDigest       string                             `json:"intent_digest"`
+	PolicyDigest       string                             `json:"policy_digest"`
+	DelegationRequired bool                               `json:"delegation_required"`
+	ValidDelegations   int                                `json:"valid_delegations"`
+	Delegated          bool                               `json:"delegated"`
+	DelegationRef      string                             `json:"delegation_ref,omitempty"`
+	Relationship       *schemacommon.RelationshipEnvelope `json:"relationship,omitempty"`
+	Entries            []DelegationAuditEntry             `json:"entries"`
 }
 
 type ApprovalAuditEntry struct {
@@ -236,19 +246,20 @@ type ApprovalAuditEntry struct {
 }
 
 type ApprovalAuditRecord struct {
-	SchemaID          string               `json:"schema_id"`
-	SchemaVersion     string               `json:"schema_version"`
-	CreatedAt         time.Time            `json:"created_at"`
-	ProducerVersion   string               `json:"producer_version"`
-	TraceID           string               `json:"trace_id"`
-	ToolName          string               `json:"tool_name"`
-	IntentDigest      string               `json:"intent_digest"`
-	PolicyDigest      string               `json:"policy_digest"`
-	RequiredApprovals int                  `json:"required_approvals"`
-	ValidApprovals    int                  `json:"valid_approvals"`
-	Approved          bool                 `json:"approved"`
-	Approvers         []string             `json:"approvers,omitempty"`
-	Entries           []ApprovalAuditEntry `json:"entries"`
+	SchemaID          string                             `json:"schema_id"`
+	SchemaVersion     string                             `json:"schema_version"`
+	CreatedAt         time.Time                          `json:"created_at"`
+	ProducerVersion   string                             `json:"producer_version"`
+	TraceID           string                             `json:"trace_id"`
+	ToolName          string                             `json:"tool_name"`
+	IntentDigest      string                             `json:"intent_digest"`
+	PolicyDigest      string                             `json:"policy_digest"`
+	RequiredApprovals int                                `json:"required_approvals"`
+	ValidApprovals    int                                `json:"valid_approvals"`
+	Approved          bool                               `json:"approved"`
+	Approvers         []string                           `json:"approvers,omitempty"`
+	Relationship      *schemacommon.RelationshipEnvelope `json:"relationship,omitempty"`
+	Entries           []ApprovalAuditEntry               `json:"entries"`
 }
 
 type BrokerCredentialRecord struct {

--- a/core/schema/v1/runpack/types.go
+++ b/core/schema/v1/runpack/types.go
@@ -1,6 +1,10 @@
 package runpack
 
-import "time"
+import (
+	"time"
+
+	schemacommon "github.com/Clyra-AI/gait/core/schema/v1/common"
+)
 
 type Manifest struct {
 	SchemaID        string         `json:"schema_id"`
@@ -43,9 +47,10 @@ type RunEnv struct {
 }
 
 type TimelineEvt struct {
-	Event string    `json:"event"`
-	TS    time.Time `json:"ts"`
-	Ref   string    `json:"ref,omitempty"`
+	Event        string                             `json:"event"`
+	TS           time.Time                          `json:"ts"`
+	Ref          string                             `json:"ref,omitempty"`
+	Relationship *schemacommon.RelationshipEnvelope `json:"relationship,omitempty"`
 }
 
 type IntentRecord struct {
@@ -111,42 +116,47 @@ type SessionJournal struct {
 }
 
 type SessionEvent struct {
-	SchemaID        string    `json:"schema_id"`
-	SchemaVersion   string    `json:"schema_version"`
-	CreatedAt       time.Time `json:"created_at"`
-	ProducerVersion string    `json:"producer_version"`
-	SessionID       string    `json:"session_id"`
-	RunID           string    `json:"run_id"`
-	Sequence        int64     `json:"sequence"`
-	IntentID        string    `json:"intent_id,omitempty"`
-	ToolName        string    `json:"tool_name,omitempty"`
-	IntentDigest    string    `json:"intent_digest,omitempty"`
-	PolicyDigest    string    `json:"policy_digest,omitempty"`
-	TraceID         string    `json:"trace_id,omitempty"`
-	TracePath       string    `json:"trace_path,omitempty"`
-	Verdict         string    `json:"verdict,omitempty"`
-	ReasonCodes     []string  `json:"reason_codes,omitempty"`
-	Violations      []string  `json:"violations,omitempty"`
-	SafetyInvariantVersion string `json:"safety_invariant_version,omitempty"`
-	SafetyInvariantHash    string `json:"safety_invariant_hash,omitempty"`
+	SchemaID               string                             `json:"schema_id"`
+	SchemaVersion          string                             `json:"schema_version"`
+	CreatedAt              time.Time                          `json:"created_at"`
+	ProducerVersion        string                             `json:"producer_version"`
+	SessionID              string                             `json:"session_id"`
+	RunID                  string                             `json:"run_id"`
+	Sequence               int64                              `json:"sequence"`
+	IntentID               string                             `json:"intent_id,omitempty"`
+	ToolName               string                             `json:"tool_name,omitempty"`
+	IntentDigest           string                             `json:"intent_digest,omitempty"`
+	PolicyDigest           string                             `json:"policy_digest,omitempty"`
+	PolicyID               string                             `json:"policy_id,omitempty"`
+	PolicyVersion          string                             `json:"policy_version,omitempty"`
+	MatchedRuleIDs         []string                           `json:"matched_rule_ids,omitempty"`
+	TraceID                string                             `json:"trace_id,omitempty"`
+	TracePath              string                             `json:"trace_path,omitempty"`
+	Verdict                string                             `json:"verdict,omitempty"`
+	ReasonCodes            []string                           `json:"reason_codes,omitempty"`
+	Violations             []string                           `json:"violations,omitempty"`
+	Relationship           *schemacommon.RelationshipEnvelope `json:"relationship,omitempty"`
+	SafetyInvariantVersion string                             `json:"safety_invariant_version,omitempty"`
+	SafetyInvariantHash    string                             `json:"safety_invariant_hash,omitempty"`
 }
 
 type SessionCheckpoint struct {
-	SchemaID             string    `json:"schema_id"`
-	SchemaVersion        string    `json:"schema_version"`
-	CreatedAt            time.Time `json:"created_at"`
-	ProducerVersion      string    `json:"producer_version"`
-	SessionID            string    `json:"session_id"`
-	RunID                string    `json:"run_id"`
-	CheckpointIndex      int       `json:"checkpoint_index"`
-	SequenceStart        int64     `json:"sequence_start"`
-	SequenceEnd          int64     `json:"sequence_end"`
-	RunpackPath          string    `json:"runpack_path"`
-	ManifestDigest       string    `json:"manifest_digest"`
-	PrevCheckpointDigest string    `json:"prev_checkpoint_digest,omitempty"`
-	CheckpointDigest     string    `json:"checkpoint_digest"`
-	SafetyInvariantVersion string  `json:"safety_invariant_version,omitempty"`
-	SafetyInvariantHash    string  `json:"safety_invariant_hash,omitempty"`
+	SchemaID               string                             `json:"schema_id"`
+	SchemaVersion          string                             `json:"schema_version"`
+	CreatedAt              time.Time                          `json:"created_at"`
+	ProducerVersion        string                             `json:"producer_version"`
+	SessionID              string                             `json:"session_id"`
+	RunID                  string                             `json:"run_id"`
+	CheckpointIndex        int                                `json:"checkpoint_index"`
+	SequenceStart          int64                              `json:"sequence_start"`
+	SequenceEnd            int64                              `json:"sequence_end"`
+	RunpackPath            string                             `json:"runpack_path"`
+	ManifestDigest         string                             `json:"manifest_digest"`
+	PrevCheckpointDigest   string                             `json:"prev_checkpoint_digest,omitempty"`
+	CheckpointDigest       string                             `json:"checkpoint_digest"`
+	Relationship           *schemacommon.RelationshipEnvelope `json:"relationship,omitempty"`
+	SafetyInvariantVersion string                             `json:"safety_invariant_version,omitempty"`
+	SafetyInvariantHash    string                             `json:"safety_invariant_hash,omitempty"`
 }
 
 type SessionChain struct {

--- a/core/schema/v1/scout/types.go
+++ b/core/schema/v1/scout/types.go
@@ -1,6 +1,10 @@
 package scout
 
-import "time"
+import (
+	"time"
+
+	schemacommon "github.com/Clyra-AI/gait/core/schema/v1/common"
+)
 
 type InventorySnapshot struct {
 	SchemaID        string          `json:"schema_id"`
@@ -13,13 +17,14 @@ type InventorySnapshot struct {
 }
 
 type InventoryItem struct {
-	ID          string   `json:"id"`
-	Kind        string   `json:"kind"`
-	Name        string   `json:"name"`
-	Locator     string   `json:"locator"`
-	RiskLevel   string   `json:"risk_level,omitempty"`
-	Tags        []string `json:"tags,omitempty"`
-	LastSeenRun string   `json:"last_seen_run,omitempty"`
+	ID           string                             `json:"id"`
+	Kind         string                             `json:"kind"`
+	Name         string                             `json:"name"`
+	Locator      string                             `json:"locator"`
+	RiskLevel    string                             `json:"risk_level,omitempty"`
+	Tags         []string                           `json:"tags,omitempty"`
+	LastSeenRun  string                             `json:"last_seen_run,omitempty"`
+	Relationship *schemacommon.RelationshipEnvelope `json:"relationship,omitempty"`
 }
 
 type AdoptionEvent struct {

--- a/core/scout/scout_test.go
+++ b/core/scout/scout_test.go
@@ -45,6 +45,14 @@ def list_orders():
 	if len(snapshot.Items) < 4 {
 		t.Fatalf("expected at least 4 inventory items, got %d", len(snapshot.Items))
 	}
+	for _, item := range snapshot.Items {
+		if item.Relationship == nil {
+			t.Fatalf("expected inventory relationship envelope on item: %#v", item)
+		}
+		if item.Relationship.ParentRef == nil || item.Relationship.ParentRef.Kind != "evidence" || item.Relationship.ParentRef.ID != snapshot.SnapshotID {
+			t.Fatalf("unexpected inventory relationship parent_ref: %#v", item.Relationship.ParentRef)
+		}
+	}
 
 	policyPath := filepath.Join(workDir, "policy.yaml")
 	policySource := `default_verdict: block

--- a/docs/contracts/artifact_graph.md
+++ b/docs/contracts/artifact_graph.md
@@ -23,6 +23,17 @@ Applies to:
 - Cross-artifact references SHOULD use immutable identifiers (digest, run_id, trace_id) and MUST NOT rely on mutable display names.
 - Producers MUST preserve deterministic serialization for stable verification and diff behavior.
 - Consumers MUST treat unknown additive fields as non-breaking within major `v1.x`.
+- Producers MAY include a standardized optional `relationship` envelope to emit graph-ready topology with:
+  - `parent_ref`
+  - `entity_refs[]`
+  - `policy_ref`
+  - `agent_chain[]`
+  - `edges[]`
+- Relationship envelope values MUST be deterministic when present:
+  - lowercase digest identifiers
+  - deduplicated arrays
+  - stable sort order for refs and edges
+  - UTC/RFC3339 for timestamps already carried in parent artifacts
 
 ## Graph Integrity Expectations
 
@@ -35,6 +46,10 @@ Applies to:
 - A `RegressResult` SHOULD reference fixture/run identity so failures can map back to captured artifacts.
 - Evidence bundles SHOULD include pointers back to the exact runpack/trace/regress artifacts they summarize.
 - Delegation audits SHOULD reference the trace and delegation token IDs used for allow/block outcomes.
+- Trace and audit producers SHOULD include `relationship` envelopes when enough local context exists to bind:
+  - actor -> tool (`calls`)
+  - tool -> policy (`governed_by`)
+  - delegator -> delegate (`delegates_to`)
 - Consumer projections SHOULD preserve intent/receipt digest continuity (`intent_digest`, `policy_digest`, `refs.context_set_digest`, `refs.receipts[*].{query_digest,content_digest}`) when deriving audit views.
 
 ## Compatibility Model

--- a/docs/contracts/primitive_contract.md
+++ b/docs/contracts/primitive_contract.md
@@ -28,6 +28,31 @@ Intent + receipt continuity conformance profile:
 - Semantic changes to required fields MUST NOT occur without a version bump.
 - Optional fields MAY be added in minor/patch versions if consumers can ignore unknown fields safely.
 
+## Standard Relationship Envelope (`relationship`, optional)
+
+Purpose: emit graph-ready topology without changing required primitive contracts.
+
+Fields (all optional):
+
+- `parent_ref` (`kind`, `id`)
+- `entity_refs[]` (`kind`, `id`)
+- `policy_ref` (`policy_id`, `policy_version`, `policy_digest`, `matched_rule_ids[]`)
+- `agent_chain[]` (`identity`, `role`)
+- `edges[]` (`kind`, `from`, `to`)
+
+Producer obligations when present:
+
+- MUST keep `relationship` additive-only within `v1.x`.
+- MUST normalize digest identifiers to lowercase.
+- MUST deduplicate and deterministically sort `entity_refs` and `edges`.
+- MUST include relationship fields in canonical JSON hashing/signing naturally (no out-of-band exclusion).
+
+Consumer obligations:
+
+- MUST tolerate absence of `relationship`.
+- MUST ignore unknown additive fields within `relationship` in `v1.x` readers.
+- MUST NOT treat relationship presence as required for base primitive validity.
+
 ## IntentRequest (`gait.gate.intent_request`, `1.0.0`)
 
 Purpose: normalized tool-call intent at the execution boundary.
@@ -144,6 +169,7 @@ Producer obligations:
   - `context_set_digest`
   - `context_evidence_mode`
   - `context_ref_count`
+- MAY carry standardized graph links in `relationship` for topology queries.
 
 Consumer obligations:
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/Clyra-AI/gait
 go 1.25.7
 
 require (
-	github.com/Clyra-AI/proof v0.4.4
+	github.com/Clyra-AI/proof v0.4.5
 	github.com/goccy/go-yaml v1.19.2
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/Clyra-AI/proof v0.4.4 h1:JHMPthKX+2Ud3pRWSd13LKHkS04uDXHizna7T1D2mpw=
-github.com/Clyra-AI/proof v0.4.4/go.mod h1:EDff6buidj222E+EYyqQXXj1rtPgSFlYOxl2JFfWKFs=
+github.com/Clyra-AI/proof v0.4.5 h1:6l25eL8rh5x5ZTmyXdcc33kluaC3TJDWDPR5pG/cdow=
+github.com/Clyra-AI/proof v0.4.5/go.mod h1:EDff6buidj222E+EYyqQXXj1rtPgSFlYOxl2JFfWKFs=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/schemas/v1/common/relationship_envelope.schema.json
+++ b/schemas/v1/common/relationship_envelope.schema.json
@@ -1,0 +1,109 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "parent_ref": {
+      "type": "object",
+      "required": ["kind", "id"],
+      "properties": {
+        "kind": {
+          "type": "string",
+          "enum": ["trace", "run", "session", "intent", "policy", "agent", "evidence"]
+        },
+        "id": { "type": "string", "minLength": 1 }
+      }
+    },
+    "entity_refs": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "type": "object",
+        "required": ["kind", "id"],
+        "properties": {
+          "kind": {
+            "type": "string",
+            "enum": ["agent", "tool", "resource", "policy", "run", "trace", "delegation", "evidence"]
+          },
+          "id": { "type": "string", "minLength": 1 }
+        }
+      }
+    },
+    "policy_ref": {
+      "type": "object",
+      "properties": {
+        "policy_id": { "type": "string", "minLength": 1 },
+        "policy_version": { "type": "string", "minLength": 1 },
+        "policy_digest": { "type": "string", "pattern": "^(sha256:)?[a-f0-9]{64}$" },
+        "matched_rule_ids": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": { "type": "string", "minLength": 1 }
+        }
+      }
+    },
+    "agent_chain": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["identity", "role"],
+        "properties": {
+          "identity": { "type": "string", "minLength": 1 },
+          "role": { "type": "string", "enum": ["requester", "delegator", "delegate"] }
+        }
+      }
+    },
+    "edges": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "type": "object",
+        "required": ["kind", "from", "to"],
+        "properties": {
+          "kind": {
+            "type": "string",
+            "enum": ["delegates_to", "calls", "governed_by", "targets", "derived_from", "emits_evidence"]
+          },
+          "from": {
+            "type": "object",
+            "required": ["kind", "id"],
+            "properties": {
+              "kind": { "type": "string", "minLength": 1 },
+              "id": { "type": "string", "minLength": 1 }
+            }
+          },
+          "to": {
+            "type": "object",
+            "required": ["kind", "id"],
+            "properties": {
+              "kind": { "type": "string", "minLength": 1 },
+              "id": { "type": "string", "minLength": 1 }
+            }
+          }
+        }
+      }
+    },
+    "parent_record_id": { "type": "string", "minLength": 1 },
+    "related_record_ids": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "related_entity_ids": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "agent_lineage": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["agent_id"],
+        "properties": {
+          "agent_id": { "type": "string", "minLength": 1 },
+          "delegated_by": { "type": "string", "minLength": 1 },
+          "delegation_record_id": { "type": "string", "minLength": 1 }
+        }
+      }
+    }
+  }
+}

--- a/schemas/v1/gate/approval_audit_record.schema.json
+++ b/schemas/v1/gate/approval_audit_record.schema.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://gait.dev/schemas/v1/gate/approval_audit_record.schema.json",
   "title": "Approval Audit Record",
   "type": "object",
   "required": [
@@ -33,6 +32,7 @@
       "type": "array",
       "items": { "type": "string", "minLength": 1 }
     },
+    "relationship": { "$ref": "#/$defs/relationship_envelope" },
     "entries": {
       "type": "array",
       "items": {
@@ -52,6 +52,131 @@
         },
         "additionalProperties": false
       }
+    }
+  },
+  "$defs": {
+    "relationship_parent_ref": {
+      "type": "object",
+      "required": ["kind", "id"],
+      "properties": {
+        "kind": {
+          "type": "string",
+          "enum": ["trace", "run", "session", "intent", "policy", "agent", "evidence"]
+        },
+        "id": { "type": "string", "minLength": 1 }
+      },
+      "additionalProperties": false
+    },
+    "relationship_entity_ref": {
+      "type": "object",
+      "required": ["kind", "id"],
+      "properties": {
+        "kind": {
+          "type": "string",
+          "enum": ["agent", "tool", "resource", "policy", "run", "trace", "delegation", "evidence"]
+        },
+        "id": { "type": "string", "minLength": 1 }
+      },
+      "additionalProperties": false
+    },
+    "policy_ref": {
+      "type": "object",
+      "properties": {
+        "policy_id": { "type": "string", "minLength": 1 },
+        "policy_version": { "type": "string", "minLength": 1 },
+        "policy_digest": { "type": "string", "pattern": "^(sha256:)?[a-f0-9]{64}$" },
+        "matched_rule_ids": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "uniqueItems": true
+        }
+      },
+      "additionalProperties": false
+    },
+    "agent_link": {
+      "type": "object",
+      "required": ["identity", "role"],
+      "properties": {
+        "identity": { "type": "string", "minLength": 1 },
+        "role": { "type": "string", "enum": ["requester", "delegator", "delegate"] }
+      },
+      "additionalProperties": false
+    },
+    "relationship_edge": {
+      "type": "object",
+      "required": ["kind", "from", "to"],
+      "properties": {
+        "kind": {
+          "type": "string",
+          "enum": ["delegates_to", "calls", "governed_by", "targets", "derived_from", "emits_evidence"]
+        },
+        "from": {
+          "type": "object",
+          "required": ["kind", "id"],
+          "properties": {
+            "kind": { "type": "string", "minLength": 1 },
+            "id": { "type": "string", "minLength": 1 }
+          },
+          "additionalProperties": false
+        },
+        "to": {
+          "type": "object",
+          "required": ["kind", "id"],
+          "properties": {
+            "kind": { "type": "string", "minLength": 1 },
+            "id": { "type": "string", "minLength": 1 }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "agent_lineage": {
+      "type": "object",
+      "required": ["agent_id"],
+      "properties": {
+        "agent_id": { "type": "string", "minLength": 1 },
+        "delegated_by": { "type": "string", "minLength": 1 },
+        "delegation_record_id": { "type": "string", "minLength": 1 }
+      },
+      "additionalProperties": false
+    },
+    "relationship_envelope": {
+      "type": "object",
+      "properties": {
+        "parent_ref": { "$ref": "#/$defs/relationship_parent_ref" },
+        "entity_refs": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/relationship_entity_ref" },
+          "uniqueItems": true
+        },
+        "policy_ref": { "$ref": "#/$defs/policy_ref" },
+        "agent_chain": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/agent_link" }
+        },
+        "edges": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/relationship_edge" },
+          "uniqueItems": true
+        },
+        "parent_record_id": { "type": "string", "minLength": 1 },
+        "related_record_ids": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "uniqueItems": true
+        },
+        "related_entity_ids": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "uniqueItems": true
+        },
+        "agent_lineage": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/agent_lineage" }
+        }
+      },
+      "additionalProperties": false
     }
   },
   "additionalProperties": false

--- a/schemas/v1/gate/delegation_audit_record.schema.json
+++ b/schemas/v1/gate/delegation_audit_record.schema.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://gait.dev/schemas/v1/gate/delegation_audit_record.schema.json",
   "title": "Delegation Audit Record",
   "type": "object",
   "required": [
@@ -30,6 +29,7 @@
     "valid_delegations": { "type": "integer", "minimum": 0 },
     "delegated": { "type": "boolean" },
     "delegation_ref": { "type": "string" },
+    "relationship": { "$ref": "#/$defs/relationship_envelope" },
     "entries": {
       "type": "array",
       "items": {
@@ -46,6 +46,131 @@
         },
         "additionalProperties": false
       }
+    }
+  },
+  "$defs": {
+    "relationship_parent_ref": {
+      "type": "object",
+      "required": ["kind", "id"],
+      "properties": {
+        "kind": {
+          "type": "string",
+          "enum": ["trace", "run", "session", "intent", "policy", "agent", "evidence"]
+        },
+        "id": { "type": "string", "minLength": 1 }
+      },
+      "additionalProperties": false
+    },
+    "relationship_entity_ref": {
+      "type": "object",
+      "required": ["kind", "id"],
+      "properties": {
+        "kind": {
+          "type": "string",
+          "enum": ["agent", "tool", "resource", "policy", "run", "trace", "delegation", "evidence"]
+        },
+        "id": { "type": "string", "minLength": 1 }
+      },
+      "additionalProperties": false
+    },
+    "policy_ref": {
+      "type": "object",
+      "properties": {
+        "policy_id": { "type": "string", "minLength": 1 },
+        "policy_version": { "type": "string", "minLength": 1 },
+        "policy_digest": { "type": "string", "pattern": "^(sha256:)?[a-f0-9]{64}$" },
+        "matched_rule_ids": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "uniqueItems": true
+        }
+      },
+      "additionalProperties": false
+    },
+    "agent_link": {
+      "type": "object",
+      "required": ["identity", "role"],
+      "properties": {
+        "identity": { "type": "string", "minLength": 1 },
+        "role": { "type": "string", "enum": ["requester", "delegator", "delegate"] }
+      },
+      "additionalProperties": false
+    },
+    "relationship_edge": {
+      "type": "object",
+      "required": ["kind", "from", "to"],
+      "properties": {
+        "kind": {
+          "type": "string",
+          "enum": ["delegates_to", "calls", "governed_by", "targets", "derived_from", "emits_evidence"]
+        },
+        "from": {
+          "type": "object",
+          "required": ["kind", "id"],
+          "properties": {
+            "kind": { "type": "string", "minLength": 1 },
+            "id": { "type": "string", "minLength": 1 }
+          },
+          "additionalProperties": false
+        },
+        "to": {
+          "type": "object",
+          "required": ["kind", "id"],
+          "properties": {
+            "kind": { "type": "string", "minLength": 1 },
+            "id": { "type": "string", "minLength": 1 }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "agent_lineage": {
+      "type": "object",
+      "required": ["agent_id"],
+      "properties": {
+        "agent_id": { "type": "string", "minLength": 1 },
+        "delegated_by": { "type": "string", "minLength": 1 },
+        "delegation_record_id": { "type": "string", "minLength": 1 }
+      },
+      "additionalProperties": false
+    },
+    "relationship_envelope": {
+      "type": "object",
+      "properties": {
+        "parent_ref": { "$ref": "#/$defs/relationship_parent_ref" },
+        "entity_refs": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/relationship_entity_ref" },
+          "uniqueItems": true
+        },
+        "policy_ref": { "$ref": "#/$defs/policy_ref" },
+        "agent_chain": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/agent_link" }
+        },
+        "edges": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/relationship_edge" },
+          "uniqueItems": true
+        },
+        "parent_record_id": { "type": "string", "minLength": 1 },
+        "related_record_ids": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "uniqueItems": true
+        },
+        "related_entity_ids": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "uniqueItems": true
+        },
+        "agent_lineage": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/agent_lineage" }
+        }
+      },
+      "additionalProperties": false
     }
   },
   "additionalProperties": false

--- a/schemas/v1/gate/intent_request.schema.json
+++ b/schemas/v1/gate/intent_request.schema.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://gait.dev/schemas/v1/gate/intent_request.schema.json",
   "title": "Gate Intent Request",
   "type": "object",
   "required": [
@@ -199,6 +198,7 @@
       },
       "additionalProperties": false
     },
+    "relationship": { "$ref": "#/$defs/relationship_envelope" },
     "context": {
       "type": "object",
       "required": ["identity", "workspace", "risk_class"],
@@ -227,6 +227,131 @@
         }
       },
       "additionalProperties": true
+    }
+  },
+  "$defs": {
+    "relationship_parent_ref": {
+      "type": "object",
+      "required": ["kind", "id"],
+      "properties": {
+        "kind": {
+          "type": "string",
+          "enum": ["trace", "run", "session", "intent", "policy", "agent", "evidence"]
+        },
+        "id": { "type": "string", "minLength": 1 }
+      },
+      "additionalProperties": false
+    },
+    "relationship_entity_ref": {
+      "type": "object",
+      "required": ["kind", "id"],
+      "properties": {
+        "kind": {
+          "type": "string",
+          "enum": ["agent", "tool", "resource", "policy", "run", "trace", "delegation", "evidence"]
+        },
+        "id": { "type": "string", "minLength": 1 }
+      },
+      "additionalProperties": false
+    },
+    "policy_ref": {
+      "type": "object",
+      "properties": {
+        "policy_id": { "type": "string", "minLength": 1 },
+        "policy_version": { "type": "string", "minLength": 1 },
+        "policy_digest": { "type": "string", "pattern": "^(sha256:)?[a-f0-9]{64}$" },
+        "matched_rule_ids": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "uniqueItems": true
+        }
+      },
+      "additionalProperties": false
+    },
+    "agent_link": {
+      "type": "object",
+      "required": ["identity", "role"],
+      "properties": {
+        "identity": { "type": "string", "minLength": 1 },
+        "role": { "type": "string", "enum": ["requester", "delegator", "delegate"] }
+      },
+      "additionalProperties": false
+    },
+    "relationship_edge": {
+      "type": "object",
+      "required": ["kind", "from", "to"],
+      "properties": {
+        "kind": {
+          "type": "string",
+          "enum": ["delegates_to", "calls", "governed_by", "targets", "derived_from", "emits_evidence"]
+        },
+        "from": {
+          "type": "object",
+          "required": ["kind", "id"],
+          "properties": {
+            "kind": { "type": "string", "minLength": 1 },
+            "id": { "type": "string", "minLength": 1 }
+          },
+          "additionalProperties": false
+        },
+        "to": {
+          "type": "object",
+          "required": ["kind", "id"],
+          "properties": {
+            "kind": { "type": "string", "minLength": 1 },
+            "id": { "type": "string", "minLength": 1 }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "agent_lineage": {
+      "type": "object",
+      "required": ["agent_id"],
+      "properties": {
+        "agent_id": { "type": "string", "minLength": 1 },
+        "delegated_by": { "type": "string", "minLength": 1 },
+        "delegation_record_id": { "type": "string", "minLength": 1 }
+      },
+      "additionalProperties": false
+    },
+    "relationship_envelope": {
+      "type": "object",
+      "properties": {
+        "parent_ref": { "$ref": "#/$defs/relationship_parent_ref" },
+        "entity_refs": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/relationship_entity_ref" },
+          "uniqueItems": true
+        },
+        "policy_ref": { "$ref": "#/$defs/policy_ref" },
+        "agent_chain": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/agent_link" }
+        },
+        "edges": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/relationship_edge" },
+          "uniqueItems": true
+        },
+        "parent_record_id": { "type": "string", "minLength": 1 },
+        "related_record_ids": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "uniqueItems": true
+        },
+        "related_entity_ids": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "uniqueItems": true
+        },
+        "agent_lineage": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/agent_lineage" }
+        }
+      },
+      "additionalProperties": false
     }
   },
   "additionalProperties": false

--- a/schemas/v1/gate/trace_record.schema.json
+++ b/schemas/v1/gate/trace_record.schema.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://gait.dev/schemas/v1/gate/trace_record.schema.json",
   "title": "Gate Trace Record",
   "type": "object",
   "required": [
@@ -28,6 +27,12 @@
     "args_digest": { "type": "string", "pattern": "^[a-fA-F0-9]{64}$" },
     "intent_digest": { "type": "string", "pattern": "^[a-fA-F0-9]{64}$" },
     "policy_digest": { "type": "string", "pattern": "^[a-fA-F0-9]{64}$" },
+    "policy_id": { "type": "string", "minLength": 1 },
+    "policy_version": { "type": "string", "minLength": 1 },
+    "matched_rule_ids": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 }
+    },
     "verdict": { "type": "string", "enum": ["allow", "block", "dry_run", "require_approval"] },
     "context_set_digest": { "type": "string", "pattern": "^[a-fA-F0-9]{64}$" },
     "context_evidence_mode": { "type": "string", "enum": ["best_effort", "required"] },
@@ -84,6 +89,7 @@
       },
       "additionalProperties": false
     },
+    "relationship": { "$ref": "#/$defs/relationship_envelope" },
     "signature": {
       "type": "object",
       "required": ["alg", "key_id", "sig"],
@@ -92,6 +98,131 @@
         "key_id": { "type": "string" },
         "sig": { "type": "string" },
         "signed_digest": { "type": "string", "pattern": "^[a-fA-F0-9]{64}$" }
+      },
+      "additionalProperties": false
+    }
+  },
+  "$defs": {
+    "relationship_parent_ref": {
+      "type": "object",
+      "required": ["kind", "id"],
+      "properties": {
+        "kind": {
+          "type": "string",
+          "enum": ["trace", "run", "session", "intent", "policy", "agent", "evidence"]
+        },
+        "id": { "type": "string", "minLength": 1 }
+      },
+      "additionalProperties": false
+    },
+    "relationship_entity_ref": {
+      "type": "object",
+      "required": ["kind", "id"],
+      "properties": {
+        "kind": {
+          "type": "string",
+          "enum": ["agent", "tool", "resource", "policy", "run", "trace", "delegation", "evidence"]
+        },
+        "id": { "type": "string", "minLength": 1 }
+      },
+      "additionalProperties": false
+    },
+    "policy_ref": {
+      "type": "object",
+      "properties": {
+        "policy_id": { "type": "string", "minLength": 1 },
+        "policy_version": { "type": "string", "minLength": 1 },
+        "policy_digest": { "type": "string", "pattern": "^(sha256:)?[a-f0-9]{64}$" },
+        "matched_rule_ids": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "uniqueItems": true
+        }
+      },
+      "additionalProperties": false
+    },
+    "agent_link": {
+      "type": "object",
+      "required": ["identity", "role"],
+      "properties": {
+        "identity": { "type": "string", "minLength": 1 },
+        "role": { "type": "string", "enum": ["requester", "delegator", "delegate"] }
+      },
+      "additionalProperties": false
+    },
+    "relationship_edge": {
+      "type": "object",
+      "required": ["kind", "from", "to"],
+      "properties": {
+        "kind": {
+          "type": "string",
+          "enum": ["delegates_to", "calls", "governed_by", "targets", "derived_from", "emits_evidence"]
+        },
+        "from": {
+          "type": "object",
+          "required": ["kind", "id"],
+          "properties": {
+            "kind": { "type": "string", "minLength": 1 },
+            "id": { "type": "string", "minLength": 1 }
+          },
+          "additionalProperties": false
+        },
+        "to": {
+          "type": "object",
+          "required": ["kind", "id"],
+          "properties": {
+            "kind": { "type": "string", "minLength": 1 },
+            "id": { "type": "string", "minLength": 1 }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "agent_lineage": {
+      "type": "object",
+      "required": ["agent_id"],
+      "properties": {
+        "agent_id": { "type": "string", "minLength": 1 },
+        "delegated_by": { "type": "string", "minLength": 1 },
+        "delegation_record_id": { "type": "string", "minLength": 1 }
+      },
+      "additionalProperties": false
+    },
+    "relationship_envelope": {
+      "type": "object",
+      "properties": {
+        "parent_ref": { "$ref": "#/$defs/relationship_parent_ref" },
+        "entity_refs": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/relationship_entity_ref" },
+          "uniqueItems": true
+        },
+        "policy_ref": { "$ref": "#/$defs/policy_ref" },
+        "agent_chain": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/agent_link" }
+        },
+        "edges": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/relationship_edge" },
+          "uniqueItems": true
+        },
+        "parent_record_id": { "type": "string", "minLength": 1 },
+        "related_record_ids": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "uniqueItems": true
+        },
+        "related_entity_ids": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "uniqueItems": true
+        },
+        "agent_lineage": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/agent_lineage" }
+        }
       },
       "additionalProperties": false
     }

--- a/schemas/v1/runpack/run.schema.json
+++ b/schemas/v1/runpack/run.schema.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://gait.dev/schemas/v1/runpack/run.schema.json",
   "title": "Runpack Run",
   "type": "object",
   "required": [
@@ -36,10 +35,136 @@
         "properties": {
           "event": { "type": "string" },
           "ts": { "type": "string", "format": "date-time" },
-          "ref": { "type": "string" }
+          "ref": { "type": "string" },
+          "relationship": { "$ref": "#/$defs/relationship_envelope" }
         },
         "additionalProperties": true
       }
+    }
+  },
+  "$defs": {
+    "relationship_parent_ref": {
+      "type": "object",
+      "required": ["kind", "id"],
+      "properties": {
+        "kind": {
+          "type": "string",
+          "enum": ["trace", "run", "session", "intent", "policy", "agent", "evidence"]
+        },
+        "id": { "type": "string", "minLength": 1 }
+      },
+      "additionalProperties": false
+    },
+    "relationship_entity_ref": {
+      "type": "object",
+      "required": ["kind", "id"],
+      "properties": {
+        "kind": {
+          "type": "string",
+          "enum": ["agent", "tool", "resource", "policy", "run", "trace", "delegation", "evidence"]
+        },
+        "id": { "type": "string", "minLength": 1 }
+      },
+      "additionalProperties": false
+    },
+    "policy_ref": {
+      "type": "object",
+      "properties": {
+        "policy_id": { "type": "string", "minLength": 1 },
+        "policy_version": { "type": "string", "minLength": 1 },
+        "policy_digest": { "type": "string", "pattern": "^(sha256:)?[a-f0-9]{64}$" },
+        "matched_rule_ids": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "uniqueItems": true
+        }
+      },
+      "additionalProperties": false
+    },
+    "agent_link": {
+      "type": "object",
+      "required": ["identity", "role"],
+      "properties": {
+        "identity": { "type": "string", "minLength": 1 },
+        "role": { "type": "string", "enum": ["requester", "delegator", "delegate"] }
+      },
+      "additionalProperties": false
+    },
+    "relationship_edge": {
+      "type": "object",
+      "required": ["kind", "from", "to"],
+      "properties": {
+        "kind": {
+          "type": "string",
+          "enum": ["delegates_to", "calls", "governed_by", "targets", "derived_from", "emits_evidence"]
+        },
+        "from": {
+          "type": "object",
+          "required": ["kind", "id"],
+          "properties": {
+            "kind": { "type": "string", "minLength": 1 },
+            "id": { "type": "string", "minLength": 1 }
+          },
+          "additionalProperties": false
+        },
+        "to": {
+          "type": "object",
+          "required": ["kind", "id"],
+          "properties": {
+            "kind": { "type": "string", "minLength": 1 },
+            "id": { "type": "string", "minLength": 1 }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "agent_lineage": {
+      "type": "object",
+      "required": ["agent_id"],
+      "properties": {
+        "agent_id": { "type": "string", "minLength": 1 },
+        "delegated_by": { "type": "string", "minLength": 1 },
+        "delegation_record_id": { "type": "string", "minLength": 1 }
+      },
+      "additionalProperties": false
+    },
+    "relationship_envelope": {
+      "type": "object",
+      "properties": {
+        "parent_ref": { "$ref": "#/$defs/relationship_parent_ref" },
+        "entity_refs": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/relationship_entity_ref" },
+          "uniqueItems": true
+        },
+        "policy_ref": { "$ref": "#/$defs/policy_ref" },
+        "agent_chain": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/agent_link" }
+        },
+        "edges": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/relationship_edge" },
+          "uniqueItems": true
+        },
+        "parent_record_id": { "type": "string", "minLength": 1 },
+        "related_record_ids": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "uniqueItems": true
+        },
+        "related_entity_ids": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "uniqueItems": true
+        },
+        "agent_lineage": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/agent_lineage" }
+        }
+      },
+      "additionalProperties": false
     }
   },
   "additionalProperties": false

--- a/schemas/v1/runpack/session_chain.schema.json
+++ b/schemas/v1/runpack/session_chain.schema.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://gait.dev/schemas/v1/runpack/session_chain.schema.json",
   "title": "Runpack Session Chain",
   "type": "object",
   "required": [
@@ -51,10 +50,136 @@
           "runpack_path": { "type": "string", "minLength": 1 },
           "manifest_digest": { "type": "string", "pattern": "^[a-fA-F0-9]{64}$" },
           "prev_checkpoint_digest": { "type": "string", "pattern": "^[a-fA-F0-9]{64}$" },
-          "checkpoint_digest": { "type": "string", "pattern": "^[a-fA-F0-9]{64}$" }
+          "checkpoint_digest": { "type": "string", "pattern": "^[a-fA-F0-9]{64}$" },
+          "relationship": { "$ref": "#/$defs/relationship_envelope" }
         },
         "additionalProperties": false
       }
+    }
+  },
+  "$defs": {
+    "relationship_parent_ref": {
+      "type": "object",
+      "required": ["kind", "id"],
+      "properties": {
+        "kind": {
+          "type": "string",
+          "enum": ["trace", "run", "session", "intent", "policy", "agent", "evidence"]
+        },
+        "id": { "type": "string", "minLength": 1 }
+      },
+      "additionalProperties": false
+    },
+    "relationship_entity_ref": {
+      "type": "object",
+      "required": ["kind", "id"],
+      "properties": {
+        "kind": {
+          "type": "string",
+          "enum": ["agent", "tool", "resource", "policy", "run", "trace", "delegation", "evidence"]
+        },
+        "id": { "type": "string", "minLength": 1 }
+      },
+      "additionalProperties": false
+    },
+    "policy_ref": {
+      "type": "object",
+      "properties": {
+        "policy_id": { "type": "string", "minLength": 1 },
+        "policy_version": { "type": "string", "minLength": 1 },
+        "policy_digest": { "type": "string", "pattern": "^(sha256:)?[a-f0-9]{64}$" },
+        "matched_rule_ids": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "uniqueItems": true
+        }
+      },
+      "additionalProperties": false
+    },
+    "agent_link": {
+      "type": "object",
+      "required": ["identity", "role"],
+      "properties": {
+        "identity": { "type": "string", "minLength": 1 },
+        "role": { "type": "string", "enum": ["requester", "delegator", "delegate"] }
+      },
+      "additionalProperties": false
+    },
+    "relationship_edge": {
+      "type": "object",
+      "required": ["kind", "from", "to"],
+      "properties": {
+        "kind": {
+          "type": "string",
+          "enum": ["delegates_to", "calls", "governed_by", "targets", "derived_from", "emits_evidence"]
+        },
+        "from": {
+          "type": "object",
+          "required": ["kind", "id"],
+          "properties": {
+            "kind": { "type": "string", "minLength": 1 },
+            "id": { "type": "string", "minLength": 1 }
+          },
+          "additionalProperties": false
+        },
+        "to": {
+          "type": "object",
+          "required": ["kind", "id"],
+          "properties": {
+            "kind": { "type": "string", "minLength": 1 },
+            "id": { "type": "string", "minLength": 1 }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "agent_lineage": {
+      "type": "object",
+      "required": ["agent_id"],
+      "properties": {
+        "agent_id": { "type": "string", "minLength": 1 },
+        "delegated_by": { "type": "string", "minLength": 1 },
+        "delegation_record_id": { "type": "string", "minLength": 1 }
+      },
+      "additionalProperties": false
+    },
+    "relationship_envelope": {
+      "type": "object",
+      "properties": {
+        "parent_ref": { "$ref": "#/$defs/relationship_parent_ref" },
+        "entity_refs": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/relationship_entity_ref" },
+          "uniqueItems": true
+        },
+        "policy_ref": { "$ref": "#/$defs/policy_ref" },
+        "agent_chain": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/agent_link" }
+        },
+        "edges": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/relationship_edge" },
+          "uniqueItems": true
+        },
+        "parent_record_id": { "type": "string", "minLength": 1 },
+        "related_record_ids": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "uniqueItems": true
+        },
+        "related_entity_ids": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "uniqueItems": true
+        },
+        "agent_lineage": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/agent_lineage" }
+        }
+      },
+      "additionalProperties": false
     }
   },
   "additionalProperties": false

--- a/schemas/v1/runpack/session_checkpoint.schema.json
+++ b/schemas/v1/runpack/session_checkpoint.schema.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://gait.dev/schemas/v1/runpack/session_checkpoint.schema.json",
   "title": "Runpack Session Checkpoint",
   "type": "object",
   "required": [
@@ -30,7 +29,133 @@
     "runpack_path": { "type": "string", "minLength": 1 },
     "manifest_digest": { "type": "string", "pattern": "^[a-fA-F0-9]{64}$" },
     "prev_checkpoint_digest": { "type": "string", "pattern": "^[a-fA-F0-9]{64}$" },
-    "checkpoint_digest": { "type": "string", "pattern": "^[a-fA-F0-9]{64}$" }
+    "checkpoint_digest": { "type": "string", "pattern": "^[a-fA-F0-9]{64}$" },
+    "relationship": { "$ref": "#/$defs/relationship_envelope" }
+  },
+  "$defs": {
+    "relationship_parent_ref": {
+      "type": "object",
+      "required": ["kind", "id"],
+      "properties": {
+        "kind": {
+          "type": "string",
+          "enum": ["trace", "run", "session", "intent", "policy", "agent", "evidence"]
+        },
+        "id": { "type": "string", "minLength": 1 }
+      },
+      "additionalProperties": false
+    },
+    "relationship_entity_ref": {
+      "type": "object",
+      "required": ["kind", "id"],
+      "properties": {
+        "kind": {
+          "type": "string",
+          "enum": ["agent", "tool", "resource", "policy", "run", "trace", "delegation", "evidence"]
+        },
+        "id": { "type": "string", "minLength": 1 }
+      },
+      "additionalProperties": false
+    },
+    "policy_ref": {
+      "type": "object",
+      "properties": {
+        "policy_id": { "type": "string", "minLength": 1 },
+        "policy_version": { "type": "string", "minLength": 1 },
+        "policy_digest": { "type": "string", "pattern": "^(sha256:)?[a-f0-9]{64}$" },
+        "matched_rule_ids": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "uniqueItems": true
+        }
+      },
+      "additionalProperties": false
+    },
+    "agent_link": {
+      "type": "object",
+      "required": ["identity", "role"],
+      "properties": {
+        "identity": { "type": "string", "minLength": 1 },
+        "role": { "type": "string", "enum": ["requester", "delegator", "delegate"] }
+      },
+      "additionalProperties": false
+    },
+    "relationship_edge": {
+      "type": "object",
+      "required": ["kind", "from", "to"],
+      "properties": {
+        "kind": {
+          "type": "string",
+          "enum": ["delegates_to", "calls", "governed_by", "targets", "derived_from", "emits_evidence"]
+        },
+        "from": {
+          "type": "object",
+          "required": ["kind", "id"],
+          "properties": {
+            "kind": { "type": "string", "minLength": 1 },
+            "id": { "type": "string", "minLength": 1 }
+          },
+          "additionalProperties": false
+        },
+        "to": {
+          "type": "object",
+          "required": ["kind", "id"],
+          "properties": {
+            "kind": { "type": "string", "minLength": 1 },
+            "id": { "type": "string", "minLength": 1 }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "agent_lineage": {
+      "type": "object",
+      "required": ["agent_id"],
+      "properties": {
+        "agent_id": { "type": "string", "minLength": 1 },
+        "delegated_by": { "type": "string", "minLength": 1 },
+        "delegation_record_id": { "type": "string", "minLength": 1 }
+      },
+      "additionalProperties": false
+    },
+    "relationship_envelope": {
+      "type": "object",
+      "properties": {
+        "parent_ref": { "$ref": "#/$defs/relationship_parent_ref" },
+        "entity_refs": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/relationship_entity_ref" },
+          "uniqueItems": true
+        },
+        "policy_ref": { "$ref": "#/$defs/policy_ref" },
+        "agent_chain": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/agent_link" }
+        },
+        "edges": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/relationship_edge" },
+          "uniqueItems": true
+        },
+        "parent_record_id": { "type": "string", "minLength": 1 },
+        "related_record_ids": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "uniqueItems": true
+        },
+        "related_entity_ids": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "uniqueItems": true
+        },
+        "agent_lineage": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/agent_lineage" }
+        }
+      },
+      "additionalProperties": false
+    }
   },
   "additionalProperties": false
 }

--- a/schemas/v1/runpack/session_journal.schema.json
+++ b/schemas/v1/runpack/session_journal.schema.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://gait.dev/schemas/v1/runpack/session_journal.schema.json",
   "title": "Runpack Session Journal",
   "type": "object",
   "required": [
@@ -46,11 +45,18 @@
           "tool_name": { "type": "string" },
           "intent_digest": { "type": "string", "pattern": "^[a-fA-F0-9]{64}$" },
           "policy_digest": { "type": "string", "pattern": "^[a-fA-F0-9]{64}$" },
+          "policy_id": { "type": "string", "minLength": 1 },
+          "policy_version": { "type": "string", "minLength": 1 },
+          "matched_rule_ids": {
+            "type": "array",
+            "items": { "type": "string", "minLength": 1 }
+          },
           "trace_id": { "type": "string" },
           "trace_path": { "type": "string" },
           "verdict": { "type": "string", "enum": ["allow", "block", "dry_run", "require_approval"] },
           "reason_codes": { "type": "array", "items": { "type": "string" } },
           "violations": { "type": "array", "items": { "type": "string" } },
+          "relationship": { "$ref": "#/$defs/relationship_envelope" },
           "safety_invariant_version": { "type": "string", "minLength": 1 },
           "safety_invariant_hash": { "type": "string", "pattern": "^[a-fA-F0-9]{64}$" }
         },
@@ -89,11 +95,137 @@
           "manifest_digest": { "type": "string", "pattern": "^[a-fA-F0-9]{64}$" },
           "prev_checkpoint_digest": { "type": "string", "pattern": "^[a-fA-F0-9]{64}$" },
           "checkpoint_digest": { "type": "string", "pattern": "^[a-fA-F0-9]{64}$" },
+          "relationship": { "$ref": "#/$defs/relationship_envelope" },
           "safety_invariant_version": { "type": "string", "minLength": 1 },
           "safety_invariant_hash": { "type": "string", "pattern": "^[a-fA-F0-9]{64}$" }
         },
         "additionalProperties": false
       }
+    }
+  },
+  "$defs": {
+    "relationship_parent_ref": {
+      "type": "object",
+      "required": ["kind", "id"],
+      "properties": {
+        "kind": {
+          "type": "string",
+          "enum": ["trace", "run", "session", "intent", "policy", "agent", "evidence"]
+        },
+        "id": { "type": "string", "minLength": 1 }
+      },
+      "additionalProperties": false
+    },
+    "relationship_entity_ref": {
+      "type": "object",
+      "required": ["kind", "id"],
+      "properties": {
+        "kind": {
+          "type": "string",
+          "enum": ["agent", "tool", "resource", "policy", "run", "trace", "delegation", "evidence"]
+        },
+        "id": { "type": "string", "minLength": 1 }
+      },
+      "additionalProperties": false
+    },
+    "policy_ref": {
+      "type": "object",
+      "properties": {
+        "policy_id": { "type": "string", "minLength": 1 },
+        "policy_version": { "type": "string", "minLength": 1 },
+        "policy_digest": { "type": "string", "pattern": "^(sha256:)?[a-f0-9]{64}$" },
+        "matched_rule_ids": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "uniqueItems": true
+        }
+      },
+      "additionalProperties": false
+    },
+    "agent_link": {
+      "type": "object",
+      "required": ["identity", "role"],
+      "properties": {
+        "identity": { "type": "string", "minLength": 1 },
+        "role": { "type": "string", "enum": ["requester", "delegator", "delegate"] }
+      },
+      "additionalProperties": false
+    },
+    "relationship_edge": {
+      "type": "object",
+      "required": ["kind", "from", "to"],
+      "properties": {
+        "kind": {
+          "type": "string",
+          "enum": ["delegates_to", "calls", "governed_by", "targets", "derived_from", "emits_evidence"]
+        },
+        "from": {
+          "type": "object",
+          "required": ["kind", "id"],
+          "properties": {
+            "kind": { "type": "string", "minLength": 1 },
+            "id": { "type": "string", "minLength": 1 }
+          },
+          "additionalProperties": false
+        },
+        "to": {
+          "type": "object",
+          "required": ["kind", "id"],
+          "properties": {
+            "kind": { "type": "string", "minLength": 1 },
+            "id": { "type": "string", "minLength": 1 }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "agent_lineage": {
+      "type": "object",
+      "required": ["agent_id"],
+      "properties": {
+        "agent_id": { "type": "string", "minLength": 1 },
+        "delegated_by": { "type": "string", "minLength": 1 },
+        "delegation_record_id": { "type": "string", "minLength": 1 }
+      },
+      "additionalProperties": false
+    },
+    "relationship_envelope": {
+      "type": "object",
+      "properties": {
+        "parent_ref": { "$ref": "#/$defs/relationship_parent_ref" },
+        "entity_refs": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/relationship_entity_ref" },
+          "uniqueItems": true
+        },
+        "policy_ref": { "$ref": "#/$defs/policy_ref" },
+        "agent_chain": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/agent_link" }
+        },
+        "edges": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/relationship_edge" },
+          "uniqueItems": true
+        },
+        "parent_record_id": { "type": "string", "minLength": 1 },
+        "related_record_ids": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "uniqueItems": true
+        },
+        "related_entity_ids": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "uniqueItems": true
+        },
+        "agent_lineage": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/agent_lineage" }
+        }
+      },
+      "additionalProperties": false
     }
   },
   "additionalProperties": false

--- a/schemas/v1/scout/inventory_snapshot.schema.json
+++ b/schemas/v1/scout/inventory_snapshot.schema.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://gait.dev/schemas/v1/scout/inventory_snapshot.schema.json",
   "title": "Scout Inventory Snapshot",
   "type": "object",
   "required": [
@@ -30,10 +29,136 @@
           "locator": { "type": "string" },
           "risk_level": { "type": "string", "enum": ["low", "medium", "high", "critical"] },
           "tags": { "type": "array", "items": { "type": "string" } },
-          "last_seen_run": { "type": "string", "pattern": "^run_[A-Za-z0-9_-]+$" }
+          "last_seen_run": { "type": "string", "pattern": "^run_[A-Za-z0-9_-]+$" },
+          "relationship": { "$ref": "#/$defs/relationship_envelope" }
         },
         "additionalProperties": false
       }
+    }
+  },
+  "$defs": {
+    "relationship_parent_ref": {
+      "type": "object",
+      "required": ["kind", "id"],
+      "properties": {
+        "kind": {
+          "type": "string",
+          "enum": ["trace", "run", "session", "intent", "policy", "agent", "evidence"]
+        },
+        "id": { "type": "string", "minLength": 1 }
+      },
+      "additionalProperties": false
+    },
+    "relationship_entity_ref": {
+      "type": "object",
+      "required": ["kind", "id"],
+      "properties": {
+        "kind": {
+          "type": "string",
+          "enum": ["agent", "tool", "resource", "policy", "run", "trace", "delegation", "evidence"]
+        },
+        "id": { "type": "string", "minLength": 1 }
+      },
+      "additionalProperties": false
+    },
+    "policy_ref": {
+      "type": "object",
+      "properties": {
+        "policy_id": { "type": "string", "minLength": 1 },
+        "policy_version": { "type": "string", "minLength": 1 },
+        "policy_digest": { "type": "string", "pattern": "^(sha256:)?[a-f0-9]{64}$" },
+        "matched_rule_ids": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "uniqueItems": true
+        }
+      },
+      "additionalProperties": false
+    },
+    "agent_link": {
+      "type": "object",
+      "required": ["identity", "role"],
+      "properties": {
+        "identity": { "type": "string", "minLength": 1 },
+        "role": { "type": "string", "enum": ["requester", "delegator", "delegate"] }
+      },
+      "additionalProperties": false
+    },
+    "relationship_edge": {
+      "type": "object",
+      "required": ["kind", "from", "to"],
+      "properties": {
+        "kind": {
+          "type": "string",
+          "enum": ["delegates_to", "calls", "governed_by", "targets", "derived_from", "emits_evidence"]
+        },
+        "from": {
+          "type": "object",
+          "required": ["kind", "id"],
+          "properties": {
+            "kind": { "type": "string", "minLength": 1 },
+            "id": { "type": "string", "minLength": 1 }
+          },
+          "additionalProperties": false
+        },
+        "to": {
+          "type": "object",
+          "required": ["kind", "id"],
+          "properties": {
+            "kind": { "type": "string", "minLength": 1 },
+            "id": { "type": "string", "minLength": 1 }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "agent_lineage": {
+      "type": "object",
+      "required": ["agent_id"],
+      "properties": {
+        "agent_id": { "type": "string", "minLength": 1 },
+        "delegated_by": { "type": "string", "minLength": 1 },
+        "delegation_record_id": { "type": "string", "minLength": 1 }
+      },
+      "additionalProperties": false
+    },
+    "relationship_envelope": {
+      "type": "object",
+      "properties": {
+        "parent_ref": { "$ref": "#/$defs/relationship_parent_ref" },
+        "entity_refs": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/relationship_entity_ref" },
+          "uniqueItems": true
+        },
+        "policy_ref": { "$ref": "#/$defs/policy_ref" },
+        "agent_chain": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/agent_link" }
+        },
+        "edges": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/relationship_edge" },
+          "uniqueItems": true
+        },
+        "parent_record_id": { "type": "string", "minLength": 1 },
+        "related_record_ids": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "uniqueItems": true
+        },
+        "related_entity_ids": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "uniqueItems": true
+        },
+        "agent_lineage": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/agent_lineage" }
+        }
+      },
+      "additionalProperties": false
     }
   },
   "additionalProperties": false

--- a/scripts/test_ent_consumer_contract.sh
+++ b/scripts/test_ent_consumer_contract.sh
@@ -239,6 +239,21 @@ require("endpoint_destructive_operation" in (endpoint_approval.get("reason_codes
 # Enterprise consumers must tolerate additive unknown fields.
 trace_with_extension = dict(trace_record)
 trace_with_extension["enterprise_extension"] = {"opaque": True}
+trace_with_extension["relationship"] = {
+    "parent_ref": {"kind": "session", "id": "sess_demo"},
+    "entity_refs": [
+        {"kind": "agent", "id": "agent.demo"},
+        {"kind": "tool", "id": trace_record.get("tool_name", "")},
+    ],
+    "policy_ref": {"policy_digest": trace_record.get("policy_digest", "")},
+    "edges": [
+        {
+            "kind": "governed_by",
+            "from": {"kind": "tool", "id": trace_record.get("tool_name", "")},
+            "to": {"kind": "policy", "id": trace_record.get("policy_digest", "")},
+        }
+    ],
+}
 regress_with_extension = dict(regress_result)
 regress_with_extension["enterprise_extension"] = "v2"
 signal_with_extension = dict(signal_report)


### PR DESCRIPTION
## Problem
PolicyGraph-ready relationships and lineage metadata needed to be emitted consistently from day one across core artifacts (intent/trace/run/session/scout), while preserving additive compatibility and deterministic behavior. We also needed to align Gait with released `proof v0.4.5`.

## Changes
- Bumped `github.com/Clyra-AI/proof` to `v0.4.5` in `go.mod`/`go.sum`.
- Added a standard optional relationship envelope in core artifact contracts and runtime emission paths:
  - gate intent/trace/audit records
  - run/session timeline + checkpoint/session events
  - scout inventory records
- Added optional policy lineage fields beyond digest where available:
  - `policy_id`, `policy_version`, `matched_rule_ids`
- Added normalization helpers for relationship envelopes and wired lineage propagation through MCP/voice/session paths.
- Extended schema + fixture coverage for additive compatibility and invalid-shape rejection.
- Added deterministic contract tests for with/without relationship fields and unknown-field tolerance.
- Updated contract docs and enterprise consumer contract script to reflect relationship-first envelope expectations.

## Validation
- `make prepush-full`
- push hook `make prepush` (ran automatically on `git push`)
