### PR TITLE
build: uplift Go floor to 1.26.1

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-golang 1.25.7
+golang 1.26.1
 python 3.13.7

--- a/examples/ci/portability/circleci/config.yml
+++ b/examples/ci/portability/circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 jobs:
   gait_regress:
     docker:
-      - image: cimg/go:1.25
+      - image: cimg/go:1.26
     steps:
       - checkout
       - run:

--- a/examples/ci/portability/gitlab/.gitlab-ci.yml
+++ b/examples/ci/portability/gitlab/.gitlab-ci.yml
@@ -3,7 +3,7 @@ stages:
 
 gait_regress:
   stage: regress
-  image: golang:1.25
+  image: golang:1.26
   script:
     - bash scripts/ci_regress_contract.sh
   artifacts:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Clyra-AI/gait
 
-go 1.25.7
+go 1.26.1
 
 require (
 	github.com/Clyra-AI/proof v0.4.6


### PR DESCRIPTION
## Problem
The repo was still pinned to Go 1.25.7, which matched the March 7, 2026 `govulncheck -mode=binary` failures in `adoption-nightly` and `nightly-full-windows`.

## Changes
- bump the authoritative Go floor in `go.mod` to `1.26.1`
- bump `.tool-versions` to `golang 1.26.1`
- update the CircleCI and GitLab portability examples from Go 1.25 to Go 1.26

## Validation
- `./gait doctor --json`
- `make prepush-full`
- `make test-ci-portability-templates`
- `go run golang.org/x/vuln/cmd/govulncheck@v1.1.4 -mode=binary ./gait`
