### PR TITLE
docs: clarify integration-first adoption paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,40 @@ Docs: [clyra-ai.github.io/gait](https://clyra-ai.github.io/gait/) | Install: [`d
 
 Managed/preloaded agent note: managed agents can use Gait at the tool boundary, but Gait does not host the model or replace your agent runtime.
 
+## Integration First (New or Existing Agent Flows)
+
+The integration contract is simple:
+
+1. normalize a tool call into intent
+2. call Gait for a verdict
+3. execute real side effects only on `allow`
+4. keep the signed trace/artifact
+
+```python
+def dispatch_tool(tool_call):
+    decision = gait_evaluate(tool_call)
+    if decision["verdict"] != "allow":
+        return {"executed": False, "verdict": decision["verdict"]}
+    return {"executed": True, "result": execute_real_tool(tool_call)}
+```
+
+Pick the adoption lane that matches your stack:
+
+- Inline runtime wrapper (any language): call `gait gate eval` in your dispatcher before tool execution.
+- MCP sidecar/transport lane: `gait mcp proxy` (one-shot) or `gait mcp serve` (long-running) at the boundary.
+- Python SDK lane: use `sdk/python/gait` for ergonomics; it is intentionally a thin subprocess wrapper over the local Go `gait` binary.
+
+If you do not want Python subprocess boundaries, call `gait` directly from your runtime or use the MCP sidecar path.
+
+Start here:
+
+- Blessed lane: [`examples/integrations/openai_agents/`](examples/integrations/openai_agents/)
+- Quickstart script: `examples/integrations/openai_agents/quickstart.py`
+- Integration boundary guide: [`docs/agent_integration_boundary.md`](docs/agent_integration_boundary.md)
+- Integration checklist: [`docs/integration_checklist.md`](docs/integration_checklist.md)
+- MCP capability matrix: [`docs/mcp_capability_matrix.md`](docs/mcp_capability_matrix.md)
+- Python SDK contract: [`docs/sdk/python.md`](docs/sdk/python.md)
+
 ## When To Use Gait
 
 - Tool-calling AI agents need enforceable allow/block/approval decisions.
@@ -116,27 +150,9 @@ See: [2,880 tool calls gate-checked in 24 hours](docs/blog/openclaw_24h_boundary
 
 **Risk ranking** — rank highest-risk actions across runs and traces by tool class and blast radius. Offline, no dashboard.
 
-## Integrations
+## Additional Adapters
 
-```python
-def dispatch_tool(tool_call):
-    decision = gait_evaluate(tool_call)
-    if decision["verdict"] != "allow":
-        return {"executed": False, "verdict": decision["verdict"]}
-    return {"executed": True, "result": execute_real_tool(tool_call)}
-```
-
-Gait enforces at the tool boundary, not the prompt boundary. Your dispatcher calls Gait; non-`allow` means non-execute.
-
-Blessed lane: [`examples/integrations/openai_agents/`](examples/integrations/openai_agents/)
-
-Quickstart script: `examples/integrations/openai_agents/quickstart.py`
-
-Additional adapters: [LangChain](examples/integrations/langchain/) · [AutoGen](examples/integrations/autogen/) · [AutoGPT](examples/integrations/autogpt/) · [OpenClaw](examples/integrations/openclaw/) · [Gastown](examples/integrations/gastown/) · [Voice](examples/integrations/voice_reference/)
-
-MCP-native: `gait mcp proxy` (one-shot) | `gait mcp serve` (long-running). Details: [`docs/mcp_capability_matrix.md`](docs/mcp_capability_matrix.md)
-
-Integration boundary guide: [`docs/agent_integration_boundary.md`](docs/agent_integration_boundary.md) | Checklist: [`docs/integration_checklist.md`](docs/integration_checklist.md) | Python SDK: [`docs/sdk/python.md`](docs/sdk/python.md)
+[LangChain](examples/integrations/langchain/) · [AutoGen](examples/integrations/autogen/) · [AutoGPT](examples/integrations/autogpt/) · [OpenClaw](examples/integrations/openclaw/) · [Gastown](examples/integrations/gastown/) · [Voice](examples/integrations/voice_reference/)
 
 ## CI Adoption (One PR)
 

--- a/docs-site/src/app/page.tsx
+++ b/docs-site/src/app/page.tsx
@@ -23,6 +23,12 @@ gait verify run_demo
 # Turn it into a CI regression gate
 gait regress bootstrap --from run_demo --junit ./gait-out/junit.xml`;
 
+const INTEGRATION_SNIPPET = `def dispatch_tool(tool_call):
+    decision = gait_evaluate(tool_call)
+    if decision["verdict"] != "allow":
+        return {"executed": False, "verdict": decision["verdict"]}
+    return {"executed": True, "result": execute_real_tool(tool_call)}`;
+
 const features = [
   {
     title: 'Durable Jobs: Run Without Losing State',
@@ -156,9 +162,41 @@ export default function HomePage() {
       </div>
 
       <div className="max-w-3xl mx-auto mb-16">
+        <h2 className="text-2xl font-bold text-white mb-4 text-center">Integrate Into Existing Agent Flows</h2>
+        <p className="text-sm text-gray-300 text-center mb-4">
+          Put Gait at the tool boundary: normalize intent, evaluate verdict, execute side effects only on <code>allow</code>, keep signed trace artifacts.
+        </p>
+        <div className="grid md:grid-cols-3 gap-4 mb-5 text-sm">
+          <div className="rounded-lg border border-gray-700 bg-gray-900/40 p-4">
+            <h3 className="font-semibold text-white mb-2">Inline Wrapper</h3>
+            <p className="text-gray-300">
+              Call <code>gait gate eval</code> in your dispatcher before real tool execution.
+            </p>
+          </div>
+          <div className="rounded-lg border border-gray-700 bg-gray-900/40 p-4">
+            <h3 className="font-semibold text-white mb-2">MCP Sidecar</h3>
+            <p className="text-gray-300">
+              Use <code>gait mcp proxy</code> for one-shot calls or <code>gait mcp serve</code> for long-running boundaries.
+            </p>
+          </div>
+          <div className="rounded-lg border border-gray-700 bg-gray-900/40 p-4">
+            <h3 className="font-semibold text-white mb-2">Python SDK</h3>
+            <p className="text-gray-300">
+              Thin ergonomics layer over the local Go binary via subprocess. Prefer inline CLI or MCP path if you do not want subprocess boundaries.
+            </p>
+          </div>
+        </div>
+        <div className="bg-gray-900/60 rounded-lg border border-gray-700 p-4 overflow-x-auto mb-5">
+          <pre><code className="text-cyan-300 text-sm">{INTEGRATION_SNIPPET}</code></pre>
+        </div>
         <div className="bg-gray-800/50 rounded-lg border border-gray-700 p-4 overflow-x-auto">
           <pre><code className="text-cyan-300 text-sm">{QUICKSTART}</code></pre>
         </div>
+        <p className="text-xs text-gray-500 mt-3">
+          Start with <Link href="/docs/integration_checklist" className="text-cyan-300 hover:text-cyan-200">integration checklist</Link>,{' '}
+          <Link href="/docs/agent_integration_boundary" className="text-cyan-300 hover:text-cyan-200">boundary guide</Link>, and{' '}
+          <Link href="/docs/sdk/python" className="text-cyan-300 hover:text-cyan-200">Python SDK contract</Link>.
+        </p>
       </div>
 
       <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6 mb-16">


### PR DESCRIPTION
## Problem
README feedback asked for immediate integration clarity: how to adopt Gait in existing/new flows, whether integration is sidecar vs SDK vs other, and an explicit note that Python SDK calls a local Go binary via subprocess.

## Changes
- Reordered `README.md` to put integration-first adoption guidance near the top.
- Added explicit adoption lanes:
  - inline runtime wrapper (`gait gate eval`)
  - MCP sidecar/transport (`gait mcp proxy` / `gait mcp serve`)
  - Python SDK boundary (thin subprocess wrapper over local Go binary)
- Added direct “what developers do” integration contract and quick links.
- Kept adapter details as a concise later section.
- Mirrored this positioning surgically on docs-site homepage (`docs-site/src/app/page.tsx`) with a top integration modes block and boundary note.

## Validation
- `gait doctor --json`
- `make prepush-full`
- pre-push hook (`make prepush`) on `git push`
