### PR TITLE
update skills and proof version

### DIFF
--- a/.agents/skills/adhoc-implement/SKILL.md
+++ b/.agents/skills/adhoc-implement/SKILL.md
@@ -10,7 +10,7 @@ Execute this workflow for: "implement this plan file", "run plan from <path>", o
 
 ## Scope
 
-- Repository: `/Users/davidahmann/Projects/gait`
+- Repository: `/Users/tr/gait`
 - Mandatory input argument: `plan_path`
 - `plan_path` must point to a specific plan document provided by the user
 - No default fallback to `product/PLAN_NEXT.md`
@@ -51,6 +51,7 @@ Rules:
 ## Workflow
 
 1. Parse plan and build execution queue by dependency and priority (`P0 -> P1 -> P2`).
+   - Respect any explicit `Wave 1` before `Wave 2` sequencing in the plan.
 2. Run baseline before first edit:
 - `make lint-fast`
 - `make test-fast`
@@ -58,6 +59,8 @@ Rules:
 3. Implement one story at a time (no parallel story execution).
 4. For each story:
 - implement scoped code/docs/tests only
+- keep orchestration thin when architecture is touched; move parsing, persistence, reporting, or policy logic into focused packages instead of coordinator layers
+- make side effects explicit in API names/signatures and preserve symmetric semantics unless the distinction is intentionally named
 - run story `Run commands`
 - run story `Test requirements`
 - run story `Matrix wiring` lanes
@@ -79,6 +82,15 @@ When collecting evidence or emitting machine-readable status, use `gait` command
 
 - `gait doctor --json`
 - `gait gate eval --policy examples/policy/strict.yaml --intent examples/policy/intents/file_delete.json --json`
+
+## Contract Discipline Rules
+
+- If a story changes public CLI/SDK/schema surfaces, update stable/internal/deprecated surface notes in the same change.
+- If versioning or schema compatibility behavior changes, document what is breaking vs additive and the migration expectation in the same story.
+- If errors cross CLI or SDK boundaries, preserve structured machine-readable errors and stable mappings.
+- If a story touches long-running workflows, verify cancellation and timeout propagation end-to-end.
+- If enterprise customization pressure appears in scope, prefer explicit extension points over fork-only designs when feasible.
+- For user-facing docs, explain integration hooks before internals and keep `README.md`, repo docs, and generated/public docs in sync.
 
 ## Test Requirements by Work Type (Mandatory)
 
@@ -136,12 +148,19 @@ No story is complete if any required lane is skipped or failing.
 
 ## Surgical Docs Sync Rule
 
-- If a story changes user-visible behavior, update only impacted docs in the same story:
-- `/Users/davidahmann/Projects/gait/README.md`
-- `/Users/davidahmann/Projects/gait/docs/`
-- `/Users/davidahmann/Projects/gait/docs-site/public/llms.txt`
-- `/Users/davidahmann/Projects/gait/docs-site/public/llm/*.md`
-- If internal-only behavior with no user-visible impact, avoid unnecessary doc churn.
+If a story changes user-visible behavior, update only impacted docs in the same story:
+- `/Users/tr/gait/README.md`
+- `/Users/tr/gait/docs/`
+- `/Users/tr/gait/docs-site/public/llms.txt`
+- `/Users/tr/gait/docs-site/public/llm/*.md`
+- `/Users/tr/gait/CONTRIBUTING.md`
+- `/Users/tr/gait/CHANGELOG.md`
+- `/Users/tr/gait/CODE_OF_CONDUCT.md`
+- `/Users/tr/gait/SECURITY.md`
+- `/Users/tr/gait/.github/ISSUE_TEMPLATE/`
+- `/Users/tr/gait/.github/pull_request_template.md`
+
+If internal-only behavior with no user-visible impact, avoid unnecessary doc churn.
 
 ## Safety Rules
 
@@ -157,6 +176,8 @@ No story is complete if any required lane is skipped or failing.
 - Do not claim tests ran if they were not run.
 - Tests must use temp dirs for generated artifacts; do not leak test outputs into tracked source paths.
 - If docs/CLI drift occurs due to user-visible changes, patch docs in same story.
+- Keep README first-screen coverage crisp: what it is, who it is for, how it integrates, and how to get value quickly.
+- Keep one docs source of truth and update generated/public derivatives in the same story.
 
 ## Blocker Handling
 

--- a/.agents/skills/adhoc-plan/SKILL.md
+++ b/.agents/skills/adhoc-plan/SKILL.md
@@ -10,9 +10,9 @@ Execute this workflow when the user asks to turn recommended items into a concre
 
 ## Scope
 
-- Repository root: `/Users/davidahmann/Projects/gait`
+- Repository root: `/Users/tr/gait`
 - Recommendation source: user-provided recommended items for this run
-- No dependency on `/Users/davidahmann/Projects/gait/product/ideas.md`
+- No dependency on `/Users/tr/gait/product/ideas.md`
 - Planning-only skill. Do not implement code in this workflow.
 
 ## Input Contract (Mandatory)
@@ -34,7 +34,7 @@ Validation rules:
 - expected moat/benefit
 2. Remove duplicates and out-of-scope items.
 3. Cluster recommendations into coherent epics.
-4. Prioritize with `P0/P1/P2` using contract risk, moat gain, adoption leverage, and dependency order.
+4. Prioritize with `P0/P1/P2` using contract risk, moat gain, adoption leverage, and dependency order. Sequence work in waves: `Wave 1` contract/runtime correctness and architecture boundaries, `Wave 2` docs, OSS hygiene, and distribution UX.
 5. Create execution-ready stories with:
 - tasks
 - repo paths
@@ -42,6 +42,7 @@ Validation rules:
 - test requirements
 - matrix wiring
 - acceptance criteria
+- If a story affects public surfaces, include stable/internal boundary notes, migration expectations, and where users integrate Gait into their code or pipeline.
 6. Add plan-level `Test Matrix Wiring`.
 7. Add `Recommendation Traceability` mapping recommendations to epic/story IDs.
 8. Add `Minimum-Now Sequence`, `Exit Criteria`, and `Definition of Done`.
@@ -66,6 +67,12 @@ Use `gait` commands with `--json` whenever the plan needs machine-readable evide
 - Respect architecture boundaries:
 - Go core authoritative for enforcement/verification
 - Python remains thin adoption layer
+- Treat architecture as enforceable code boundaries, not doc-only intent.
+- Prefer thin orchestration and focused packages for parsing, persistence, reporting, and policy logic.
+- Make side effects explicit in names/signatures and avoid ambiguous `plan` vs `apply` or `read` vs `read+validate` semantics.
+- Public-surface stories must cover versioning/deprecation expectations, machine-readable error behavior, and install/version discoverability where relevant.
+- Long-running workflow stories must include cancellation/timeout propagation expectations.
+- Prefer extension points over enterprise forks when the recommendation implies customization pressure.
 - No dashboard-first scope in core backlog.
 - No minor polish as primary backlog.
 - Every story must include tests and matrix wiring.
@@ -109,6 +116,10 @@ Use `gait` commands with `--json` whenever the plan needs machine-readable evide
 8. Docs/examples changes:
 - docs consistency checks
 - storyline/smoke checks when user flow changes
+- README/quickstart/integration coverage checks when public docs change
+- install/version discoverability checks when onboarding changes
+- docs source-of-truth sync tasks for `README.md`, `docs/`, `docs-site/public/llms.txt`, and `docs-site/public/llm/*.md`
+- OSS trust-baseline updates when public launch/support expectations change
 
 ## Test Matrix Wiring Contract (Plan-Level)
 
@@ -162,6 +173,9 @@ Before finalizing:
 - Test requirements match story type.
 - Matrix wiring exists for every story.
 - Sequence is dependency-aware and implementation-ready.
+- Wave 1 contract/runtime work precedes Wave 2 docs/OSS/distribution work.
+- Public/internal boundaries, integration hooks, and side effects are explicit where stories affect user-facing surfaces.
+- Launch-facing plans include OSS trust-baseline and docs source-of-truth work when relevant.
 
 ## Failure Mode
 

--- a/.agents/skills/app-audit/SKILL.md
+++ b/.agents/skills/app-audit/SKILL.md
@@ -10,29 +10,48 @@ Execute this workflow when asked to perform app review, release readiness, archi
 
 ## Scope
 
-- Repository: `/Users/davidahmann/Projects/gait`
+- Repository: `/Users/tr/gait`
 - Analyze current code/docs only; do not invent features/markets.
 - Default mode is read-only unless user explicitly asks for fixes.
 
 ## Workflow
 
-1. Build whiteboard mental model from onboarding to sustained use.
-2. Map personas, JTBD, and MVP user-story coverage.
-3. List required inputs/config/secrets/dependencies and setup friction.
-4. Evaluate “aha” moments per primary user story.
-5. Run technical validation on affected surfaces (build/lint/tests as needed).
+1. Build whiteboard mental model from first-screen README/onboarding to sustained use.
+2. Map personas, JTBD, MVP user-story coverage, and the first-10-minutes experience.
+3. Audit architecture boundaries and code organization:
+   - orchestration thickness vs focused packages
+   - explicit side effects in API names/signatures
+   - symmetry of public semantics (`plan` vs `apply`, `read` vs `read+validate`)
+   - timeout/cancellation propagation in long-running flows
+   - extension points vs likely enterprise forks
+4. Audit public contract surfaces:
+   - stable vs internal surface map
+   - schema/versioning policy clarity and migration expectations
+   - machine-readable error support for library or SDK consumers
+   - install/version discoverability
+5. List required inputs/config/secrets/dependencies and setup friction.
 6. Audit docs for integration clarity:
-   - where Gait sits in runtime path
-   - what is customer code vs Gait vs tool/provider
-   - sync vs async behavior and failure handling
-7. Compare stated product intent vs implemented behavior.
-8. Assess security posture and fail-closed guarantees.
-9. Assess market wedge sharpness for existing personas only.
-10. Produce final go/no-go verdict with minimum blocker set.
+   - README first screen answers what it is, who it is for, how it integrates, and how to get value quickly
+   - integration before internals
+   - problem -> solution framing before primitive lists
+   - file/state lifecycle and canonical path model
+   - single docs source of truth and how generated/public docs derive from repo docs
+7. Audit OSS trust baseline:
+   - `CONTRIBUTING.md`, `CHANGELOG.md`, `CODE_OF_CONDUCT.md`, `SECURITY.md`
+   - issue/PR templates
+   - maintainer/org context and support expectations
+   - standalone vs ecosystem dependency clarity
+   - public vs private planning artifact choices
+8. Run technical validation on affected surfaces (build/lint/tests as needed).
+9. Compare stated product intent vs implemented behavior.
+10. Assess security posture and fail-closed guarantees.
+11. Assess market wedge sharpness for existing personas only.
+12. Produce final go/no-go verdict with minimum blocker set.
 
 ## Non-Negotiables
 
 - Evidence-first: every claim must cite command output or file path.
+- Contract-first: evaluate behavior, boundaries, and integration guarantees before polish.
 - Boundary-first: explicitly separate ownership and integration points.
 - Incident-first: lead with failure scenarios and operational impact.
 - No cosmetics as blockers.
@@ -55,11 +74,12 @@ Execute this workflow when asked to perform app review, release readiness, archi
 
 - Section 1: End-to-end product model
 - Section 2: Persona/story coverage map
-- Section 3: Inputs/config friction table
-- Section 4: Aha analysis
-- Section 5: Technical audit + release readiness
-- Section 6: Business/market fit assessment
-- Section 7: Final verdict (go/no-go) + top 3 launch risks
+- Section 3: Contract and boundary audit
+- Section 4: Inputs/install/config friction table
+- Section 5: Docs and OSS trust-baseline audit
+- Section 6: Technical audit + release readiness
+- Section 7: Business/market fit assessment
+- Section 8: Final verdict (go/no-go) + top 3 launch risks
 
 Each section must include:
 - Findings

--- a/.agents/skills/backlog-plan/SKILL.md
+++ b/.agents/skills/backlog-plan/SKILL.md
@@ -10,15 +10,14 @@ Execute this workflow when asked to convert strategic feature recommendations in
 
 ## Scope
 
-- Repository root: `/Users/davidahmann/Projects/gait`
-- Input file: `/Users/davidahmann/Projects/gait/product/ideas.md`
+- Repository root: `/Users/tr/gait`
+- Input file: `/Users/tr/gait/product/ideas.md`
 - Structure references (match level of detail and style):
-- `/Users/davidahmann/Projects/gait/product/PLAN_v1.md`
-- `/Users/davidahmann/Projects/gait/product/PLAN_v1.7.md`
-- `/Users/davidahmann/Projects/gait/product/PLAN_HARDENING.md`
-- `/Users/davidahmann/Projects/gait/product/PLAN_ADOPTION.md`
-- `/Users/davidahmann/Projects/gait/product/PLAN_ENT.md`
-- Output file: `/Users/davidahmann/Projects/gait/product/PLAN_NEXT.md` (unless user specifies a different target)
+- `/Users/tr/gait/product/PLAN_v1.md`
+- `/Users/tr/gait/product/PLAN_v1.7.md`
+- `/Users/tr/gait/product/PLAN_HARDENING.md`
+- `/Users/tr/gait/product/PLAN_ADOPTION.md`
+- Output file: `/Users/tr/gait/product/PLAN_NEXT.md` (unless user specifies a different target)
 - Planning only. Do not implement code or docs outside the target plan file.
 
 ## Preconditions
@@ -38,13 +37,13 @@ If these are missing, stop and output a gap note instead of inventing details.
 1. Read `ideas.md` and extract candidate initiatives.
 2. Read reference plans to mirror structure and detail level.
 3. Cluster ideas into coherent epics (avoid one-idea-per-epic fragmentation).
-4. Prioritize using `P0/P1/P2` based on contract risk reduction, moat expansion, adoption leverage, and sequencing dependency.
+4. Prioritize using `P0/P1/P2` based on contract risk reduction, moat expansion, adoption leverage, and sequencing dependency. Sequence work in waves: `Wave 1` for contract/runtime correctness and architecture boundaries, `Wave 2` for docs, OSS hygiene, and distribution UX.
 5. Produce execution-ready epics and stories.
-6. For every story, include concrete tasks, repo paths, run commands, acceptance criteria, test requirements, and CI matrix wiring.
+6. For every story, include concrete tasks, repo paths, run commands, acceptance criteria, test requirements, and CI matrix wiring. If a story touches public surfaces, require explicit notes for stable/internal boundaries, migration expectations, and where users integrate Gait into their code or pipeline.
 7. Build a plan-level test matrix section mapping stories to CI lanes (fast, integration, acceptance, cross-platform).
 8. Ensure each story defines tests based on work type (schema, CLI, gate/policy, determinism, runtime, SDK, docs/examples).
-9. Add explicit boundaries and non-goals to prevent scope drift.
-10. Add delivery sequencing section (phase/week-based minimum-now path).
+9. Add explicit boundaries, ownership, and non-goals to prevent scope drift.
+10. Add delivery sequencing section (phase/week-based minimum-now path) that keeps docs/OSS/distribution work after the enabling contract/runtime work.
 11. Add definition of done and release/exit gate criteria.
 12. Write full plan to target file, overwriting prior contents.
 
@@ -52,6 +51,12 @@ If these are missing, stop and output a gap note instead of inventing details.
 
 - Preserve Gait core contracts: determinism, offline-first defaults, fail-closed policy posture, schema stability, and exit code stability.
 - Respect architecture boundaries: Go core is authoritative for enforcement/verification logic; Python remains thin adoption layer.
+- Treat architecture as enforceable boundaries in code, not aspirational docs.
+- Prefer thin orchestration and focused packages for parsing, persistence, reporting, and policy logic.
+- Make side effects explicit in names/signatures and avoid asymmetric public semantics unless the distinction is named directly.
+- Public-surface stories must cover API stability/deprecation notes, schema/versioning expectations, machine-readable error behavior, and install/version discoverability where relevant.
+- Long-running workflow stories must account for timeout/cancellation propagation end-to-end.
+- Add extension points early when enterprise adoption would otherwise require forks.
 - Avoid dashboard-first or hosted-only dependencies in backlog core.
 - Do not include implementation code, pseudo-code, or ticket boilerplate.
 - Do not recommend minor polish work as primary backlog items.
@@ -93,6 +98,10 @@ If these are missing, stop and output a gap note instead of inventing details.
 7. Docs/examples contract changes:
 - Add command-smoke checks for documented flows.
 - Add docs-versus-CLI parity checks where possible.
+- Add README/quickstart/integration smoke checks for `what it is`, `who it is for`, `how it integrates`, and `first value` coverage when public docs change.
+- Add install/version discoverability checks (`gait version`, minimal install path) when operator onboarding changes.
+- Add docs source-of-truth sync tasks for `README.md`, `docs/`, `docs-site/public/llms.txt`, and `docs-site/public/llm/*.md`.
+- Add OSS trust-baseline updates (`CONTRIBUTING.md`, `CHANGELOG.md`, `CODE_OF_CONDUCT.md`, `SECURITY.md`, issue/PR templates) when launch/distribution expectations change.
 - Update acceptance scripts if docs alter required operator path.
 
 ## Test Matrix Wiring Contract (Plan-Level)
@@ -146,6 +155,9 @@ Before finalizing, verify:
 - Test requirements match story work type.
 - Matrix wiring is present for every story.
 - Sequence is dependency-aware.
+- Wave 1 contract/runtime work lands before Wave 2 docs/OSS/distribution work.
+- Public/internal boundaries, integration points, and side effects are explicit where stories touch user-facing surfaces.
+- Launch-facing plans cover OSS trust baseline and docs source-of-truth responsibilities when relevant.
 - Plan stays strategic and execution-relevant (not cosmetic).
 
 ## Command Anchors

--- a/.agents/skills/branches-clean/SKILL.md
+++ b/.agents/skills/branches-clean/SKILL.md
@@ -10,7 +10,7 @@ Execute this workflow when asked to clean up branches by deleting all non-`main`
 
 ## Scope
 
-- Repository: `/Users/davidahmann/Projects/gait`
+- Repository: `/Users/tr/gait`
 - Target: all non-`main` branches
 - Deletion style: one-by-one only (no grouped delete commands)
 - Applies to:

--- a/.agents/skills/code-review/SKILL.md
+++ b/.agents/skills/code-review/SKILL.md
@@ -11,15 +11,17 @@ Execute this workflow for: "review the codebase", "audit repo health", "run a fu
 ## Reviewer Personality
 
 - Contract-first: behavior and guarantees over style.
+- Boundary-first: controls belong at the execution boundary, not prompt/UI layers.
 - Regression-first: look for latent breakage paths.
 - Fail-closed safety bias: block safety/control weakening.
+- Determinism required: same input/state should produce the same decisions and artifacts.
 - Scenario-driven: each finding includes concrete break path and impact.
 - Portability-aware: Linux/macOS/CI/toolchain/path behavior.
 - Signal over noise: findings-first, severity-ranked output.
 
 ## Scope
 
-- Repository root: `/Users/davidahmann/Projects/gait`
+- Repository root: `/Users/tr/gait`
 - Review entire repo, not only current diffs.
 - Prioritize high-risk surfaces first, then remaining components.
 
@@ -30,20 +32,25 @@ Execute this workflow for: "review the codebase", "audit repo health", "run a fu
 3. `core/mcp` and adapter boundaries
 4. `sdk/python` wrapper behavior and error mapping
 5. `schemas/v1` and compatibility-sensitive artifacts
-6. `docs`, `README.md`, and `docs-site` command/contract accuracy
+6. `docs`, `README.md`, `docs-site`, OSS baseline files, and `.github` workflow/template surfaces
 
 ## Workflow
 
-1. Build repository map and contract map from code/tests/help text.
+1. Build repository map and contract map from code/tests/help text, including stable/internal/deprecated surfaces, schema/version/CLI/exit-code compatibility rules, authoritative-core boundaries, and docs source-of-truth flow.
 2. Run baseline validation where feasible (lint/build/tests) and record gaps if not run.
 3. Review each subsystem for:
-   - Safety/control bypasses
-   - Determinism or reproducibility breaks
-   - Integrity verification weakening
-   - False-green test/CI paths
-   - Portability/toolchain/path assumptions
-   - Schema/CLI contract drift
-   - Docs/examples that do not match real behavior
+   - Enforceable boundary violations, including controls living in prompt/UI paths instead of execution/runtime boundaries
+   - Contract drift before logic drift: schema/version/CLI/exit-code breaks, non-additive evolution, or missing dual-reader compatibility
+   - Public APIs that hide side effects, blur `plan` vs `apply`, or weaken scoped approvals, out-of-band stop, and destructive-budget safety patterns
+   - Missing timeout/cancellation propagation, crash-safe state handling, lock/permission discipline, or contention coverage in long-running flows
+   - Fail-closed gaps where ambiguity in high-risk paths can silently allow instead of block
+   - Determinism or reproducibility breaks across decisions, hashes, traces, diagnostics, and artifacts for the same input/state
+   - Authoritative-core leaks where wrappers/SDKs duplicate policy, signing, verification, or other decision logic
+   - Missing machine-readable failures: stable JSON envelopes, error taxonomy, retryability hints, or consistent error mapping on public boundaries
+   - Missing operator observability: deterministic `doctor` output, correlation IDs, or local structured logs
+   - False-green CI/release paths, including risk-tiered lane gaps (fast/core/acceptance/cross-platform/chaos/perf), weak merge policy wiring, supply-chain verification gaps, or missing post-merge regression monitoring
+   - Weak adoption architecture: unclear quickstart, missing expected outputs/integration diagrams, or troubleshooting-only-afterthought docs
+   - Governance and launch drift: missing ADRs, risk register, explicit non-goals, definition-of-done, or OSS trust-baseline artifacts
 4. Verify findings with concrete evidence (file refs, commands, test output).
 5. Rank findings by severity and confidence.
 6. Report minimum blocker set for safe release posture.
@@ -71,6 +78,7 @@ Execute this workflow for: "review the codebase", "audit repo health", "run a fu
 - Do not report style nits unless they cause runtime/contract risk.
 - Do not claim tests/commands were run if they were not.
 - Separate facts from inference.
+- Prefer the smallest finding that exposes the broken contract or unsafe boundary.
 - If no findings, explicitly state `No material findings` and list residual risks/testing gaps.
 
 ## Command Anchors
@@ -89,3 +97,4 @@ Execute this workflow for: "review the codebase", "audit repo health", "run a fu
    - technical health today
    - minimum blockers (if any)
    - top 3 risk concentrations
+   - merge/release confidence given current CI, observability, and release-integrity posture

--- a/.agents/skills/commit-push/SKILL.md
+++ b/.agents/skills/commit-push/SKILL.md
@@ -10,7 +10,7 @@ Execute this workflow for: "commit/push/open PR", "ship this branch", "merge aft
 
 ## Scope
 
-- Repository: `/Users/davidahmann/Projects/gait`
+- Repository: `/Users/tr/gait`
 - Works on current local branch, then merges into `main`.
 - No GitHub issue creation.
 - PR text must use heredoc EOF bodies (no inline `--body` strings).
@@ -63,18 +63,60 @@ If preconditions fail, stop and report.
 - flaky/infra/transient
 - permission/workflow policy failure
 
-8. Merge PR after green:
+8. Codex review settle gate (mandatory, passive, latest-head preferred):
+- After PR creation/update and green CI, inspect Codex review output before merge.
+- Poll PR reviews/comments/reactions every `15s` for up to `5 minutes`, preferring signals tied to the latest PR head SHA.
+- Never post `@codex review` or any other PR/issue comment solely to solicit review.
+- Default reviewer identity for this gate: `chatgpt-codex-connector` (GitHub UI may render as `chatgpt-codex-connector bot`).
+- Accepted settle signals on the latest PR head:
+- actionable Codex review comments/suggestions -> proceed to pre-merge fix loop
+- explicit approval/all-good signal -> review gate satisfied
+- Codex-authored `+1` / thumbs-up on PR body, issue comment, or review comment -> review gate satisfied when required PR CI is green and no unresolved `P0/P1` Codex items remain
+- If no latest-head signal appears within timeout, fall back to PR-wide Codex review inventory:
+- collect prior Codex reviews, inline comments, issue comments, and Codex-authored `+1` / thumbs-up reactions on the PR
+- require at least one prior Codex review artifact before permitting `carry_forward`
+- if required PR CI is green and no unresolved `P0/P1` Codex items remain, treat gate as satisfied as `carry_forward`
+- if unresolved `P0/P1` Codex items remain, stop and report blocker
+- if no prior Codex review artifact exists, stop and report blocker
+- if Codex explicitly reports service/quota failure for automatic review, stop and report blocker
+- Do not create a new GitHub comment to force or retry review.
+
+9. Pre-merge unresolved comment triage and fix loop (max 2 loops):
+- Fetch unresolved PR review threads/comments, preferring latest-head Codex items first and then any still-open carry-forward `P0/P1` items from earlier heads.
+- Triage each unresolved item as `implement`, `blocked`, `defer`, `reject`, or `already_satisfied`.
+- Resolve the corresponding GitHub review thread for `implement` or `already_satisfied` items once they are satisfied on the current head.
+- Do not resolve threads for `blocked`, `defer`, or `reject`.
+- Auto-fix only `implement` items that are:
+- `P0/P1`, or
+- high-confidence `P2` with concrete repro or break path
+- For each fix loop:
+- apply the minimal scoped fix on the same PR branch
+- run `make prepush-full`
+- `git add -A`
+- `git commit -m "fix: address actionable PR comments (loop <n>)"` (skip only if no changes)
+- push branch
+- re-watch PR CI to green
+- resolve satisfied GitHub review threads/comments
+- re-run the passive Codex review settle gate on the new latest PR head SHA
+- re-fetch unresolved threads/comments
+- If unresolved `P0/P1` items remain after loop cap, stop and report blocker.
+
+10. Merge PR after green and review gate satisfied:
+- Merge only when all are true on the latest PR head SHA:
+- required PR CI is green
+- Codex review settle gate is satisfied (`approved`, `thumbs_up`, `actionable` resolved, or `carry_forward`)
+- no unresolved `P0/P1` review items remain
 - Merge non-interactively (repo-default merge strategy or explicitly chosen one).
 - Record merged PR URL and merge commit SHA.
 
-9. Switch to main and sync:
+11. Switch to main and sync:
 - `git checkout main`
 - `git pull --ff-only origin main`
 
-10. Monitor post-merge CI on `main`:
+12. Monitor post-merge CI on `main`:
 - Watch the latest `main` CI run with timeout `25 minutes`.
 
-11. Hotfix loop on post-merge red (max 2 loops):
+13. Hotfix loop on post-merge red (max 2 loops):
 - Run only for actionable failures.
 - Loop cap: `2`.
 - For each loop:
@@ -90,8 +132,10 @@ If preconditions fail, stop and report.
 - `git checkout main && git pull --ff-only origin main`
 - Monitor post-merge CI again (25 min timeout).
 
-12. Stop conditions:
+14. Stop conditions:
 - CI green on main: success.
+- Codex gate unresolved after passive latest-head poll plus PR-wide carry-forward triage: stop and report blocker.
+- Unresolved pre-merge `P0/P1` comments after 2 fix loops: stop and report blocker.
 - Non-actionable failure class: stop and report.
 - Loop count exceeded (`>2`): stop and report blocker.
 
@@ -100,6 +144,8 @@ If preconditions fail, stop and report.
 - `gait doctor --json` before ship to capture machine-readable local readiness evidence.
 - `gait pack verify <artifact.zip> --json` when validating artifact integrity in a failing CI path.
 - `gait gate eval --policy <policy.yaml> --intent <intent.json> --json` when policy-path checks are implicated.
+- Use `gh pr view --json number,headRefOid` and `gh repo view --json nameWithOwner` to seed Codex review inspection.
+- Use `gh api` against PR reviews, review comments, issue comments, and their reactions to inspect latest-head Codex signals and carry-forward artifacts.
 
 ## EOF Rule (Mandatory)
 
@@ -116,13 +162,19 @@ Never use inline `--body "..."` for multi-line PR text.
 - Never use destructive git commands unless explicitly requested.
 - Never amend commits unless explicitly requested.
 - Never create duplicate PRs for the same head branch.
-- Keep fixes scoped to CI failure root cause.
+- Never post `@codex review` or equivalent review-trigger comments.
+- Never merge with unresolved `P0/P1` Codex review items.
+- Never leave an implemented Codex review thread unresolved before merge.
+- Keep fixes scoped to the CI or review root cause.
 - If unexpected repo state appears, stop and ask.
 
 ## CI Policy
 
 - Required local gate before push: `make prepush-full` (includes CodeQL in this repo).
 - PR CI watch timeout: `25 minutes`.
+- Codex review settle polling interval: `15 seconds`.
+- Codex review settle timeout: `5 minutes` (mandatory pre-merge gate; passive only, no trigger comments).
+- Pre-merge comment-fix loop cap: `2`.
 - Post-merge main CI watch timeout: `25 minutes`.
 - Retry/hotfix loop cap: `2`.
 
@@ -132,6 +184,8 @@ Never use inline `--body "..."` for multi-line PR text.
 - Commit SHA(s)
 - PR URL(s)
 - CI status per cycle
+- Codex review settle status per cycle
+- Resolved review thread/comment refs
 - Merge commit SHA(s)
 - Post-merge CI status on `main`
 - If stopped: blocker reason and last failing check

--- a/.agents/skills/cut-release/SKILL.md
+++ b/.agents/skills/cut-release/SKILL.md
@@ -10,7 +10,7 @@ Execute this workflow for: "cut release", "ship vX.Y.Z", "push tag and monitor r
 
 ## Scope
 
-- Repository: `/Users/davidahmann/Projects/gait`
+- Repository: `/Users/tr/gait`
 - Tag source branch: `main` only
 - No pre-release branch creation
 - No pre-release PR creation

--- a/.agents/skills/feature-discovery/SKILL.md
+++ b/.agents/skills/feature-discovery/SKILL.md
@@ -10,11 +10,11 @@ Execute this workflow when asked to identify strategic upgrades for Gait based o
 
 ## Scope
 
-- Project context: `/Users/davidahmann/Projects/gait`
+- Project context: `/Users/tr/gait`
 - Date anchor: determine the current local date/time at runtime before collecting sources.
 - Time window: exactly the last 7 days from the run date (inclusive), using that runtime date anchor.
 - Focus: AI/agent developments materially relevant to Gait’s durable runtime, policy enforcement, provenance, fail-closed execution, and enterprise adoption.
-- Output target: `/Users/davidahmann/Projects/gait/product/ideas.md`
+- Output target: `/Users/tr/gait/product/ideas.md`
 - This skill is strategy-only. No implementation tasks.
 
 ## Workflow

--- a/.agents/skills/plan-implement/SKILL.md
+++ b/.agents/skills/plan-implement/SKILL.md
@@ -10,9 +10,9 @@ Execute this workflow for: "implement the plan", "execute PLAN_NEXT", "ship plan
 
 ## Scope
 
-- Repository: `/Users/davidahmann/Projects/gait`
-- Default input plan: `/Users/davidahmann/Projects/gait/product/PLAN_NEXT.md`
-- Optional input plan: user-specified file under `/Users/davidahmann/Projects/gait/product/`
+- Repository: `/Users/tr/gait`
+- Default input plan: `/Users/tr/gait/product/PLAN_NEXT.md`
+- Optional input plan: user-specified file under `/Users/tr/gait/product/`
 - This skill executes code/docs/tests for planned stories.
 - Out of scope by default:
 - GitHub issue creation
@@ -49,6 +49,7 @@ Rules:
 1. Parse plan and build execution queue:
 - Follow `Minimum-Now Sequence` first.
 - Respect dependencies and `P0 -> P1 -> P2`.
+- Respect any explicit `Wave 1` before `Wave 2` sequencing in the plan.
 
 2. Run baseline before first code change:
 - `make lint-fast`
@@ -57,6 +58,8 @@ Rules:
 
 3. Execute one story at a time:
 - Implement only scoped story changes.
+- Keep orchestration thin when story scope touches architecture; move parsing, persistence, reporting, or policy logic into focused packages instead of coordinator layers.
+- Make side effects explicit in API names/signatures and preserve symmetric semantics unless the distinction is intentionally named.
 - Update tests required by story type.
 - Update docs surgically only if user-facing behavior changed.
 - Do not start next story until current story is validated.
@@ -86,6 +89,15 @@ Rules:
 - `gait doctor --json` to verify local environment and dependency readiness before implementation.
 - `gait gate eval --policy <policy.yaml> --intent <intent.json> --json` for policy-story contract checks.
 - `gait pack verify <artifact.zip> --json` for artifact-story integrity checks.
+
+## Contract Discipline Rules
+
+- If a story changes public CLI/SDK/schema surfaces, update the stable/internal/deprecated surface notes in the same change.
+- If versioning or schema compatibility behavior changes, document what is breaking vs additive and the migration expectation in the same story.
+- If errors cross CLI or SDK boundaries, preserve structured machine-readable errors and stable mappings.
+- If a story touches long-running workflows, verify cancellation and timeout propagation end-to-end.
+- If enterprise customization pressure appears in scope, prefer explicit extension points over fork-only designs when feasible.
+- For user-facing docs, explain integration hooks before internals and keep `README.md`, repo docs, and generated/public docs in sync.
 
 ## Test Requirements by Work Type (Mandatory)
 
@@ -145,10 +157,16 @@ No story is complete without passing its mapped lanes.
 
 If a story introduces user-visible behavior changes, update only impacted docs in the same story:
 
-- `/Users/davidahmann/Projects/gait/README.md`
-- `/Users/davidahmann/Projects/gait/docs/`
-- `/Users/davidahmann/Projects/gait/docs-site/public/llms.txt`
-- `/Users/davidahmann/Projects/gait/docs-site/public/llm/*.md`
+- `/Users/tr/gait/README.md`
+- `/Users/tr/gait/docs/`
+- `/Users/tr/gait/docs-site/public/llms.txt`
+- `/Users/tr/gait/docs-site/public/llm/*.md`
+- `/Users/tr/gait/CONTRIBUTING.md`
+- `/Users/tr/gait/CHANGELOG.md`
+- `/Users/tr/gait/CODE_OF_CONDUCT.md`
+- `/Users/tr/gait/SECURITY.md`
+- `/Users/tr/gait/.github/ISSUE_TEMPLATE/`
+- `/Users/tr/gait/.github/pull_request_template.md`
 
 If story is internal-only and behavior is unchanged, do not force doc churn.
 
@@ -167,6 +185,8 @@ If story is internal-only and behavior is unchanged, do not force doc churn.
 - No silent skips of required checks.
 - Tests must use temp output paths (no artifact leakage into source tree).
 - If code/docs drift is introduced by user-facing change, patch docs in same story.
+- Keep README first-screen coverage crisp: what it is, who it is for, how it integrates, and how to get value quickly.
+- Keep one docs source of truth and update generated/public derivatives in the same story.
 
 ## Blocker Handling
 

--- a/.agents/skills/pr-comments/SKILL.md
+++ b/.agents/skills/pr-comments/SKILL.md
@@ -10,7 +10,7 @@ Execute this workflow when asked to review PR comments from agents/Codex and rec
 
 ## Scope
 
-- Repository context: `/Users/davidahmann/Projects/gait`
+- Repository context: `/Users/tr/gait`
 - Input PRs: user-provided PR number(s)
 - Mode: analysis and recommendation only (read-only by default)
 - No code changes, commits, or pushes in this skill unless explicitly requested in a follow-up

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/Clyra-AI/gait
 go 1.25.7
 
 require (
-	github.com/Clyra-AI/proof v0.4.5
+	github.com/Clyra-AI/proof v0.4.6
 	github.com/goccy/go-yaml v1.19.2
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/Clyra-AI/proof v0.4.5 h1:6l25eL8rh5x5ZTmyXdcc33kluaC3TJDWDPR5pG/cdow=
 github.com/Clyra-AI/proof v0.4.5/go.mod h1:EDff6buidj222E+EYyqQXXj1rtPgSFlYOxl2JFfWKFs=
+github.com/Clyra-AI/proof v0.4.6 h1:k7WMrpOvuS9IZWj+5smbOFEXla8A5CXoOsGtNQ/xqQ4=
+github.com/Clyra-AI/proof v0.4.6/go.mod h1:EDff6buidj222E+EYyqQXXj1rtPgSFlYOxl2JFfWKFs=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
## Summary

## Testing

- [ ] `make fmt`
- [ ] `make lint`
- [ ] `make test`

## Hardening Review

- [ ] Failure classification impact reviewed (`error_category`, `error_code`, retryability)
- [ ] Exit code contract impact reviewed (no accidental contract break)
- [ ] Deterministic output impact reviewed (`--json`, artifacts, golden fixtures)
- [ ] Security/privacy impact reviewed (secrets redaction, key handling, fail-closed behavior)

## Operational Notes

- [ ] User-facing docs updated where behavior changed (`README.md`, `docs/hardening/*`, runbooks)
- [ ] Docs sync checked across onboarding surfaces (`README.md`, `docs/README.md`, `docs-site/public/llm/*`, `docs-site/public/llms.txt`)
- [ ] New docs pages added to discoverability surfaces (`docs-site/src/lib/navigation.ts`, `docs-site/src/app/docs/page.tsx`, `docs-site/public/sitemap.xml`)
- [ ] Terminology changes reconciled in canonical definition pages (tool boundary + capability taxonomy)
- [ ] If agent behavior touched production-like paths, attached runpack evidence (`If your agent touched prod, attach the runpack.`)
- [ ] Included ticket footer evidence line (`gait run receipt --from <run_id|path>`)
- [ ] For new/expanded official integration lane proposals, attached `gait-out/integration_lane_scorecard.json` evidence and decision outcome
