### PR TITLE
feat: add langchain middleware for python sdk

### DIFF
--- a/.agents/skills/commit-push/SKILL.md
+++ b/.agents/skills/commit-push/SKILL.md
@@ -74,11 +74,12 @@ If preconditions fail, stop and report.
 - Codex-authored `+1` / thumbs-up on PR body, issue comment, or review comment -> review gate satisfied when required PR CI is green and no unresolved `P0/P1` Codex items remain
 - Codex-authored `eyes` reaction on the PR body, issue comment, or review comment means review is in progress:
 - treat `eyes` as a live in-progress signal, not a terminal settle signal
-- while `eyes` is present and no later terminal Codex signal exists for the current review cycle, keep polling and do not fail the gate because 5 minutes elapsed
+- once `eyes` is observed, assume a terminal Codex signal should follow soon and continue polling every `30s` for up to `15 minutes` before declaring the gate blocked
 - once `eyes` is observed, wait for a terminal Codex signal (`actionable`, `approved`, `thumbs_up`, explicit service/quota failure, or a new actionable comment/review on the latest head) before deciding the gate result
 - Use a two-stage gate:
 - Stage A: for the first `5 minutes`, look for latest-head Codex terminal signals or an `eyes` in-progress signal
-- Stage B: if `eyes` was observed during Stage A or later, continue polling without the 5-minute stop until Codex finishes or reports an explicit failure condition
+- Stage B: if `eyes` was observed during Stage A or later, continue polling every `30s` for up to `15 minutes` from the first observed `eyes` on the current review cycle
+- If no terminal Codex signal appears within that `15 minute` Stage B window, stop and report a blocked Codex review gate
 - If no latest-head terminal signal appears and no `eyes` in-progress signal is seen during Stage A, fall back to PR-wide Codex review inventory:
 - collect prior Codex reviews, inline comments, issue comments, and Codex-authored `+1` / thumbs-up reactions on the PR
 - require at least one prior Codex review artifact before permitting `carry_forward`
@@ -89,10 +90,11 @@ If preconditions fail, stop and report.
 - Do not create a new GitHub comment to force or retry review.
 
 9. Pre-merge unresolved comment triage and fix loop (max 2 loops):
-- Fetch unresolved PR review threads/comments, preferring latest-head Codex items first and then any still-open carry-forward `P0/P1` items from earlier heads.
+- Fetch unresolved PR review threads/comments, preferring latest-head Codex items first, then any GitHub Advanced Security inline comments on the latest head, and then any still-open carry-forward `P0/P1` items from earlier heads.
 - Triage each unresolved item as `implement`, `blocked`, `defer`, `reject`, or `already_satisfied`.
 - Resolve the corresponding GitHub review thread for `implement` or `already_satisfied` items once they are satisfied on the current head.
 - Do not resolve threads for `blocked`, `defer`, or `reject`.
+- Treat deterministic GitHub Advanced Security inline comments as `implement` by default when they describe a concrete code pattern on the current head.
 - Auto-fix only `implement` items that are:
 - `P0/P1`, or
 - high-confidence `P2` with concrete repro or break path
@@ -142,7 +144,7 @@ If preconditions fail, stop and report.
 14. Stop conditions:
 - CI green on main: success.
 - Codex gate unresolved after passive latest-head poll plus PR-wide carry-forward triage, without any Codex `eyes` in-progress signal: stop and report blocker.
-- Codex gate remains pending with Codex `eyes` in-progress signal: continue waiting; do not stop solely because the initial 5-minute window elapsed.
+- Codex gate remains pending with Codex `eyes` in-progress signal: continue waiting up to the `15 minute` Stage B window; only then stop and report blocker if no terminal signal appears.
 - Unresolved pre-merge `P0/P1` comments after 2 fix loops: stop and report blocker.
 - Non-actionable failure class: stop and report.
 - Loop count exceeded (`>2`): stop and report blocker.
@@ -182,7 +184,7 @@ Never use inline `--body "..."` for multi-line PR text.
 - PR CI watch timeout: `25 minutes`.
 - Codex review settle polling interval: `15 seconds`.
 - Codex review settle initial window: `5 minutes` to find latest-head terminal signals or an `eyes` in-progress signal.
-- Codex review settle after `eyes`: no fixed timeout; keep polling until Codex emits a terminal review signal or explicit failure.
+- Codex review settle after `eyes`: poll every `30 seconds` for up to `15 minutes` before blocking if no terminal signal appears.
 - Pre-merge comment-fix loop cap: `2`.
 - Post-merge main CI watch timeout: `25 minutes`.
 - Retry/hotfix loop cap: `2`.

--- a/docs/integration_checklist.md
+++ b/docs/integration_checklist.md
@@ -175,7 +175,7 @@ Contract docs:
 
 Supported references:
 
-- `examples/integrations/langchain/`
+- `examples/integrations/langchain/` (official middleware with optional callback correlation)
 - `examples/integrations/autogen/`
 - `examples/integrations/openclaw/`
 - `examples/integrations/autogpt/`
@@ -207,6 +207,9 @@ go build -o ./gait ./cmd/gait
 python3 examples/integrations/openai_agents/quickstart.py --scenario allow
 python3 examples/integrations/openai_agents/quickstart.py --scenario block
 python3 examples/integrations/openai_agents/quickstart.py --scenario require_approval
+python3 examples/integrations/langchain/quickstart.py --scenario allow
+python3 examples/integrations/langchain/quickstart.py --scenario block
+python3 examples/integrations/langchain/quickstart.py --scenario require_approval
 python3 examples/integrations/voice_reference/quickstart.py --scenario allow
 python3 examples/integrations/voice_reference/quickstart.py --scenario block
 python3 examples/integrations/voice_reference/quickstart.py --scenario require_approval

--- a/docs/sdk/python.md
+++ b/docs/sdk/python.md
@@ -22,6 +22,7 @@ Supported primitives:
 - regress fixture init (`create_regress_fixture`)
 - run capture (`record_runpack`)
 - trace copy/validation (`write_trace`)
+- optional LangChain middleware (`GaitLangChainMiddleware`)
 
 Non-goals:
 
@@ -97,6 +98,11 @@ The SDK is a thin subprocess wrapper that calls the local `gait` binary. The Go 
 
 No. The Python SDK has zero external runtime dependencies. Dev dependencies (pytest, ruff, mypy) are for development only.
 
+LangChain is opt-in:
+
+- install with `uv sync --extra langchain --extra dev` when you want the middleware surface
+- base SDK users do not need LangChain installed
+
 ### What Python version is required?
 
 Python 3.13 or higher.
@@ -104,6 +110,16 @@ Python 3.13 or higher.
 ### How do I wrap a tool function with Gait?
 
 Use the `@gate_tool` decorator from the SDK. It automatically evaluates gate policy before executing the tool and records the result.
+
+### How does the official LangChain integration work?
+
+The official surface is `GaitLangChainMiddleware`, and enforcement only happens in `wrap_tool_call`.
+
+- tool name and args are captured into a normal `IntentRequest`
+- execution still routes through `ToolAdapter.execute`
+- optional `GaitLangChainCallbackHandler` receives additive correlation metadata such as `run_id`, `request_id`, `trace_path`, `policy_digest`, and `intent_digest`
+- callback handlers never decide allow or block behavior
+- the official example lane is `examples/integrations/langchain/quickstart.py`
 
 ### What happens if the Gait binary is not found?
 

--- a/examples/integrations/README.md
+++ b/examples/integrations/README.md
@@ -5,7 +5,7 @@ This directory contains framework adapters that demonstrate the same Gait execut
 Current adapters:
 
 - `openai_agents`
-- `langchain`
+- `langchain` (official middleware with optional callback correlation)
 - `autogen`
 - `openclaw`
 - `autogpt`

--- a/examples/integrations/langchain/README.md
+++ b/examples/integrations/langchain/README.md
@@ -1,11 +1,11 @@
-# LangChain Quickstart (Wrapped Tool Boundary)
+# LangChain Quickstart (Official Middleware)
 
-This guide shows the minimal wrapped execution path:
+This guide shows the shipped LangChain lane:
 
-1. LangChain tool payload -> normalized intent payload.
-2. `gait gate eval` against policy.
-3. Execute only on `allow`.
-4. Persist trace artifact path for audit/debug.
+1. Build a real `create_agent(..., middleware=[GaitLangChainMiddleware(...)])` agent.
+2. Enforce only in `wrap_tool_call`.
+3. Surface additive correlation metadata with an optional callback handler.
+4. Capture one Gait runpack for the whole agent run with `run_session(...)`.
 
 ## Run
 
@@ -15,6 +15,7 @@ From repo root:
 go build -o ./gait ./cmd/gait
 python3 examples/integrations/langchain/quickstart.py --scenario allow
 python3 examples/integrations/langchain/quickstart.py --scenario block
+python3 examples/integrations/langchain/quickstart.py --scenario require_approval
 ```
 
 Expected allow output:
@@ -26,6 +27,7 @@ verdict=allow
 executed=true
 trace_path=/.../gait-out/integrations/langchain/trace_allow.json
 executor_output=/.../gait-out/integrations/langchain/executor_allow.json
+runpack_path=/.../gait-out/integrations/langchain/runpacks/runpack_run_langchain_allow.zip
 ```
 
 Expected block output:
@@ -38,7 +40,27 @@ executed=false
 trace_path=/.../gait-out/integrations/langchain/trace_block.json
 ```
 
-Trace record location:
+Expected approval output:
+
+```text
+framework=langchain
+scenario=require_approval
+verdict=require_approval
+executed=false
+trace_path=/.../gait-out/integrations/langchain/trace_require_approval.json
+```
+
+Deterministic artifacts:
 
 - `gait-out/integrations/langchain/trace_allow.json`
 - `gait-out/integrations/langchain/trace_block.json`
+- `gait-out/integrations/langchain/trace_require_approval.json`
+- `gait-out/integrations/langchain/runpacks/runpack_run_langchain_allow.zip`
+- `gait-out/integrations/langchain/runpacks/runpack_run_langchain_block.zip`
+- `gait-out/integrations/langchain/runpacks/runpack_run_langchain_require_approval.zip`
+
+Language contract:
+
+- official wording: middleware with optional callback correlation
+- callbacks do not make allow or block decisions
+- only `allow` executes the tool

--- a/examples/integrations/langchain/README.md
+++ b/examples/integrations/langchain/README.md
@@ -13,9 +13,10 @@ From repo root:
 
 ```bash
 go build -o ./gait ./cmd/gait
-python3 examples/integrations/langchain/quickstart.py --scenario allow
-python3 examples/integrations/langchain/quickstart.py --scenario block
-python3 examples/integrations/langchain/quickstart.py --scenario require_approval
+(cd sdk/python && uv sync --extra langchain --extra dev)
+(cd sdk/python && uv run --python 3.13 --extra langchain python ../../examples/integrations/langchain/quickstart.py --scenario allow)
+(cd sdk/python && uv run --python 3.13 --extra langchain python ../../examples/integrations/langchain/quickstart.py --scenario block)
+(cd sdk/python && uv run --python 3.13 --extra langchain python ../../examples/integrations/langchain/quickstart.py --scenario require_approval)
 ```
 
 Expected allow output:

--- a/examples/integrations/langchain/agent_middleware.py
+++ b/examples/integrations/langchain/agent_middleware.py
@@ -1,0 +1,220 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from gait import (
+    GaitLangChainCallbackHandler,
+    GaitLangChainMiddleware,
+    IntentArgProvenance,
+    IntentContext,
+    IntentTarget,
+    ToolAdapter,
+    capture_intent,
+    run_session,
+)
+from gait.adapter import GateEnforcementError
+from langchain.agents import create_agent
+from langchain_core.language_models.chat_models import BaseChatModel
+from langchain_core.messages import AIMessage
+from langchain_core.outputs import ChatGeneration, ChatResult
+from langchain_core.tools import tool
+
+FRAMEWORK = "langchain"
+
+
+@dataclass(slots=True)
+class LangChainRuntimeContext:
+    identity: str
+    workspace: str
+    risk_class: str
+    run_id: str
+    request_id: str
+    auth_context: dict[str, str]
+
+
+class DeterministicToolModel(BaseChatModel):
+    responses: list[AIMessage]
+
+    @property
+    def _llm_type(self) -> str:
+        return "deterministic-tool-model"
+
+    def bind_tools(self, tools: Any, *, tool_choice: str | None = None, **kwargs: Any) -> Any:
+        return self
+
+    def _generate(
+        self,
+        messages: list[Any],
+        stop: list[str] | None = None,
+        run_manager: Any | None = None,
+        **kwargs: Any,
+    ) -> ChatResult:
+        del messages, stop, run_manager, kwargs
+        if not self.responses:
+            raise RuntimeError("deterministic tool model ran out of responses")
+        message = self.responses.pop(0)
+        return ChatResult(generations=[ChatGeneration(message=message)])
+
+
+def run_langchain_scenario(
+    *,
+    repo_root: Path,
+    gait_bin: str,
+    scenario: str,
+) -> dict[str, str]:
+    run_dir = repo_root / "gait-out" / "integrations" / FRAMEWORK
+    runpack_dir = run_dir / "runpacks"
+    run_dir.mkdir(parents=True, exist_ok=True)
+    runpack_dir.mkdir(parents=True, exist_ok=True)
+
+    executor_path = run_dir / f"executor_{scenario}.json"
+    intent_path = run_dir / f"intent_{scenario}.json"
+    trace_path = run_dir / f"trace_{scenario}.json"
+    run_id = f"run_{FRAMEWORK}_{scenario}"
+    request_id = f"req_{FRAMEWORK}_{scenario}"
+    policy_path = Path(__file__).with_name(f"policy_{scenario}.yaml")
+
+    executor_path.unlink(missing_ok=True)
+    intent_path.unlink(missing_ok=True)
+    trace_path.unlink(missing_ok=True)
+    (runpack_dir / f"runpack_{run_id}.zip").unlink(missing_ok=True)
+
+    runtime_context = LangChainRuntimeContext(
+        identity="agent-langchain",
+        workspace="/tmp/gait-langchain",
+        risk_class="high",
+        run_id=run_id,
+        request_id=request_id,
+        auth_context={"framework": FRAMEWORK, "operator": "example-user"},
+    )
+    callback = GaitLangChainCallbackHandler()
+    adapter = ToolAdapter(policy_path=policy_path, gait_bin=gait_bin)
+    middleware = GaitLangChainMiddleware(
+        adapter,
+        intent_factory=lambda request: build_langchain_intent(
+            request=request,
+            runtime_context=runtime_context,
+            intent_path=intent_path,
+        ),
+        cwd=repo_root,
+        trace_path_factory=lambda _request: trace_path,
+        callback_handler=callback,
+        producer_version="0.0.0-example",
+    )
+    model = DeterministicToolModel(
+        responses=[
+            AIMessage(content="", tool_calls=[build_tool_call(scenario)]),
+            AIMessage(content=f"{scenario} complete"),
+        ]
+    )
+    agent = create_agent(
+        model=model,
+        tools=[build_write_tool(executor_path)],
+        context_schema=LangChainRuntimeContext,
+        middleware=[middleware],
+    )
+
+    with run_session(
+        run_id=run_id,
+        gait_bin=gait_bin,
+        cwd=repo_root,
+        out_dir=runpack_dir,
+    ) as session:
+        try:
+            result = agent.invoke(
+                {"messages": [{"role": "user", "content": "write the file"}]},
+                context=runtime_context,
+            )
+            final_message = str(result["messages"][-1].content)
+        except GateEnforcementError as error:
+            final_message = str(error)
+            if error.decision.verdict is None:
+                raise RuntimeError("langchain middleware returned a gate error without verdict") from error
+
+    if session.capture is None:
+        raise RuntimeError("langchain middleware example did not emit a runpack")
+    if not callback.events:
+        raise RuntimeError("langchain middleware example did not emit correlation metadata")
+
+    metadata = callback.events[-1]
+    output = {
+        "framework": FRAMEWORK,
+        "scenario": scenario,
+        "verdict": metadata.verdict or "unknown",
+        "executed": "true" if metadata.executed else "false",
+        "trace_path": metadata.trace_path or str(trace_path),
+        "intent_path": str(intent_path),
+        "run_id": run_id,
+        "request_id": request_id,
+        "policy_digest": metadata.policy_digest or "",
+        "intent_digest": metadata.intent_digest or "",
+        "runpack_path": session.capture.bundle_path,
+        "ticket_footer": session.capture.ticket_footer,
+        "agent_response": final_message,
+    }
+    if metadata.executed:
+        output["executor_output"] = str(executor_path)
+    return output
+
+
+def build_tool_call(scenario: str) -> dict[str, Any]:
+    return {
+        "name": "tool.write",
+        "args": {
+            "path": f"/tmp/gait-{FRAMEWORK}-{scenario}.json",
+            "content": {"framework": FRAMEWORK, "scenario": scenario},
+        },
+        "id": f"call_{FRAMEWORK}_{scenario}",
+        "type": "tool_call",
+    }
+
+
+def build_langchain_intent(
+    *,
+    request: Any,
+    runtime_context: LangChainRuntimeContext,
+    intent_path: Path | None = None,
+) -> Any:
+    args = dict(request.tool_call["args"])
+    intent = capture_intent(
+        tool_name=str(request.tool_call["name"]),
+        args=args,
+        context=IntentContext(
+            identity=runtime_context.identity,
+            workspace=runtime_context.workspace,
+            risk_class=runtime_context.risk_class,
+            session_id=runtime_context.run_id,
+            request_id=runtime_context.request_id,
+            auth_context=runtime_context.auth_context,
+        ),
+        targets=[
+            IntentTarget(
+                kind="path",
+                value=str(args["path"]),
+                operation="write",
+            )
+        ],
+        arg_provenance=[IntentArgProvenance(arg_path="$.path", source="user")],
+        producer_version="0.0.0-example",
+    )
+    if intent_path is not None:
+        intent_path.write_text(json.dumps(intent.to_dict(), indent=2) + "\n", encoding="utf-8")
+    return intent
+
+
+def build_write_tool(executor_path: Path) -> Any:
+    @tool("tool.write")
+    def write_tool(path: str, content: dict[str, str]) -> str:
+        """Write deterministic JSON content after middleware approval."""
+
+        executor_path.parent.mkdir(parents=True, exist_ok=True)
+        executor_path.write_text(
+            json.dumps({"path": path, "content": content}, indent=2) + "\n",
+            encoding="utf-8",
+        )
+        return str(executor_path)
+
+    return write_tool

--- a/examples/integrations/langchain/policy_require_approval.yaml
+++ b/examples/integrations/langchain/policy_require_approval.yaml
@@ -1,0 +1,3 @@
+schema_id: gait.gate.policy
+schema_version: 1.0.0
+default_verdict: require_approval

--- a/examples/integrations/langchain/quickstart.py
+++ b/examples/integrations/langchain/quickstart.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 
 import argparse
 import os
-import shutil
-import subprocess  # nosec B404
 import sys
 from pathlib import Path
 
@@ -19,34 +17,6 @@ def ensure_sdk_path(repo_root: Path) -> None:
     sdk_root = repo_root / "sdk" / "python"
     if str(sdk_root) not in sys.path:
         sys.path.insert(0, str(sdk_root))
-
-
-def ensure_langchain_available(repo_root: Path) -> None:
-    if os.environ.get("GAIT_LANGCHAIN_READY") == "1":
-        return
-    try:
-        __import__("langchain")
-    except ImportError:
-        uv_bin = shutil.which("uv")
-        if uv_bin is None:
-            raise RuntimeError(
-                "langchain is not installed and `uv` is unavailable; install langchain or "
-                "run with `uv run --with langchain`."
-            ) from None
-        command = [
-            uv_bin,
-            "run",
-            "--with",
-            "langchain>=1.0,<2.0",
-            "python",
-            __file__,
-            *sys.argv[1:],
-        ]
-        env = dict(os.environ)
-        env["GAIT_LANGCHAIN_READY"] = "1"
-        raise SystemExit(
-            subprocess.run(command, cwd=repo_root, env=env, check=False).returncode  # nosec B603
-        )
 
 
 def resolve_gait_bin(repo_root: Path) -> str:
@@ -73,9 +43,15 @@ def main() -> int:
 
     repo_root = resolve_repo_root()
     ensure_sdk_path(repo_root)
-    ensure_langchain_available(repo_root)
-
-    from agent_middleware import run_langchain_scenario
+    try:
+        from agent_middleware import run_langchain_scenario
+    except ImportError as error:
+        if error.name and error.name.startswith("langchain"):
+            raise RuntimeError(
+                "langchain quickstart requires optional LangChain dependencies; "
+                "run `cd sdk/python && uv sync --extra langchain --extra dev` first."
+            ) from error
+        raise
 
     gait_bin = resolve_gait_bin(repo_root)
     result = run_langchain_scenario(

--- a/examples/integrations/langchain/quickstart.py
+++ b/examples/integrations/langchain/quickstart.py
@@ -2,19 +2,51 @@
 from __future__ import annotations
 
 import argparse
-import json
 import os
 import shutil
 import subprocess  # nosec B404
+import sys
 from pathlib import Path
-from typing import Any
 
 FRAMEWORK = "langchain"
-CREATED_AT = "2026-02-06T00:00:00Z"
 
 
 def resolve_repo_root() -> Path:
     return Path(__file__).resolve().parents[3]
+
+
+def ensure_sdk_path(repo_root: Path) -> None:
+    sdk_root = repo_root / "sdk" / "python"
+    if str(sdk_root) not in sys.path:
+        sys.path.insert(0, str(sdk_root))
+
+
+def ensure_langchain_available(repo_root: Path) -> None:
+    if os.environ.get("GAIT_LANGCHAIN_READY") == "1":
+        return
+    try:
+        __import__("langchain")
+    except ImportError:
+        uv_bin = shutil.which("uv")
+        if uv_bin is None:
+            raise RuntimeError(
+                "langchain is not installed and `uv` is unavailable; install langchain or "
+                "run with `uv run --with langchain`."
+            ) from None
+        command = [
+            uv_bin,
+            "run",
+            "--with",
+            "langchain>=1.0,<2.0",
+            "python",
+            __file__,
+            *sys.argv[1:],
+        ]
+        env = dict(os.environ)
+        env["GAIT_LANGCHAIN_READY"] = "1"
+        raise SystemExit(
+            subprocess.run(command, cwd=repo_root, env=env, check=False).returncode  # nosec B603
+        )
 
 
 def resolve_gait_bin(repo_root: Path) -> str:
@@ -30,172 +62,30 @@ def resolve_gait_bin(repo_root: Path) -> str:
     raise RuntimeError("unable to find gait binary; set GAIT_BIN or build ./gait")
 
 
-def build_langchain_tool_call(scenario: str) -> dict[str, Any]:
-    return {
-        "tool": "write_file",
-        "tool_input": {
-            "path": f"/tmp/gait-{FRAMEWORK}-{scenario}.json",
-            "content": {"framework": FRAMEWORK, "scenario": scenario},
-            "skill": {
-                "name": "safe_writer",
-                "version": "1.0.0",
-                "source": "registry",
-                "publisher": "acme",
-                "digest": "a" * 64,
-                "signature_key_id": "acme-dev-key",
-            },
-        },
-    }
-
-
-def to_intent_payload(tool_call: dict[str, Any], scenario: str) -> dict[str, Any]:
-    arguments = dict(tool_call["tool_input"])
-    skill = dict(arguments.pop("skill"))
-    path = str(arguments["path"])
-    return {
-        "schema_id": "gait.gate.intent_request",
-        "schema_version": "1.0.0",
-        "created_at": CREATED_AT,
-        "producer_version": "0.0.0-example",
-        "tool_name": "tool.write",
-        "args": arguments,
-        "targets": [
-            {
-                "kind": "path",
-                "value": path,
-                "operation": "write",
-                "endpoint_class": "fs.write",
-            }
-        ],
-        "arg_provenance": [{"arg_path": "$.path", "source": "user"}],
-        "skill_provenance": {
-            "skill_name": str(skill["name"]),
-            "skill_version": str(skill.get("version", "")),
-            "source": str(skill["source"]),
-            "publisher": str(skill["publisher"]),
-            "digest": str(skill.get("digest", "")),
-            "signature_key_id": str(skill.get("signature_key_id", "")),
-        },
-        "delegation": {
-            "requester_identity": "langchain-user",
-            "scope_class": "write",
-            "token_refs": [f"delegation-{FRAMEWORK}-{scenario}"],
-            "chain": [
-                {
-                    "delegator_identity": "agent.lead",
-                    "delegate_identity": "langchain-user",
-                    "scope_class": "write",
-                    "token_ref": f"delegation-{FRAMEWORK}-{scenario}",
-                }
-            ],
-        },
-        "context": {
-            "identity": "langchain-user",
-            "workspace": "/tmp/gait-langchain",
-            "risk_class": "high",
-            "session_id": f"sess-{FRAMEWORK}-{scenario}",
-            "auth_context": {
-                "framework": FRAMEWORK,
-                "operator": "example-user",
-            },
-            "credential_scopes": ["files.write", "network.egress"],
-            "environment_fingerprint": f"{FRAMEWORK}:local:{scenario}",
-        },
-    }
-
-
-def run_gate_eval(
-    gait_bin: str, policy_path: Path, intent_path: Path, trace_path: Path
-) -> tuple[int, dict[str, Any]]:
-    command = [
-        gait_bin,
-        "gate",
-        "eval",
-        "--policy",
-        str(policy_path),
-        "--intent",
-        str(intent_path),
-        "--trace-out",
-        str(trace_path),
-        "--key-mode",
-        "dev",
-        "--json",
-    ]
-    completed = subprocess.run(  # nosec B603
-        command,
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-    if not completed.stdout.strip():
-        raise RuntimeError(
-            f"gait gate eval produced no JSON output (stderr={completed.stderr.strip()})"
-        )
-    payload = json.loads(completed.stdout)
-    if not isinstance(payload, dict):
-        raise RuntimeError("gait gate eval returned non-object JSON")
-    return completed.returncode, payload
-
-
-def execute_wrapped_tool(intent_payload: dict[str, Any], output_path: Path) -> None:
-    output_path.parent.mkdir(parents=True, exist_ok=True)
-    output_path.write_text(
-        json.dumps(intent_payload["args"], indent=2) + "\n", encoding="utf-8"
-    )
-
-
 def main() -> int:
-    parser = argparse.ArgumentParser(
-        description="LangChain wrapped tool-call quickstart"
+    parser = argparse.ArgumentParser(description="LangChain middleware quickstart")
+    parser.add_argument(
+        "--scenario",
+        choices=["allow", "block", "require_approval"],
+        required=True,
     )
-    parser.add_argument("--scenario", choices=["allow", "block"], required=True)
     args = parser.parse_args()
 
     repo_root = resolve_repo_root()
+    ensure_sdk_path(repo_root)
+    ensure_langchain_available(repo_root)
+
+    from agent_middleware import run_langchain_scenario
+
     gait_bin = resolve_gait_bin(repo_root)
-    scenario = args.scenario
-    policy_path = Path(__file__).with_name(f"policy_{scenario}.yaml")
-    run_dir = repo_root / "gait-out" / "integrations" / FRAMEWORK
-    run_dir.mkdir(parents=True, exist_ok=True)
-    intent_path = run_dir / f"intent_{scenario}.json"
-    trace_path = run_dir / f"trace_{scenario}.json"
-    executor_path = run_dir / f"executor_{scenario}.json"
-
-    langchain_call = build_langchain_tool_call(scenario)
-    intent_payload = to_intent_payload(langchain_call, scenario)
-    intent_path.write_text(
-        json.dumps(intent_payload, indent=2) + "\n", encoding="utf-8"
+    result = run_langchain_scenario(
+        repo_root=repo_root,
+        gait_bin=gait_bin,
+        scenario=args.scenario,
     )
 
-    exit_code, gate_payload = run_gate_eval(
-        gait_bin, policy_path, intent_path, trace_path
-    )
-    verdict = str(gate_payload.get("verdict", "unknown"))
-    traced = str(gate_payload.get("trace_path", trace_path))
-
-    if scenario == "allow":
-        if exit_code != 0 or verdict != "allow":
-            raise RuntimeError(
-                f"expected allow flow, got exit_code={exit_code} verdict={verdict}"
-            )
-        execute_wrapped_tool(intent_payload, executor_path)
-        print(f"framework={FRAMEWORK}")
-        print("scenario=allow")
-        print(f"verdict={verdict}")
-        print("executed=true")
-        print(f"trace_path={traced}")
-        print(f"executor_output={executor_path}")
-        return 0
-
-    if verdict != "block" or exit_code not in (0, 3):
-        raise RuntimeError(
-            f"expected block flow, got exit_code={exit_code} verdict={verdict}"
-        )
-    print(f"framework={FRAMEWORK}")
-    print("scenario=block")
-    print(f"verdict={verdict}")
-    print("executed=false")
-    print(f"trace_path={traced}")
+    for key, value in result.items():
+        print(f"{key}={value}")
     return 0
 
 

--- a/scripts/test_adapter_parity.sh
+++ b/scripts/test_adapter_parity.sh
@@ -17,7 +17,15 @@ for framework in "${frameworks[@]}"; do
   fi
   for scenario in "${scenarios[@]}"; do
     echo "--> $framework $scenario"
-    adapter_output="$(python3 "examples/integrations/${framework}/quickstart.py" --scenario "$scenario")"
+    if [[ "$framework" == "langchain" ]]; then
+      adapter_output="$(
+        cd "$repo_root/sdk/python" && \
+          uv run --python 3.13 --extra langchain python \
+            "../../examples/integrations/${framework}/quickstart.py" --scenario "$scenario"
+      )"
+    else
+      adapter_output="$(python3 "examples/integrations/${framework}/quickstart.py" --scenario "$scenario")"
+    fi
     printf '%s\n' "$adapter_output"
     ADAPTER_FRAMEWORK="$framework" ADAPTER_SCENARIO="$scenario" ADAPTER_OUTPUT="$adapter_output" python3 - <<'PY'
 import json

--- a/scripts/test_adapter_parity.sh
+++ b/scripts/test_adapter_parity.sh
@@ -11,7 +11,11 @@ frameworks=(openai_agents langchain autogen openclaw autogpt gastown claude_code
 
 echo "==> adapter parity smoke"
 for framework in "${frameworks[@]}"; do
-  for scenario in allow block; do
+  scenarios=(allow block)
+  if [[ "$framework" == "langchain" ]]; then
+    scenarios=(allow block require_approval)
+  fi
+  for scenario in "${scenarios[@]}"; do
     echo "--> $framework $scenario"
     adapter_output="$(python3 "examples/integrations/${framework}/quickstart.py" --scenario "$scenario")"
     printf '%s\n' "$adapter_output"
@@ -55,49 +59,72 @@ if expected_trace_suffix not in str(trace_path).replace("\\", "/"):
 trace_payload = json.loads(trace_path.read_text(encoding="utf-8"))
 if trace_payload.get("tool_name") != "tool.write":
     raise SystemExit(f"unexpected tool_name in trace: {trace_payload.get('tool_name')}")
-skill = trace_payload.get("skill_provenance")
-if not isinstance(skill, dict):
-    raise SystemExit("trace skill_provenance missing")
-if skill.get("publisher") != "acme" or skill.get("source") != "registry":
-    raise SystemExit(f"unexpected skill provenance in trace: {skill}")
-
 intent_path = trace_path.parent / f"intent_{scenario}.json"
+if framework == "langchain":
+    for field in ("run_id", "request_id", "policy_digest", "intent_digest", "runpack_path", "intent_path"):
+        if field not in parsed:
+            raise SystemExit(f"missing field {field} in langchain output: {output}")
+    if not Path(parsed["runpack_path"]).exists():
+        raise SystemExit(f"langchain runpack missing: {parsed['runpack_path']}")
+    if Path(parsed["intent_path"]) != intent_path:
+        raise SystemExit(
+            f"langchain intent_path mismatch: expected={intent_path} got={parsed['intent_path']}"
+        )
+else:
+    skill = trace_payload.get("skill_provenance")
+    if not isinstance(skill, dict):
+        raise SystemExit("trace skill_provenance missing")
+    if skill.get("publisher") != "acme" or skill.get("source") != "registry":
+        raise SystemExit(f"unexpected skill provenance in trace: {skill}")
+
 if not intent_path.exists():
     raise SystemExit(f"intent fixture missing: {intent_path}")
 intent_payload = json.loads(intent_path.read_text(encoding="utf-8"))
 targets = intent_payload.get("targets")
 if not isinstance(targets, list) or not targets:
     raise SystemExit(f"intent targets missing: {intent_path}")
-endpoint_class = targets[0].get("endpoint_class")
-if endpoint_class != "fs.write":
-    raise SystemExit(f"endpoint_class mismatch: expected fs.write got {endpoint_class}")
 context = intent_payload.get("context")
 if not isinstance(context, dict):
     raise SystemExit(f"intent context missing: {intent_path}")
-session_id = context.get("session_id")
-if not isinstance(session_id, str) or not session_id:
-    raise SystemExit(f"session_id missing in context: {intent_path}")
 auth_context = context.get("auth_context")
 if not isinstance(auth_context, dict) or not auth_context:
     raise SystemExit(f"auth_context missing in context: {intent_path}")
-credential_scopes = context.get("credential_scopes")
-if not isinstance(credential_scopes, list) or not credential_scopes:
-    raise SystemExit(f"credential_scopes missing in context: {intent_path}")
-env_fp = context.get("environment_fingerprint")
-if not isinstance(env_fp, str) or not env_fp:
-    raise SystemExit(f"environment_fingerprint missing in context: {intent_path}")
+if framework == "langchain":
+    if targets[0].get("operation") != "write":
+        raise SystemExit(f"langchain target operation mismatch: {targets[0]}")
+    if context.get("request_id") != parsed["request_id"]:
+        raise SystemExit(
+            f"langchain request_id mismatch: expected={parsed['request_id']} got={context.get('request_id')}"
+        )
+    if context.get("session_id") != parsed["run_id"]:
+        raise SystemExit(
+            f"langchain session_id mismatch: expected={parsed['run_id']} got={context.get('session_id')}"
+        )
+else:
+    endpoint_class = targets[0].get("endpoint_class")
+    if endpoint_class != "fs.write":
+        raise SystemExit(f"endpoint_class mismatch: expected fs.write got {endpoint_class}")
+    session_id = context.get("session_id")
+    if not isinstance(session_id, str) or not session_id:
+        raise SystemExit(f"session_id missing in context: {intent_path}")
+    credential_scopes = context.get("credential_scopes")
+    if not isinstance(credential_scopes, list) or not credential_scopes:
+        raise SystemExit(f"credential_scopes missing in context: {intent_path}")
+    env_fp = context.get("environment_fingerprint")
+    if not isinstance(env_fp, str) or not env_fp:
+        raise SystemExit(f"environment_fingerprint missing in context: {intent_path}")
 
-delegation = intent_payload.get("delegation")
-if not isinstance(delegation, dict):
-    raise SystemExit(f"delegation missing from intent: {intent_path}")
-if not delegation.get("requester_identity"):
-    raise SystemExit(f"delegation requester_identity missing: {intent_path}")
-chain = delegation.get("chain")
-if not isinstance(chain, list) or not chain:
-    raise SystemExit(f"delegation chain missing: {intent_path}")
-first_link = chain[0]
-if not isinstance(first_link, dict) or not first_link.get("delegator_identity") or not first_link.get("delegate_identity"):
-    raise SystemExit(f"delegation chain link invalid: {intent_path}")
+    delegation = intent_payload.get("delegation")
+    if not isinstance(delegation, dict):
+        raise SystemExit(f"delegation missing from intent: {intent_path}")
+    if not delegation.get("requester_identity"):
+        raise SystemExit(f"delegation requester_identity missing: {intent_path}")
+    chain = delegation.get("chain")
+    if not isinstance(chain, list) or not chain:
+        raise SystemExit(f"delegation chain missing: {intent_path}")
+    first_link = chain[0]
+    if not isinstance(first_link, dict) or not first_link.get("delegator_identity") or not first_link.get("delegate_identity"):
+        raise SystemExit(f"delegation chain link invalid: {intent_path}")
 
 if scenario == "allow":
     if parsed["verdict"] != "allow":
@@ -111,14 +138,17 @@ if scenario == "allow":
     if not executor_path.exists():
         raise SystemExit(f"allow scenario executor output missing: {executor_path}")
 else:
-    if parsed["verdict"] == "allow":
-        raise SystemExit("block scenario unexpectedly returned allow verdict")
+    expected_verdict = "block" if scenario == "block" else "require_approval"
+    if parsed["verdict"] != expected_verdict:
+        raise SystemExit(
+            f"{scenario} scenario verdict mismatch: expected={expected_verdict} got={parsed['verdict']}"
+        )
     if parsed["executed"].lower() != "false":
-        raise SystemExit(f"block scenario executed mismatch: {parsed['executed']}")
+        raise SystemExit(f"{scenario} scenario executed mismatch: {parsed['executed']}")
     executor_output = parsed.get("executor_output", "")
     if executor_output and Path(executor_output).exists():
         raise SystemExit(
-            f"block scenario must not materialize executor output: {executor_output}"
+            f"{scenario} scenario must not materialize executor output: {executor_output}"
         )
 PY
   done

--- a/scripts/test_adoption_smoke.sh
+++ b/scripts/test_adoption_smoke.sh
@@ -146,6 +146,12 @@ python3 - <<'PY'
 from pathlib import Path
 
 required = [
+    Path("gait-out/integrations/langchain/trace_allow.json"),
+    Path("gait-out/integrations/langchain/trace_block.json"),
+    Path("gait-out/integrations/langchain/trace_require_approval.json"),
+    Path("gait-out/integrations/langchain/runpacks/runpack_run_langchain_allow.zip"),
+    Path("gait-out/integrations/langchain/runpacks/runpack_run_langchain_block.zip"),
+    Path("gait-out/integrations/langchain/runpacks/runpack_run_langchain_require_approval.zip"),
     Path("gait-out/integrations/template/trace_allow.json"),
     Path("gait-out/integrations/template/trace_block.json"),
     Path("gait-out/integrations/template/trace_require_approval.json"),

--- a/sdk/python/gait/__init__.py
+++ b/sdk/python/gait/__init__.py
@@ -10,6 +10,7 @@ from .client import (
     write_trace,
 )
 from .decorators import gate_tool
+from .langchain import GaitLangChainCallbackHandler, GaitLangChainMiddleware
 from .models import (
     DelegationLink,
     DemoCapture,
@@ -21,6 +22,7 @@ from .models import (
     IntentScript,
     IntentScriptStep,
     IntentTarget,
+    LangChainDecisionMetadata,
     RegressInitResult,
     RunRecordCapture,
     TraceRecord,
@@ -36,6 +38,8 @@ __all__ = [
     "GaitError",
     "GateEnforcementError",
     "GateEvalResult",
+    "GaitLangChainCallbackHandler",
+    "GaitLangChainMiddleware",
     "IntentArgProvenance",
     "IntentContext",
     "IntentDelegation",
@@ -43,6 +47,7 @@ __all__ = [
     "IntentScript",
     "IntentScriptStep",
     "IntentTarget",
+    "LangChainDecisionMetadata",
     "RegressInitResult",
     "RunAttempt",
     "RunRecordCapture",

--- a/sdk/python/gait/client.py
+++ b/sdk/python/gait/client.py
@@ -152,7 +152,7 @@ def evaluate_gate(
                 stderr=result.stderr,
             )
 
-        if result.exit_code in (0, 4):
+        if result.exit_code in (0, 3, 4):
             return GateEvalResult.from_dict(payload, exit_code=result.exit_code)
 
         message = str(payload.get("error") or "gait gate eval failed")

--- a/sdk/python/gait/langchain.py
+++ b/sdk/python/gait/langchain.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+# mypy: disable-error-code=import-not-found
 
 import os
 import re

--- a/sdk/python/gait/langchain.py
+++ b/sdk/python/gait/langchain.py
@@ -14,9 +14,9 @@ _ToolCallRequest: Any
 _CallbackHandlerBase: type[Any]
 
 try:
-    from langchain.agents.middleware import AgentMiddleware as _ImportedAgentMiddleware  # type: ignore[import-not-found]
-    from langchain.tools.tool_node import ToolCallRequest as _ImportedToolCallRequest  # type: ignore[import-not-found]
-    from langchain_core.callbacks.base import BaseCallbackHandler as _ImportedCallbackHandler  # type: ignore[import-not-found]
+    from langchain.agents.middleware import AgentMiddleware as _ImportedAgentMiddleware
+    from langchain.tools.tool_node import ToolCallRequest as _ImportedToolCallRequest
+    from langchain_core.callbacks.base import BaseCallbackHandler as _ImportedCallbackHandler
 except ImportError as error:
     _LANGCHAIN_IMPORT_ERROR: ImportError | None = error
     _AgentMiddlewareBase = object
@@ -178,7 +178,11 @@ class GaitLangChainMiddleware(_AgentMiddlewareBase):  # type: ignore[misc]
             verdict=verdict,
             executed=executed,
         )
-        self._callback_handler.on_gait_decision(metadata)
+        try:
+            # Correlation sinks are additive only and must not affect tool execution.
+            self._callback_handler.on_gait_decision(metadata)
+        except Exception:
+            return
 
 
 def _require_langchain() -> None:

--- a/sdk/python/gait/langchain.py
+++ b/sdk/python/gait/langchain.py
@@ -1,0 +1,298 @@
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+from typing import Any, Callable, Mapping, Protocol
+
+from .adapter import GateEnforcementError, ToolAdapter
+from .client import capture_intent
+from .models import IntentContext, IntentRequest, LangChainDecisionMetadata
+
+_AgentMiddlewareBase: type[Any]
+_ToolCallRequest: Any
+_CallbackHandlerBase: type[Any]
+
+try:
+    from langchain.agents.middleware import AgentMiddleware as _ImportedAgentMiddleware  # type: ignore[import-not-found]
+    from langchain.tools.tool_node import ToolCallRequest as _ImportedToolCallRequest  # type: ignore[import-not-found]
+    from langchain_core.callbacks.base import BaseCallbackHandler as _ImportedCallbackHandler  # type: ignore[import-not-found]
+except ImportError as error:
+    _LANGCHAIN_IMPORT_ERROR: ImportError | None = error
+    _AgentMiddlewareBase = object
+    _ToolCallRequest = Any
+    _CallbackHandlerBase = object
+else:
+    _LANGCHAIN_IMPORT_ERROR = None
+    _AgentMiddlewareBase = _ImportedAgentMiddleware
+    _ToolCallRequest = _ImportedToolCallRequest
+    _CallbackHandlerBase = _ImportedCallbackHandler
+
+
+class SupportsGaitDecision(Protocol):
+    def on_gait_decision(self, metadata: LangChainDecisionMetadata) -> None:
+        """Capture additive correlation metadata after a gate decision."""
+
+
+IntentFactory = Callable[[Any], IntentRequest]
+ContextFactory = Callable[[Any], IntentContext]
+TracePathFactory = Callable[[Any], str | Path | None]
+
+
+class GaitLangChainCallbackHandler(_CallbackHandlerBase):  # type: ignore[misc]
+    """Optional correlation-only sink for middleware decision metadata."""
+
+    def __init__(
+        self,
+        *,
+        sink: Callable[[LangChainDecisionMetadata], None] | None = None,
+    ) -> None:
+        self.events: list[LangChainDecisionMetadata] = []
+        self._sink = sink
+
+    def on_gait_decision(self, metadata: LangChainDecisionMetadata) -> None:
+        self.events.append(metadata)
+        if self._sink is not None:
+            self._sink(metadata)
+
+
+class GaitLangChainMiddleware(_AgentMiddlewareBase):  # type: ignore[misc]
+    """Official Gait tool middleware for LangChain agents."""
+
+    def __init__(
+        self,
+        adapter: ToolAdapter,
+        *,
+        context_factory: ContextFactory | None = None,
+        intent_factory: IntentFactory | None = None,
+        cwd: str | Path | None = None,
+        trace_dir: str | Path | None = None,
+        trace_path_factory: TracePathFactory | None = None,
+        callback_handler: SupportsGaitDecision | None = None,
+        producer_version: str = "0.0.0-dev",
+    ) -> None:
+        _require_langchain()
+        self._adapter = adapter
+        self._context_factory = context_factory
+        self._intent_factory = intent_factory
+        self._cwd = cwd
+        self._trace_dir = Path(trace_dir) if trace_dir is not None else None
+        self._trace_path_factory = trace_path_factory
+        self._callback_handler = callback_handler
+        self._producer_version = producer_version
+
+    def wrap_tool_call(self, request: _ToolCallRequest, handler: Callable[[Any], Any]) -> Any:
+        intent = self._build_intent(request)
+        trace_out = self._resolve_trace_path(request)
+
+        try:
+            outcome = self._adapter.execute(
+                intent=intent,
+                executor=lambda _: handler(request),
+                cwd=self._cwd,
+                trace_out=trace_out,
+            )
+        except GateEnforcementError as error:
+            self._emit_metadata(
+                request=request,
+                intent=intent,
+                verdict=error.decision.verdict,
+                executed=False,
+                trace_path=error.decision.trace_path,
+                policy_digest=error.decision.policy_digest,
+                intent_digest=error.decision.intent_digest or intent.intent_digest,
+            )
+            raise
+
+        if not outcome.executed:
+            self._emit_metadata(
+                request=request,
+                intent=intent,
+                verdict=outcome.decision.verdict,
+                executed=False,
+                trace_path=outcome.decision.trace_path,
+                policy_digest=outcome.decision.policy_digest,
+                intent_digest=outcome.decision.intent_digest or intent.intent_digest,
+            )
+            raise GateEnforcementError(outcome.decision)
+
+        self._emit_metadata(
+            request=request,
+            intent=intent,
+            verdict=outcome.decision.verdict,
+            executed=True,
+            trace_path=outcome.decision.trace_path,
+            policy_digest=outcome.decision.policy_digest,
+            intent_digest=outcome.decision.intent_digest or intent.intent_digest,
+        )
+        return outcome.result
+
+    def _build_intent(self, request: _ToolCallRequest) -> IntentRequest:
+        if self._intent_factory is not None:
+            return self._intent_factory(request)
+        context = (
+            self._context_factory(request)
+            if self._context_factory is not None
+            else _default_intent_context(request)
+        )
+        tool_call = _tool_call_payload(request)
+        return capture_intent(
+            tool_name=_required_string(tool_call, "name"),
+            args=_tool_args(tool_call),
+            context=context,
+            producer_version=self._producer_version,
+        )
+
+    def _resolve_trace_path(self, request: _ToolCallRequest) -> str | Path | None:
+        if self._trace_path_factory is not None:
+            return self._trace_path_factory(request)
+        if self._trace_dir is None:
+            return None
+        tool_call = _tool_call_payload(request)
+        stem = _sanitize_filename(_required_string(tool_call, "name"))
+        call_id = _sanitize_filename(str(tool_call.get("id", "call")))
+        return self._trace_dir / f"{stem}_{call_id}.json"
+
+    def _emit_metadata(
+        self,
+        *,
+        request: _ToolCallRequest,
+        intent: IntentRequest,
+        verdict: str | None,
+        executed: bool,
+        trace_path: str | None,
+        policy_digest: str | None,
+        intent_digest: str | None,
+    ) -> None:
+        if self._callback_handler is None:
+            return
+        metadata = LangChainDecisionMetadata(
+            tool_name=intent.tool_name,
+            tool_call_id=_tool_call_id(request),
+            run_id=_context_value(_runtime_context(request), "run_id"),
+            request_id=intent.context.request_id,
+            auth_context=intent.context.auth_context,
+            trace_path=trace_path,
+            policy_digest=policy_digest,
+            intent_digest=intent_digest,
+            verdict=verdict,
+            executed=executed,
+        )
+        self._callback_handler.on_gait_decision(metadata)
+
+
+def _require_langchain() -> None:
+    if _LANGCHAIN_IMPORT_ERROR is None:
+        return
+    raise ImportError(
+        "LangChain integration requires optional dependencies; install with "
+        "`uv sync --extra langchain --extra dev` or add `langchain` to your environment."
+    ) from _LANGCHAIN_IMPORT_ERROR
+
+
+def _default_intent_context(request: _ToolCallRequest) -> IntentContext:
+    raw_context = _runtime_context(request)
+    session_id = _context_value(raw_context, "session_id")
+    run_id = _context_value(raw_context, "run_id")
+    request_id = _context_value(raw_context, "request_id") or _tool_call_id(request)
+    auth_context = _context_dict(raw_context, "auth_context")
+    credential_scopes = _context_list(raw_context, "credential_scopes")
+    context_refs = _context_list(raw_context, "context_refs")
+    return IntentContext(
+        identity=_context_string(raw_context, "identity", default="langchain-agent")
+        or "langchain-agent",
+        workspace=_context_string(raw_context, "workspace", default=os.getcwd()) or os.getcwd(),
+        risk_class=_context_string(raw_context, "risk_class", default="high") or "high",
+        session_id=session_id or run_id,
+        request_id=request_id,
+        auth_context=auth_context,
+        credential_scopes=credential_scopes,
+        environment_fingerprint=_context_string(raw_context, "environment_fingerprint"),
+        context_set_digest=_context_string(raw_context, "context_set_digest"),
+        context_evidence_mode=_context_string(raw_context, "context_evidence_mode"),
+        context_refs=context_refs,
+    )
+
+
+def _runtime_context(request: _ToolCallRequest) -> Any | None:
+    runtime = getattr(request, "runtime", None)
+    if runtime is None:
+        return None
+    return getattr(runtime, "context", None)
+
+
+def _tool_call_payload(request: _ToolCallRequest) -> Mapping[str, Any]:
+    payload = getattr(request, "tool_call", None)
+    if not isinstance(payload, Mapping):
+        raise TypeError("LangChain tool middleware expected request.tool_call to be a mapping")
+    return payload
+
+
+def _tool_args(payload: Mapping[str, Any]) -> dict[str, Any]:
+    args = payload.get("args", {})
+    if not isinstance(args, Mapping):
+        raise TypeError("LangChain tool middleware expected tool_call args to be a mapping")
+    return dict(args)
+
+
+def _tool_call_id(request: _ToolCallRequest) -> str | None:
+    payload = _tool_call_payload(request)
+    value = payload.get("id")
+    if value is None:
+        return None
+    return str(value)
+
+
+def _required_string(payload: Mapping[str, Any], key: str) -> str:
+    value = payload.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"LangChain tool middleware expected non-empty string for {key}")
+    return value
+
+
+def _context_value(context: Any | None, key: str) -> Any | None:
+    if context is None:
+        return None
+    if isinstance(context, Mapping):
+        return context.get(key)
+    return getattr(context, key, None)
+
+
+def _context_string(
+    context: Any | None,
+    key: str,
+    *,
+    default: str | None = None,
+) -> str | None:
+    value = _context_value(context, key)
+    if value is None:
+        return default
+    rendered = str(value).strip()
+    if not rendered:
+        return default
+    return rendered
+
+
+def _context_dict(context: Any | None, key: str) -> dict[str, Any] | None:
+    value = _context_value(context, key)
+    if value is None:
+        return None
+    if not isinstance(value, Mapping):
+        raise TypeError(f"expected {key} to be a mapping")
+    return {str(map_key): map_value for map_key, map_value in value.items()}
+
+
+def _context_list(context: Any | None, key: str) -> list[str]:
+    value = _context_value(context, key)
+    if value is None:
+        return []
+    if not isinstance(value, list):
+        raise TypeError(f"expected {key} to be a list")
+    return [str(item) for item in value]
+
+
+def _sanitize_filename(value: str) -> str:
+    normalized = re.sub(r"[^A-Za-z0-9._-]+", "_", value).strip("._")
+    if normalized:
+        return normalized
+    return "trace"

--- a/sdk/python/gait/models.py
+++ b/sdk/python/gait/models.py
@@ -348,6 +348,43 @@ class GateEvalResult:
 
 
 @dataclass(slots=True, frozen=True)
+class LangChainDecisionMetadata:
+    tool_name: str
+    tool_call_id: str | None
+    run_id: str | None
+    request_id: str | None
+    auth_context: dict[str, Any] | None
+    trace_path: str | None
+    policy_digest: str | None
+    intent_digest: str | None
+    verdict: str | None
+    executed: bool
+
+    def to_dict(self) -> dict[str, Any]:
+        output: dict[str, Any] = {
+            "tool_name": self.tool_name,
+            "executed": self.executed,
+        }
+        if self.tool_call_id:
+            output["tool_call_id"] = self.tool_call_id
+        if self.run_id:
+            output["run_id"] = self.run_id
+        if self.request_id:
+            output["request_id"] = self.request_id
+        if self.auth_context:
+            output["auth_context"] = dict(self.auth_context)
+        if self.trace_path:
+            output["trace_path"] = self.trace_path
+        if self.policy_digest:
+            output["policy_digest"] = self.policy_digest
+        if self.intent_digest:
+            output["intent_digest"] = self.intent_digest
+        if self.verdict:
+            output["verdict"] = self.verdict
+        return output
+
+
+@dataclass(slots=True, frozen=True)
 class TraceRecord:
     schema_id: str
     schema_version: str

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -13,6 +13,9 @@ dev = [
   "mypy>=1.8",
   "bandit>=1.7",
 ]
+langchain = [
+  "langchain>=1.0,<2.0",
+]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/sdk/python/tests/conftest.py
+++ b/sdk/python/tests/conftest.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))

--- a/sdk/python/tests/helpers.py
+++ b/sdk/python/tests/helpers.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
+import sys
+from dataclasses import dataclass, replace
 from pathlib import Path
+from types import ModuleType
+from typing import Any
 
 
 def create_fake_gait_script(path: Path) -> None:
@@ -34,6 +38,7 @@ def run_gate_eval(args):
 
     if tool_name == "tool.block":
         verdict = "block"
+        exit_code = 3
         reason_codes = ["blocked_tool"]
     elif tool_name == "tool.approval":
         verdict = "require_approval"
@@ -153,3 +158,59 @@ if __name__ == "__main__":
     raise SystemExit(main())
 """
     path.write_text(script, encoding="utf-8")
+
+
+def install_fake_langchain_modules() -> type[Any]:
+    langchain = ModuleType("langchain")
+    langchain.__path__ = []  # type: ignore[attr-defined]
+    langchain_agents = ModuleType("langchain.agents")
+    langchain_agents.__path__ = []  # type: ignore[attr-defined]
+    langchain_agents_middleware = ModuleType("langchain.agents.middleware")
+    langchain_tools = ModuleType("langchain.tools")
+    langchain_tools.__path__ = []  # type: ignore[attr-defined]
+    langchain_tools_tool_node = ModuleType("langchain.tools.tool_node")
+    langchain_core = ModuleType("langchain_core")
+    langchain_core.__path__ = []  # type: ignore[attr-defined]
+    langchain_core_callbacks = ModuleType("langchain_core.callbacks")
+    langchain_core_callbacks.__path__ = []  # type: ignore[attr-defined]
+    langchain_core_callbacks_base = ModuleType("langchain_core.callbacks.base")
+
+    class AgentMiddleware:
+        pass
+
+    @dataclass(slots=True)
+    class ToolCallRequest:
+        tool_call: dict[str, Any]
+        tool: Any | None
+        state: Any
+        runtime: Any
+
+        def override(self, **overrides: Any) -> "ToolCallRequest":
+            return replace(self, **overrides)
+
+    class BaseCallbackHandler:
+        pass
+
+    langchain_agents_middleware.AgentMiddleware = AgentMiddleware
+    langchain_tools_tool_node.ToolCallRequest = ToolCallRequest
+    langchain_core_callbacks_base.BaseCallbackHandler = BaseCallbackHandler
+
+    langchain.agents = langchain_agents  # type: ignore[attr-defined]
+    langchain_agents.middleware = langchain_agents_middleware  # type: ignore[attr-defined]
+    langchain.tools = langchain_tools  # type: ignore[attr-defined]
+    langchain_tools.tool_node = langchain_tools_tool_node  # type: ignore[attr-defined]
+    langchain_core.callbacks = langchain_core_callbacks  # type: ignore[attr-defined]
+    langchain_core_callbacks.base = langchain_core_callbacks_base  # type: ignore[attr-defined]
+
+    modules = {
+        "langchain": langchain,
+        "langchain.agents": langchain_agents,
+        "langchain.agents.middleware": langchain_agents_middleware,
+        "langchain.tools": langchain_tools,
+        "langchain.tools.tool_node": langchain_tools_tool_node,
+        "langchain_core": langchain_core,
+        "langchain_core.callbacks": langchain_core_callbacks,
+        "langchain_core.callbacks.base": langchain_core_callbacks_base,
+    }
+    sys.modules.update(modules)
+    return ToolCallRequest

--- a/sdk/python/tests/test_adapter.py
+++ b/sdk/python/tests/test_adapter.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import importlib
 import sys
+from dataclasses import dataclass
 from pathlib import Path
 
 import pytest
@@ -14,7 +16,7 @@ from gait import (
     capture_intent,
 )
 
-from helpers import create_fake_gait_script
+from helpers import create_fake_gait_script, install_fake_langchain_modules
 
 
 def test_tool_adapter_executes_allowed_intent(tmp_path: Path) -> None:
@@ -191,3 +193,149 @@ def test_tool_adapter_propagates_gate_command_failure_without_execution(
     with pytest.raises(GaitCommandError):
         adapter.execute(intent=intent, executor=_executor, cwd=tmp_path)
     assert calls["count"] == 0
+
+
+def test_langchain_middleware_requires_optional_dependency(tmp_path: Path) -> None:
+    from gait.langchain import GaitLangChainMiddleware
+
+    adapter = ToolAdapter(policy_path=tmp_path / "policy.yaml", gait_bin="gait")
+
+    with pytest.raises(ImportError, match="LangChain integration requires optional dependencies"):
+        GaitLangChainMiddleware(adapter)
+
+
+def test_langchain_middleware_wraps_tool_execution_and_emits_metadata(tmp_path: Path) -> None:
+    fake_gait = tmp_path / "fake_gait.py"
+    create_fake_gait_script(fake_gait)
+    tool_call_request = install_fake_langchain_modules()
+
+    import gait.langchain as gait_langchain
+
+    gait_langchain = importlib.reload(gait_langchain)
+
+    @dataclass(slots=True)
+    class RuntimeContext:
+        identity: str
+        workspace: str
+        risk_class: str
+        run_id: str
+        request_id: str
+        auth_context: dict[str, str]
+
+    @dataclass(slots=True)
+    class Runtime:
+        context: RuntimeContext
+
+    callback = gait_langchain.GaitLangChainCallbackHandler()
+    adapter = ToolAdapter(
+        policy_path=tmp_path / "policy.yaml",
+        gait_bin=[sys.executable, str(fake_gait)],
+    )
+    middleware = gait_langchain.GaitLangChainMiddleware(
+        adapter,
+        trace_dir=tmp_path,
+        callback_handler=callback,
+    )
+
+    request = tool_call_request(
+        tool_call={
+            "name": "tool.allow",
+            "args": {"path": "/tmp/out.txt", "content": "ok"},
+            "id": "call_langchain_allow",
+        },
+        tool=None,
+        state={},
+        runtime=Runtime(
+            context=RuntimeContext(
+                identity="agent-langchain",
+                workspace="/repo/gait",
+                risk_class="high",
+                run_id="run_langchain",
+                request_id="req_langchain",
+                auth_context={"framework": "langchain"},
+            )
+        ),
+    )
+    calls = {"count": 0}
+
+    def _handler(_: object) -> dict[str, bool]:
+        calls["count"] += 1
+        return {"ok": True}
+
+    result = middleware.wrap_tool_call(request, _handler)
+
+    assert result == {"ok": True}
+    assert calls["count"] == 1
+    assert len(callback.events) == 1
+    metadata = callback.events[0]
+    assert metadata.tool_name == "tool.allow"
+    assert metadata.tool_call_id == "call_langchain_allow"
+    assert metadata.run_id == "run_langchain"
+    assert metadata.request_id == "req_langchain"
+    assert metadata.auth_context == {"framework": "langchain"}
+    assert metadata.executed is True
+    assert metadata.verdict == "allow"
+    assert metadata.trace_path is not None
+    assert Path(metadata.trace_path).exists()
+    assert metadata.policy_digest == "3" * 64
+    assert metadata.intent_digest == "2" * 64
+
+
+def test_langchain_middleware_blocks_without_running_handler(tmp_path: Path) -> None:
+    fake_gait = tmp_path / "fake_gait.py"
+    create_fake_gait_script(fake_gait)
+    tool_call_request = install_fake_langchain_modules()
+
+    import gait.langchain as gait_langchain
+
+    gait_langchain = importlib.reload(gait_langchain)
+
+    @dataclass(slots=True)
+    class Runtime:
+        context: dict[str, object]
+
+    callback = gait_langchain.GaitLangChainCallbackHandler()
+    adapter = ToolAdapter(
+        policy_path=tmp_path / "policy.yaml",
+        gait_bin=[sys.executable, str(fake_gait)],
+    )
+    middleware = gait_langchain.GaitLangChainMiddleware(
+        adapter,
+        trace_dir=tmp_path,
+        callback_handler=callback,
+    )
+
+    request = tool_call_request(
+        tool_call={
+            "name": "tool.approval",
+            "args": {"path": "/tmp/out.txt"},
+            "id": "call_langchain_approval",
+        },
+        tool=None,
+        state={},
+        runtime=Runtime(
+            context={
+                "identity": "agent-langchain",
+                "workspace": "/repo/gait",
+                "risk_class": "high",
+                "run_id": "run_langchain",
+                "request_id": "req_langchain",
+                "auth_context": {"framework": "langchain"},
+            }
+        ),
+    )
+    calls = {"count": 0}
+
+    def _handler(_: object) -> dict[str, bool]:
+        calls["count"] += 1
+        return {"ok": True}
+
+    with pytest.raises(GateEnforcementError) as error:
+        middleware.wrap_tool_call(request, _handler)
+
+    assert error.value.decision.verdict == "require_approval"
+    assert calls["count"] == 0
+    assert len(callback.events) == 1
+    assert callback.events[0].executed is False
+    assert callback.events[0].verdict == "require_approval"
+    assert callback.events[0].trace_path is not None

--- a/sdk/python/tests/test_adapter.py
+++ b/sdk/python/tests/test_adapter.py
@@ -19,6 +19,11 @@ from gait import (
 from helpers import create_fake_gait_script, install_fake_langchain_modules
 
 
+def load_gait_langchain_module() -> object:
+    gait_langchain = importlib.import_module("gait.langchain")
+    return importlib.reload(gait_langchain)
+
+
 def test_tool_adapter_executes_allowed_intent(tmp_path: Path) -> None:
     fake_gait = tmp_path / "fake_gait.py"
     create_fake_gait_script(fake_gait)
@@ -196,22 +201,18 @@ def test_tool_adapter_propagates_gate_command_failure_without_execution(
 
 
 def test_langchain_middleware_requires_optional_dependency(tmp_path: Path) -> None:
-    from gait.langchain import GaitLangChainMiddleware
-
+    gait_langchain = load_gait_langchain_module()
     adapter = ToolAdapter(policy_path=tmp_path / "policy.yaml", gait_bin="gait")
 
     with pytest.raises(ImportError, match="LangChain integration requires optional dependencies"):
-        GaitLangChainMiddleware(adapter)
+        gait_langchain.GaitLangChainMiddleware(adapter)
 
 
 def test_langchain_middleware_wraps_tool_execution_and_emits_metadata(tmp_path: Path) -> None:
     fake_gait = tmp_path / "fake_gait.py"
     create_fake_gait_script(fake_gait)
     tool_call_request = install_fake_langchain_modules()
-
-    import gait.langchain as gait_langchain
-
-    gait_langchain = importlib.reload(gait_langchain)
+    gait_langchain = load_gait_langchain_module()
 
     @dataclass(slots=True)
     class RuntimeContext:
@@ -285,10 +286,7 @@ def test_langchain_middleware_blocks_without_running_handler(tmp_path: Path) -> 
     fake_gait = tmp_path / "fake_gait.py"
     create_fake_gait_script(fake_gait)
     tool_call_request = install_fake_langchain_modules()
-
-    import gait.langchain as gait_langchain
-
-    gait_langchain = importlib.reload(gait_langchain)
+    gait_langchain = load_gait_langchain_module()
 
     @dataclass(slots=True)
     class Runtime:

--- a/sdk/python/tests/test_adapter.py
+++ b/sdk/python/tests/test_adapter.py
@@ -200,8 +200,11 @@ def test_tool_adapter_propagates_gate_command_failure_without_execution(
     assert calls["count"] == 0
 
 
-def test_langchain_middleware_requires_optional_dependency(tmp_path: Path) -> None:
+def test_langchain_middleware_requires_optional_dependency(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     gait_langchain = load_gait_langchain_module()
+    monkeypatch.setattr(gait_langchain, "_LANGCHAIN_IMPORT_ERROR", ImportError("missing langchain"))
     adapter = ToolAdapter(policy_path=tmp_path / "policy.yaml", gait_bin="gait")
 
     with pytest.raises(ImportError, match="LangChain integration requires optional dependencies"):

--- a/sdk/python/tests/test_client.py
+++ b/sdk/python/tests/test_client.py
@@ -72,6 +72,27 @@ def test_evaluate_gate_require_approval_exit_code(tmp_path: Path) -> None:
     assert result.reason_codes == ["approval_required"]
 
 
+def test_evaluate_gate_block_exit_code(tmp_path: Path) -> None:
+    fake_gait = tmp_path / "fake_gait.py"
+    create_fake_gait_script(fake_gait)
+
+    intent = capture_intent(
+        tool_name="tool.block",
+        args={"path": "/tmp/out.txt"},
+        context=IntentContext(identity="alice", workspace="/repo/gait", risk_class="high"),
+    )
+    result = evaluate_gate(
+        policy_path=tmp_path / "policy.yaml",
+        intent=intent,
+        gait_bin=[sys.executable, str(fake_gait)],
+        cwd=tmp_path,
+    )
+
+    assert result.exit_code == 3
+    assert result.verdict == "block"
+    assert result.reason_codes == ["blocked_tool"]
+
+
 def test_capture_intent_script_payload() -> None:
     intent = capture_intent(
         tool_name="script",

--- a/sdk/python/tests/test_langchain_middleware.py
+++ b/sdk/python/tests/test_langchain_middleware.py
@@ -165,3 +165,42 @@ def test_langchain_run_session_keeps_run_id_and_trace_metadata(tmp_path: Path) -
     assert session.attempts[0].verdict == "allow"
     receipts = session.record_input["refs"]["receipts"]
     assert receipts[0]["source_locator"].endswith("tool.allow_call_langchain_session.json")
+
+
+def test_langchain_callback_failure_does_not_block_allowed_execution(tmp_path: Path) -> None:
+    tool_call_request, gait_langchain = load_langchain_test_module()
+
+    class FailingCallback:
+        def on_gait_decision(self, metadata: object) -> None:
+            raise RuntimeError(f"callback failed for {metadata}")
+
+    middleware = gait_langchain.GaitLangChainMiddleware(
+        make_adapter(tmp_path),
+        trace_dir=tmp_path,
+        callback_handler=FailingCallback(),
+    )
+    request = make_request(tool_call_request, tool_name="tool.allow", scenario="callback_allow")
+
+    result = middleware.wrap_tool_call(request, lambda _: {"ok": True})
+
+    assert result == {"ok": True}
+
+
+def test_langchain_callback_failure_does_not_mask_gate_error(tmp_path: Path) -> None:
+    tool_call_request, gait_langchain = load_langchain_test_module()
+
+    class FailingCallback:
+        def on_gait_decision(self, metadata: object) -> None:
+            raise RuntimeError(f"callback failed for {metadata}")
+
+    middleware = gait_langchain.GaitLangChainMiddleware(
+        make_adapter(tmp_path),
+        trace_dir=tmp_path,
+        callback_handler=FailingCallback(),
+    )
+    request = make_request(tool_call_request, tool_name="tool.approval", scenario="callback_block")
+
+    with pytest.raises(GateEnforcementError) as error:
+        middleware.wrap_tool_call(request, lambda _: {"ok": True})
+
+    assert error.value.decision.verdict == "require_approval"

--- a/sdk/python/tests/test_langchain_middleware.py
+++ b/sdk/python/tests/test_langchain_middleware.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+import importlib
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+from gait import ToolAdapter, run_session
+from gait.adapter import GateEnforcementError
+
+from helpers import create_fake_gait_script, install_fake_langchain_modules
+
+
+@dataclass(slots=True)
+class RuntimeContext:
+    identity: str
+    workspace: str
+    risk_class: str
+    run_id: str
+    request_id: str
+    auth_context: dict[str, str]
+
+
+@dataclass(slots=True)
+class Runtime:
+    context: RuntimeContext
+
+
+def load_langchain_test_module() -> tuple[type[object], object]:
+    tool_call_request = install_fake_langchain_modules()
+    import gait.langchain as gait_langchain
+
+    return tool_call_request, importlib.reload(gait_langchain)
+
+
+def make_request(tool_call_request: type[object], *, tool_name: str, scenario: str) -> object:
+    return tool_call_request(
+        tool_call={
+            "name": tool_name,
+            "args": {
+                "path": f"/tmp/gait-langchain-{scenario}.json",
+                "content": {"scenario": scenario},
+            },
+            "id": f"call_langchain_{scenario}",
+        },
+        tool=None,
+        state={},
+        runtime=Runtime(
+            context=RuntimeContext(
+                identity="agent-langchain",
+                workspace="/repo/gait",
+                risk_class="high",
+                run_id=f"run_langchain_{scenario}",
+                request_id=f"req_langchain_{scenario}",
+                auth_context={"framework": "langchain"},
+            )
+        ),
+    )
+
+
+def make_adapter(tmp_path: Path) -> ToolAdapter:
+    fake_gait = tmp_path / "fake_gait.py"
+    create_fake_gait_script(fake_gait)
+    return ToolAdapter(
+        policy_path=tmp_path / "policy.yaml",
+        gait_bin=[sys.executable, str(fake_gait)],
+    )
+
+
+def test_langchain_allow_executes_and_surfaces_metadata(tmp_path: Path) -> None:
+    tool_call_request, gait_langchain = load_langchain_test_module()
+    callback = gait_langchain.GaitLangChainCallbackHandler()
+    middleware = gait_langchain.GaitLangChainMiddleware(
+        make_adapter(tmp_path),
+        trace_dir=tmp_path,
+        callback_handler=callback,
+    )
+    request = make_request(tool_call_request, tool_name="tool.allow", scenario="allow")
+    calls = {"count": 0}
+
+    def _handler(_: object) -> dict[str, bool]:
+        calls["count"] += 1
+        return {"ok": True}
+
+    result = middleware.wrap_tool_call(request, _handler)
+
+    assert result == {"ok": True}
+    assert calls["count"] == 1
+    assert len(callback.events) == 1
+    metadata = callback.events[0]
+    assert metadata.executed is True
+    assert metadata.verdict == "allow"
+    assert metadata.run_id == "run_langchain_allow"
+    assert metadata.request_id == "req_langchain_allow"
+    assert metadata.auth_context == {"framework": "langchain"}
+    assert metadata.trace_path is not None
+    assert Path(metadata.trace_path).exists()
+    assert metadata.policy_digest == "3" * 64
+    assert metadata.intent_digest == "2" * 64
+
+
+@pytest.mark.parametrize(
+    ("tool_name", "scenario", "expected_verdict"),
+    [
+        ("tool.block", "block", "block"),
+        ("tool.approval", "require_approval", "require_approval"),
+    ],
+)
+def test_langchain_non_allow_verdicts_fail_closed(
+    tmp_path: Path,
+    tool_name: str,
+    scenario: str,
+    expected_verdict: str,
+) -> None:
+    tool_call_request, gait_langchain = load_langchain_test_module()
+    callback = gait_langchain.GaitLangChainCallbackHandler()
+    middleware = gait_langchain.GaitLangChainMiddleware(
+        make_adapter(tmp_path),
+        trace_dir=tmp_path,
+        callback_handler=callback,
+    )
+    request = make_request(tool_call_request, tool_name=tool_name, scenario=scenario)
+    calls = {"count": 0}
+
+    def _handler(_: object) -> dict[str, bool]:
+        calls["count"] += 1
+        return {"ok": True}
+
+    with pytest.raises(GateEnforcementError) as error:
+        middleware.wrap_tool_call(request, _handler)
+
+    assert error.value.decision.verdict == expected_verdict
+    assert calls["count"] == 0
+    assert len(callback.events) == 1
+    metadata = callback.events[0]
+    assert metadata.executed is False
+    assert metadata.verdict == expected_verdict
+    assert metadata.trace_path is not None
+    assert Path(metadata.trace_path).exists()
+
+
+def test_langchain_run_session_keeps_run_id_and_trace_metadata(tmp_path: Path) -> None:
+    tool_call_request, gait_langchain = load_langchain_test_module()
+    middleware = gait_langchain.GaitLangChainMiddleware(
+        make_adapter(tmp_path),
+        trace_dir=tmp_path,
+    )
+    request = make_request(tool_call_request, tool_name="tool.allow", scenario="session")
+
+    with run_session(
+        run_id="run_langchain_session",
+        gait_bin=[sys.executable, str(tmp_path / "fake_gait.py")],
+        cwd=tmp_path,
+        out_dir=tmp_path / "gait-out",
+    ) as session:
+        result = middleware.wrap_tool_call(request, lambda _: {"ok": True})
+
+    assert result == {"ok": True}
+    assert session.capture is not None
+    assert session.capture.run_id == "run_langchain_session"
+    assert session.record_input is not None
+    assert session.record_input["run"]["run_id"] == "run_langchain_session"
+    assert session.attempts[0].verdict == "allow"
+    receipts = session.record_input["refs"]["receipts"]
+    assert receipts[0]["source_locator"].endswith("tool.allow_call_langchain_session.json")

--- a/sdk/python/uv.lock
+++ b/sdk/python/uv.lock
@@ -3,6 +3,27 @@ revision = 3
 requires-python = ">=3.13"
 
 [[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
+name = "anyio"
+version = "4.12.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/96/f0/5eb65b2bb0d09ac6776f2eb54adee6abe8228ea05b20a5ad0e4945de8aac/anyio-4.12.1.tar.gz", hash = "sha256:41cfcc3a4c85d3f05c932da7c26d0201ac36f72abd4435ba90d0464a3ffed703", size = 228685, upload-time = "2026-01-06T11:45:21.246Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/0e/27be9fdef66e72d64c0cdc3cc2823101b80585f8119b5c112c2e8f5f7dab/anyio-4.12.1-py3-none-any.whl", hash = "sha256:d405828884fc140aa80a3c667b8beed277f1dfedec42ba031bd6ac3db606ab6c", size = 113592, upload-time = "2026-01-06T11:45:19.497Z" },
+]
+
+[[package]]
 name = "bandit"
 version = "1.9.3"
 source = { registry = "https://pypi.org/simple" }
@@ -15,6 +36,56 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/89/76/a7f3e639b78601118aaa4a394db2c66ae2597fbd8c39644c32874ed11e0c/bandit-1.9.3.tar.gz", hash = "sha256:ade4b9b7786f89ef6fc7344a52b34558caec5da74cb90373aed01de88472f774", size = 4242154, upload-time = "2026-01-19T04:05:22.802Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e0/0b/8bdc52111c83e2dc2f97403dc87c0830b8989d9ae45732b34b686326fb2c/bandit-1.9.3-py3-none-any.whl", hash = "sha256:4745917c88d2246def79748bde5e08b9d5e9b92f877863d43fab70cd8814ce6a", size = 134451, upload-time = "2026-01-19T04:05:20.938Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.2.25"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/2d/7bf41579a8986e348fa033a31cdd0e4121114f6bce2457e8876010b092dd/certifi-2026.2.25.tar.gz", hash = "sha256:e887ab5cee78ea814d3472169153c2d12cd43b14bd03329a39a9c6e2e80bfba7", size = 155029, upload-time = "2026-02-25T02:54:17.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/3c/c17fb3ca2d9c3acff52e30b309f538586f9f5b9c9cf454f3845fc9af4881/certifi-2026.2.25-py3-none-any.whl", hash = "sha256:027692e4402ad994f1c42e52a4997a9763c646b73e4096e4d5d6db8af1d6f0fa", size = 153684, upload-time = "2026-02-25T02:54:15.766Z" },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.4.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1d/35/02daf95b9cd686320bb622eb148792655c9412dbb9b67abb5694e5910a24/charset_normalizer-3.4.5.tar.gz", hash = "sha256:95adae7b6c42a6c5b5b559b1a99149f090a57128155daeea91732c8d970d8644", size = 134804, upload-time = "2026-03-06T06:03:19.46Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/48/9f34ec4bb24aa3fdba1890c1bddb97c8a4be1bd84ef5c42ac2352563ad05/charset_normalizer-3.4.5-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ac59c15e3f1465f722607800c68713f9fbc2f672b9eb649fe831da4019ae9b23", size = 280788, upload-time = "2026-03-06T06:01:37.126Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/09/6003e7ffeb90cc0560da893e3208396a44c210c5ee42efff539639def59b/charset_normalizer-3.4.5-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:165c7b21d19365464e8f70e5ce5e12524c58b48c78c1f5a57524603c1ab003f8", size = 188890, upload-time = "2026-03-06T06:01:38.73Z" },
+    { url = "https://files.pythonhosted.org/packages/42/1e/02706edf19e390680daa694d17e2b8eab4b5f7ac285e2a51168b4b22ee6b/charset_normalizer-3.4.5-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:28269983f25a4da0425743d0d257a2d6921ea7d9b83599d4039486ec5b9f911d", size = 206136, upload-time = "2026-03-06T06:01:40.016Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/87/942c3def1b37baf3cf786bad01249190f3ca3d5e63a84f831e704977de1f/charset_normalizer-3.4.5-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d27ce22ec453564770d29d03a9506d449efbb9fa13c00842262b2f6801c48cce", size = 202551, upload-time = "2026-03-06T06:01:41.522Z" },
+    { url = "https://files.pythonhosted.org/packages/94/0a/af49691938dfe175d71b8a929bd7e4ace2809c0c5134e28bc535660d5262/charset_normalizer-3.4.5-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0625665e4ebdddb553ab185de5db7054393af8879fb0c87bd5690d14379d6819", size = 195572, upload-time = "2026-03-06T06:01:43.208Z" },
+    { url = "https://files.pythonhosted.org/packages/20/ea/dfb1792a8050a8e694cfbde1570ff97ff74e48afd874152d38163d1df9ae/charset_normalizer-3.4.5-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:c23eb3263356d94858655b3e63f85ac5d50970c6e8febcdde7830209139cc37d", size = 184438, upload-time = "2026-03-06T06:01:44.755Z" },
+    { url = "https://files.pythonhosted.org/packages/72/12/c281e2067466e3ddd0595bfaea58a6946765ace5c72dfa3edc2f5f118026/charset_normalizer-3.4.5-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e6302ca4ae283deb0af68d2fbf467474b8b6aedcd3dab4db187e07f94c109763", size = 193035, upload-time = "2026-03-06T06:01:46.051Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/4f/3792c056e7708e10464bad0438a44708886fb8f92e3c3d29ec5e2d964d42/charset_normalizer-3.4.5-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:e51ae7d81c825761d941962450f50d041db028b7278e7b08930b4541b3e45cb9", size = 191340, upload-time = "2026-03-06T06:01:47.547Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/86/80ddba897127b5c7a9bccc481b0cd36c8fefa485d113262f0fe4332f0bf4/charset_normalizer-3.4.5-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:597d10dec876923e5c59e48dbd366e852eacb2b806029491d307daea6b917d7c", size = 185464, upload-time = "2026-03-06T06:01:48.764Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/00/b5eff85ba198faacab83e0e4b6f0648155f072278e3b392a82478f8b988b/charset_normalizer-3.4.5-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:5cffde4032a197bd3b42fd0b9509ec60fb70918d6970e4cc773f20fc9180ca67", size = 208014, upload-time = "2026-03-06T06:01:50.371Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/11/d36f70be01597fd30850dde8a1269ebc8efadd23ba5785808454f2389bde/charset_normalizer-3.4.5-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:2da4eedcb6338e2321e831a0165759c0c620e37f8cd044a263ff67493be8ffb3", size = 193297, upload-time = "2026-03-06T06:01:51.933Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/1d/259eb0a53d4910536c7c2abb9cb25f4153548efb42800c6a9456764649c0/charset_normalizer-3.4.5-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:65a126fb4b070d05340a84fc709dd9e7c75d9b063b610ece8a60197a291d0adf", size = 204321, upload-time = "2026-03-06T06:01:53.887Z" },
+    { url = "https://files.pythonhosted.org/packages/84/31/faa6c5b9d3688715e1ed1bb9d124c384fe2fc1633a409e503ffe1c6398c1/charset_normalizer-3.4.5-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:c7a80a9242963416bd81f99349d5f3fce1843c303bd404f204918b6d75a75fd6", size = 197509, upload-time = "2026-03-06T06:01:56.439Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/a5/c7d9dd1503ffc08950b3260f5d39ec2366dd08254f0900ecbcf3a6197c7c/charset_normalizer-3.4.5-cp313-cp313-win32.whl", hash = "sha256:f1d725b754e967e648046f00c4facc42d414840f5ccc670c5670f59f83693e4f", size = 132284, upload-time = "2026-03-06T06:01:57.812Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/0f/57072b253af40c8aa6636e6de7d75985624c1eb392815b2f934199340a89/charset_normalizer-3.4.5-cp313-cp313-win_amd64.whl", hash = "sha256:e37bd100d2c5d3ba35db9c7c5ba5a9228cbcffe5c4778dc824b164e5257813d7", size = 142630, upload-time = "2026-03-06T06:01:59.062Z" },
+    { url = "https://files.pythonhosted.org/packages/31/41/1c4b7cc9f13bd9d369ce3bc993e13d374ce25fa38a2663644283ecf422c1/charset_normalizer-3.4.5-cp313-cp313-win_arm64.whl", hash = "sha256:93b3b2cc5cf1b8743660ce77a4f45f3f6d1172068207c1defc779a36eea6bb36", size = 133254, upload-time = "2026-03-06T06:02:00.281Z" },
+    { url = "https://files.pythonhosted.org/packages/43/be/0f0fd9bb4a7fa4fb5067fb7d9ac693d4e928d306f80a0d02bde43a7c4aee/charset_normalizer-3.4.5-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:8197abe5ca1ffb7d91e78360f915eef5addff270f8a71c1fc5be24a56f3e4873", size = 280232, upload-time = "2026-03-06T06:02:01.508Z" },
+    { url = "https://files.pythonhosted.org/packages/28/02/983b5445e4bef49cd8c9da73a8e029f0825f39b74a06d201bfaa2e55142a/charset_normalizer-3.4.5-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a2aecdb364b8a1802afdc7f9327d55dad5366bc97d8502d0f5854e50712dbc5f", size = 189688, upload-time = "2026-03-06T06:02:02.857Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/88/152745c5166437687028027dc080e2daed6fe11cfa95a22f4602591c42db/charset_normalizer-3.4.5-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a66aa5022bf81ab4b1bebfb009db4fd68e0c6d4307a1ce5ef6a26e5878dfc9e4", size = 206833, upload-time = "2026-03-06T06:02:05.127Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/0f/ebc15c8b02af2f19be9678d6eed115feeeccc45ce1f4b098d986c13e8769/charset_normalizer-3.4.5-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d77f97e515688bd615c1d1f795d540f32542d514242067adcb8ef532504cb9ee", size = 202879, upload-time = "2026-03-06T06:02:06.446Z" },
+    { url = "https://files.pythonhosted.org/packages/38/9c/71336bff6934418dc8d1e8a1644176ac9088068bc571da612767619c97b3/charset_normalizer-3.4.5-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:01a1ed54b953303ca7e310fafe0fe347aab348bd81834a0bcd602eb538f89d66", size = 195764, upload-time = "2026-03-06T06:02:08.763Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/95/ce92fde4f98615661871bc282a856cf9b8a15f686ba0af012984660d480b/charset_normalizer-3.4.5-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:b2d37d78297b39a9eb9eb92c0f6df98c706467282055419df141389b23f93362", size = 183728, upload-time = "2026-03-06T06:02:10.137Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/e7/f5b4588d94e747ce45ae680f0f242bc2d98dbd4eccfab73e6160b6893893/charset_normalizer-3.4.5-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e71bbb595973622b817c042bd943c3f3667e9c9983ce3d205f973f486fec98a7", size = 192937, upload-time = "2026-03-06T06:02:11.663Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/29/9d94ed6b929bf9f48bf6ede6e7474576499f07c4c5e878fb186083622716/charset_normalizer-3.4.5-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:4cd966c2559f501c6fd69294d082c2934c8dd4719deb32c22961a5ac6db0df1d", size = 192040, upload-time = "2026-03-06T06:02:13.489Z" },
+    { url = "https://files.pythonhosted.org/packages/15/d2/1a093a1cf827957f9445f2fe7298bcc16f8fc5e05c1ed2ad1af0b239035e/charset_normalizer-3.4.5-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:d5e52d127045d6ae01a1e821acfad2f3a1866c54d0e837828538fabe8d9d1bd6", size = 184107, upload-time = "2026-03-06T06:02:14.83Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/7d/82068ce16bd36135df7b97f6333c5d808b94e01d4599a682e2337ed5fd14/charset_normalizer-3.4.5-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:30a2b1a48478c3428d047ed9690d57c23038dac838a87ad624c85c0a78ebeb39", size = 208310, upload-time = "2026-03-06T06:02:16.165Z" },
+    { url = "https://files.pythonhosted.org/packages/84/4e/4dfb52307bb6af4a5c9e73e482d171b81d36f522b21ccd28a49656baa680/charset_normalizer-3.4.5-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:d8ed79b8f6372ca4254955005830fd61c1ccdd8c0fac6603e2c145c61dd95db6", size = 192918, upload-time = "2026-03-06T06:02:18.144Z" },
+    { url = "https://files.pythonhosted.org/packages/08/a4/159ff7da662cf7201502ca89980b8f06acf3e887b278956646a8aeb178ab/charset_normalizer-3.4.5-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:c5af897b45fa606b12464ccbe0014bbf8c09191e0a66aab6aa9d5cf6e77e0c94", size = 204615, upload-time = "2026-03-06T06:02:19.821Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/62/0dd6172203cb6b429ffffc9935001fde42e5250d57f07b0c28c6046deb6b/charset_normalizer-3.4.5-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:1088345bcc93c58d8d8f3d783eca4a6e7a7752bbff26c3eee7e73c597c191c2e", size = 197784, upload-time = "2026-03-06T06:02:21.86Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/5e/1aab5cb737039b9c59e63627dc8bbc0d02562a14f831cc450e5f91d84ce1/charset_normalizer-3.4.5-cp314-cp314-win32.whl", hash = "sha256:ee57b926940ba00bca7ba7041e665cc956e55ef482f851b9b65acb20d867e7a2", size = 133009, upload-time = "2026-03-06T06:02:23.289Z" },
+    { url = "https://files.pythonhosted.org/packages/40/65/e7c6c77d7aaa4c0d7974f2e403e17f0ed2cb0fc135f77d686b916bf1eead/charset_normalizer-3.4.5-cp314-cp314-win_amd64.whl", hash = "sha256:4481e6da1830c8a1cc0b746b47f603b653dadb690bcd851d039ffaefe70533aa", size = 143511, upload-time = "2026-03-06T06:02:26.195Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/91/52b0841c71f152f563b8e072896c14e3d83b195c188b338d3cc2e582d1d4/charset_normalizer-3.4.5-cp314-cp314-win_arm64.whl", hash = "sha256:97ab7787092eb9b50fb47fa04f24c75b768a606af1bcba1957f07f128a7219e4", size = 133775, upload-time = "2026-03-06T06:02:27.473Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/60/3a621758945513adfd4db86827a5bafcc615f913dbd0b4c2ed64a65731be/charset_normalizer-3.4.5-py3-none-any.whl", hash = "sha256:9db5e3fcdcee89a78c04dffb3fe33c79f77bd741a624946db2591c81b2fc85b0", size = 55455, upload-time = "2026-03-06T06:03:17.827Z" },
 ]
 
 [[package]]
@@ -100,16 +171,66 @@ dev = [
     { name = "pytest-cov" },
     { name = "ruff" },
 ]
+langchain = [
+    { name = "langchain" },
+]
 
 [package.metadata]
 requires-dist = [
     { name = "bandit", marker = "extra == 'dev'", specifier = ">=1.7" },
+    { name = "langchain", marker = "extra == 'langchain'", specifier = ">=1.0,<2.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.8" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.8" },
 ]
-provides-extras = ["dev"]
+provides-extras = ["dev", "langchain"]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.11"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+]
 
 [[package]]
 name = "iniconfig"
@@ -118,6 +239,136 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "jsonpatch"
+version = "1.33"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jsonpointer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/78/18813351fe5d63acad16aec57f94ec2b70a09e53ca98145589e185423873/jsonpatch-1.33.tar.gz", hash = "sha256:9fcd4009c41e6d12348b4a0ff2563ba56a2923a7dfee731d004e212e1ee5030c", size = 21699, upload-time = "2023-06-26T12:07:29.144Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/73/07/02e16ed01e04a374e644b575638ec7987ae846d25ad97bcc9945a3ee4b0e/jsonpatch-1.33-py2.py3-none-any.whl", hash = "sha256:0ae28c0cd062bbd8b8ecc26d7d164fbbea9652a1a3693f3b956c1eae5145dade", size = 12898, upload-time = "2023-06-16T21:01:28.466Z" },
+]
+
+[[package]]
+name = "jsonpointer"
+version = "3.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6a/0a/eebeb1fa92507ea94016a2a790b93c2ae41a7e18778f85471dc54475ed25/jsonpointer-3.0.0.tar.gz", hash = "sha256:2b2d729f2091522d61c3b31f82e11870f60b68f43fbc705cb76bf4b832af59ef", size = 9114, upload-time = "2024-06-10T19:24:42.462Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/92/5e77f98553e9e75130c78900d000368476aed74276eb8ae8796f65f00918/jsonpointer-3.0.0-py2.py3-none-any.whl", hash = "sha256:13e088adc14fca8b6aa8177c044e12701e6ad4b28ff10e65f2267a90109c9942", size = 7595, upload-time = "2024-06-10T19:24:40.698Z" },
+]
+
+[[package]]
+name = "langchain"
+version = "1.2.11"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "langchain-core" },
+    { name = "langgraph" },
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8a/ed/990ec469ee2c4876adc367a1bb10143132a54a6fd9757269d2e440d65b37/langchain-1.2.11.tar.gz", hash = "sha256:1b0f680de88c178898a69f9814025729110fc68365b2c33cd2ba978114d5fc0a", size = 566207, upload-time = "2026-03-10T19:46:14.519Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/24/c9fd2d6f31ef7444e163aa9295c2c661892c8b2b683b4b6dd190ffd29a2f/langchain-1.2.11-py3-none-any.whl", hash = "sha256:ccc5d23e2568efa6e3cb2dde268a267d7f090bdad47d7e1ee5f0c9769e8cb7b9", size = 112136, upload-time = "2026-03-10T19:46:12.433Z" },
+]
+
+[[package]]
+name = "langchain-core"
+version = "1.2.18"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jsonpatch" },
+    { name = "langsmith" },
+    { name = "packaging" },
+    { name = "pydantic" },
+    { name = "pyyaml" },
+    { name = "tenacity" },
+    { name = "typing-extensions" },
+    { name = "uuid-utils" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/18/b7/8bbd0d99a6441b35d891e4b79e7d24c67722cdd363893ae650f24808cf5a/langchain_core-1.2.18.tar.gz", hash = "sha256:ffe53eec44636d092895b9fe25d28af3aaf79060e293fa7cda2a5aaa50c80d21", size = 836725, upload-time = "2026-03-09T20:40:07.229Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1f/d8/9418564ed4ab4f150668b25cf8c188266267d829362e9c9106946afa628b/langchain_core-1.2.18-py3-none-any.whl", hash = "sha256:cccb79523e0045174ab826054e555fddc973266770e427588c8f1ec9d9d6212b", size = 503048, upload-time = "2026-03-09T20:40:06.115Z" },
+]
+
+[[package]]
+name = "langgraph"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "langchain-core" },
+    { name = "langgraph-checkpoint" },
+    { name = "langgraph-prebuilt" },
+    { name = "langgraph-sdk" },
+    { name = "pydantic" },
+    { name = "xxhash" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c6/de/be274968aa1ce40a109e0e638718d4e31872e97dbc84d3b5c7ab81a18d4e/langgraph-1.1.0.tar.gz", hash = "sha256:2decaef5d6716166dc5c13e0fdf65637e5a1837ef4c94fd82b6bcf2115cb5c78", size = 542647, upload-time = "2026-03-10T12:46:34.156Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/61/0c/4920a1c5d2d1059f706b547019091e4da74ab30cd95fe114af737a89236f/langgraph-1.1.0-py3-none-any.whl", hash = "sha256:7d29e01312340c9c7c09eb0178db5edd0514c3f35929fa5b32a247fcd9a9cd65", size = 167249, upload-time = "2026-03-10T12:46:32.546Z" },
+]
+
+[[package]]
+name = "langgraph-checkpoint"
+version = "4.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "langchain-core" },
+    { name = "ormsgpack" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/44/a8df45d1e8b4637e29789fa8bae1db022c953cc7ac80093cfc52e923547e/langgraph_checkpoint-4.0.1.tar.gz", hash = "sha256:b433123735df11ade28829e40ce25b9be614930cd50245ff2af60629234befd9", size = 158135, upload-time = "2026-02-27T21:06:16.092Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/65/4c/09a4a0c42f5d2fc38d6c4d67884788eff7fd2cfdf367fdf7033de908b4c0/langgraph_checkpoint-4.0.1-py3-none-any.whl", hash = "sha256:e3adcd7a0e0166f3b48b8cf508ce0ea366e7420b5a73aa81289888727769b034", size = 50453, upload-time = "2026-02-27T21:06:14.293Z" },
+]
+
+[[package]]
+name = "langgraph-prebuilt"
+version = "1.0.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "langchain-core" },
+    { name = "langgraph-checkpoint" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0d/06/dd61a5c2dce009d1b03b1d56f2a85b3127659fdddf5b3be5d8f1d60820fb/langgraph_prebuilt-1.0.8.tar.gz", hash = "sha256:0cd3cf5473ced8a6cd687cc5294e08d3de57529d8dd14fdc6ae4899549efcf69", size = 164442, upload-time = "2026-02-19T18:14:39.083Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/41/ec966424ad3f2ed3996d24079d3342c8cd6c0bd0653c12b2a917a685ec6c/langgraph_prebuilt-1.0.8-py3-none-any.whl", hash = "sha256:d16a731e591ba4470f3e313a319c7eee7dbc40895bcf15c821f985a3522a7ce0", size = 35648, upload-time = "2026-02-19T18:14:37.611Z" },
+]
+
+[[package]]
+name = "langgraph-sdk"
+version = "0.3.11"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+    { name = "orjson" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/35/cd/a019f1b1e97c519f2425593f9bccd3ac463a18fb5d2111cff59ce1ef62fe/langgraph_sdk-0.3.11.tar.gz", hash = "sha256:3640134835d89d2c7c8bb7de73bd10673d4b282db3ff0e2fdaf1cee9e50cb1eb", size = 190387, upload-time = "2026-03-11T00:46:45.25Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/c8/b8d15d4b9a320a3f57a851030a371066b91dbd1420f097d3d0338da9adc9/langgraph_sdk-0.3.11-py3-none-any.whl", hash = "sha256:18905fd6248ade98b0995d859a98672d57c811fbfffc0d63d1c107a512351b26", size = 94887, upload-time = "2026-03-11T00:46:43.855Z" },
+]
+
+[[package]]
+name = "langsmith"
+version = "0.7.16"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+    { name = "orjson", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "packaging" },
+    { name = "pydantic" },
+    { name = "requests" },
+    { name = "requests-toolbelt" },
+    { name = "uuid-utils" },
+    { name = "xxhash" },
+    { name = "zstandard" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4d/18/b240d33e32d3f71a3c3375781cb11f3be6b27c275acdcf18c08a65a560cc/langsmith-0.7.16.tar.gz", hash = "sha256:87267d32c1220ec34bd0074d3d04b57c7394328a39a02182b62ab4ae09d28144", size = 1115428, upload-time = "2026-03-09T21:11:16.985Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d0/a8/4202ca65561213ec84ca3800b1d4e5d37a1441cddeec533367ecbca7f408/langsmith-0.7.16-py3-none-any.whl", hash = "sha256:c84a7a06938025fe0aad992acc546dd75ce3f757ba8ee5b00ad914911d4fc02e", size = 347538, upload-time = "2026-03-09T21:11:15.02Z" },
 ]
 
 [[package]]
@@ -219,6 +470,74 @@ wheels = [
 ]
 
 [[package]]
+name = "orjson"
+version = "3.11.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/45/b268004f745ede84e5798b48ee12b05129d19235d0e15267aa57dcdb400b/orjson-3.11.7.tar.gz", hash = "sha256:9b1a67243945819ce55d24a30b59d6a168e86220452d2c96f4d1f093e71c0c49", size = 6144992, upload-time = "2026-02-02T15:38:49.29Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/89/25/6e0e52cac5aab51d7b6dcd257e855e1dec1c2060f6b28566c509b4665f62/orjson-3.11.7-cp313-cp313-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:1d98b30cc1313d52d4af17d9c3d307b08389752ec5f2e5febdfada70b0f8c733", size = 228390, upload-time = "2026-02-02T15:38:06.8Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/29/a77f48d2fc8a05bbc529e5ff481fb43d914f9e383ea2469d4f3d51df3d00/orjson-3.11.7-cp313-cp313-macosx_15_0_arm64.whl", hash = "sha256:d897e81f8d0cbd2abb82226d1860ad2e1ab3ff16d7b08c96ca00df9d45409ef4", size = 125189, upload-time = "2026-02-02T15:38:08.181Z" },
+    { url = "https://files.pythonhosted.org/packages/89/25/0a16e0729a0e6a1504f9d1a13cdd365f030068aab64cec6958396b9969d7/orjson-3.11.7-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:814be4b49b228cfc0b3c565acf642dd7d13538f966e3ccde61f4f55be3e20785", size = 128106, upload-time = "2026-02-02T15:38:09.41Z" },
+    { url = "https://files.pythonhosted.org/packages/66/da/a2e505469d60666a05ab373f1a6322eb671cb2ba3a0ccfc7d4bc97196787/orjson-3.11.7-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d06e5c5fed5caedd2e540d62e5b1c25e8c82431b9e577c33537e5fa4aa909539", size = 123363, upload-time = "2026-02-02T15:38:10.73Z" },
+    { url = "https://files.pythonhosted.org/packages/23/bf/ed73f88396ea35c71b38961734ea4a4746f7ca0768bf28fd551d37e48dd0/orjson-3.11.7-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:31c80ce534ac4ea3739c5ee751270646cbc46e45aea7576a38ffec040b4029a1", size = 129007, upload-time = "2026-02-02T15:38:12.138Z" },
+    { url = "https://files.pythonhosted.org/packages/73/3c/b05d80716f0225fc9008fbf8ab22841dcc268a626aa550561743714ce3bf/orjson-3.11.7-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f50979824bde13d32b4320eedd513431c921102796d86be3eee0b58e58a3ecd1", size = 141667, upload-time = "2026-02-02T15:38:13.398Z" },
+    { url = "https://files.pythonhosted.org/packages/61/e8/0be9b0addd9bf86abfc938e97441dcd0375d494594b1c8ad10fe57479617/orjson-3.11.7-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9e54f3808e2b6b945078c41aa8d9b5834b28c50843846e97807e5adb75fa9705", size = 130832, upload-time = "2026-02-02T15:38:14.698Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/ec/c68e3b9021a31d9ec15a94931db1410136af862955854ed5dd7e7e4f5bff/orjson-3.11.7-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a12b80df61aab7b98b490fe9e4879925ba666fccdfcd175252ce4d9035865ace", size = 133373, upload-time = "2026-02-02T15:38:16.109Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/45/f3466739aaafa570cc8e77c6dbb853c48bf56e3b43738020e2661e08b0ac/orjson-3.11.7-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:996b65230271f1a97026fd0e6a753f51fbc0c335d2ad0c6201f711b0da32693b", size = 138307, upload-time = "2026-02-02T15:38:17.453Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/84/9f7f02288da1ffb31405c1be07657afd1eecbcb4b64ee2817b6fe0f785fa/orjson-3.11.7-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:ab49d4b2a6a1d415ddb9f37a21e02e0d5dbfe10b7870b21bf779fc21e9156157", size = 408695, upload-time = "2026-02-02T15:38:18.831Z" },
+    { url = "https://files.pythonhosted.org/packages/18/07/9dd2f0c0104f1a0295ffbe912bc8d63307a539b900dd9e2c48ef7810d971/orjson-3.11.7-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:390a1dce0c055ddf8adb6aa94a73b45a4a7d7177b5c584b8d1c1947f2ba60fb3", size = 144099, upload-time = "2026-02-02T15:38:20.28Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/66/857a8e4a3292e1f7b1b202883bcdeb43a91566cf59a93f97c53b44bd6801/orjson-3.11.7-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1eb80451a9c351a71dfaf5b7ccc13ad065405217726b59fdbeadbcc544f9d223", size = 134806, upload-time = "2026-02-02T15:38:22.186Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/5b/6ebcf3defc1aab3a338ca777214966851e92efb1f30dc7fc8285216e6d1b/orjson-3.11.7-cp313-cp313-win32.whl", hash = "sha256:7477aa6a6ec6139c5cb1cc7b214643592169a5494d200397c7fc95d740d5fcf3", size = 127914, upload-time = "2026-02-02T15:38:23.511Z" },
+    { url = "https://files.pythonhosted.org/packages/00/04/c6f72daca5092e3117840a1b1e88dfc809cc1470cf0734890d0366b684a1/orjson-3.11.7-cp313-cp313-win_amd64.whl", hash = "sha256:b9f95dcdea9d4f805daa9ddf02617a89e484c6985fa03055459f90e87d7a0757", size = 124986, upload-time = "2026-02-02T15:38:24.836Z" },
+    { url = "https://files.pythonhosted.org/packages/03/ba/077a0f6f1085d6b806937246860fafbd5b17f3919c70ee3f3d8d9c713f38/orjson-3.11.7-cp313-cp313-win_arm64.whl", hash = "sha256:800988273a014a0541483dc81021247d7eacb0c845a9d1a34a422bc718f41539", size = 126045, upload-time = "2026-02-02T15:38:26.216Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/1e/745565dca749813db9a093c5ebc4bac1a9475c64d54b95654336ac3ed961/orjson-3.11.7-cp314-cp314-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:de0a37f21d0d364954ad5de1970491d7fbd0fb1ef7417d4d56a36dc01ba0c0a0", size = 228391, upload-time = "2026-02-02T15:38:27.757Z" },
+    { url = "https://files.pythonhosted.org/packages/46/19/e40f6225da4d3aa0c8dc6e5219c5e87c2063a560fe0d72a88deb59776794/orjson-3.11.7-cp314-cp314-macosx_15_0_arm64.whl", hash = "sha256:c2428d358d85e8da9d37cba18b8c4047c55222007a84f97156a5b22028dfbfc0", size = 125188, upload-time = "2026-02-02T15:38:29.241Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/7e/c4de2babef2c0817fd1f048fd176aa48c37bec8aef53d2fa932983032cce/orjson-3.11.7-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3c4bc6c6ac52cdaa267552544c73e486fecbd710b7ac09bc024d5a78555a22f6", size = 128097, upload-time = "2026-02-02T15:38:30.618Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/74/233d360632bafd2197f217eee7fb9c9d0229eac0c18128aee5b35b0014fe/orjson-3.11.7-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bd0d68edd7dfca1b2eca9361a44ac9f24b078de3481003159929a0573f21a6bf", size = 123364, upload-time = "2026-02-02T15:38:32.363Z" },
+    { url = "https://files.pythonhosted.org/packages/79/51/af79504981dd31efe20a9e360eb49c15f06df2b40e7f25a0a52d9ae888e8/orjson-3.11.7-cp314-cp314-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:623ad1b9548ef63886319c16fa317848e465a21513b31a6ad7b57443c3e0dcf5", size = 129076, upload-time = "2026-02-02T15:38:33.68Z" },
+    { url = "https://files.pythonhosted.org/packages/67/e2/da898eb68b72304f8de05ca6715870d09d603ee98d30a27e8a9629abc64b/orjson-3.11.7-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6e776b998ac37c0396093d10290e60283f59cfe0fc3fccbd0ccc4bd04dd19892", size = 141705, upload-time = "2026-02-02T15:38:34.989Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/89/15364d92acb3d903b029e28d834edb8780c2b97404cbf7929aa6b9abdb24/orjson-3.11.7-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:652c6c3af76716f4a9c290371ba2e390ede06f6603edb277b481daf37f6f464e", size = 130855, upload-time = "2026-02-02T15:38:36.379Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/8b/ecdad52d0b38d4b8f514be603e69ccd5eacf4e7241f972e37e79792212ec/orjson-3.11.7-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a56df3239294ea5964adf074c54bcc4f0ccd21636049a2cf3ca9cf03b5d03cf1", size = 133386, upload-time = "2026-02-02T15:38:37.704Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/0e/45e1dcf10e17d0924b7c9162f87ec7b4ca79e28a0548acf6a71788d3e108/orjson-3.11.7-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:bda117c4148e81f746655d5a3239ae9bd00cb7bc3ca178b5fc5a5997e9744183", size = 138295, upload-time = "2026-02-02T15:38:39.096Z" },
+    { url = "https://files.pythonhosted.org/packages/63/d7/4d2e8b03561257af0450f2845b91fbd111d7e526ccdf737267108075e0ba/orjson-3.11.7-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:23d6c20517a97a9daf1d48b580fcdc6f0516c6f4b5038823426033690b4d2650", size = 408720, upload-time = "2026-02-02T15:38:40.634Z" },
+    { url = "https://files.pythonhosted.org/packages/78/cf/d45343518282108b29c12a65892445fc51f9319dc3c552ceb51bb5905ed2/orjson-3.11.7-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:8ff206156006da5b847c9304b6308a01e8cdbc8cce824e2779a5ba71c3def141", size = 144152, upload-time = "2026-02-02T15:38:42.262Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/3a/d6001f51a7275aacd342e77b735c71fa04125a3f93c36fee4526bc8c654e/orjson-3.11.7-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:962d046ee1765f74a1da723f4b33e3b228fe3a48bd307acce5021dfefe0e29b2", size = 134814, upload-time = "2026-02-02T15:38:43.627Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/d3/f19b47ce16820cc2c480f7f1723e17f6d411b3a295c60c8ad3aa9ff1c96a/orjson-3.11.7-cp314-cp314-win32.whl", hash = "sha256:89e13dd3f89f1c38a9c9eba5fbf7cdc2d1feca82f5f290864b4b7a6aac704576", size = 127997, upload-time = "2026-02-02T15:38:45.06Z" },
+    { url = "https://files.pythonhosted.org/packages/12/df/172771902943af54bf661a8d102bdf2e7f932127968080632bda6054b62c/orjson-3.11.7-cp314-cp314-win_amd64.whl", hash = "sha256:845c3e0d8ded9c9271cd79596b9b552448b885b97110f628fb687aee2eed11c1", size = 124985, upload-time = "2026-02-02T15:38:46.388Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/1c/f2a8d8a1b17514660a614ce5f7aac74b934e69f5abc2700cc7ced882a009/orjson-3.11.7-cp314-cp314-win_arm64.whl", hash = "sha256:4a2e9c5be347b937a2e0203866f12bba36082e89b402ddb9e927d5822e43088d", size = 126038, upload-time = "2026-02-02T15:38:47.703Z" },
+]
+
+[[package]]
+name = "ormsgpack"
+version = "1.12.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/12/0c/f1761e21486942ab9bb6feaebc610fa074f7c5e496e6962dea5873348077/ormsgpack-1.12.2.tar.gz", hash = "sha256:944a2233640273bee67521795a73cf1e959538e0dfb7ac635505010455e53b33", size = 39031, upload-time = "2026-01-18T20:55:28.023Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/29/bb0eba3288c0449efbb013e9c6f58aea79cf5cb9ee1921f8865f04c1a9d7/ormsgpack-1.12.2-cp313-cp313-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:5ea60cb5f210b1cfbad8c002948d73447508e629ec375acb82910e3efa8ff355", size = 378661, upload-time = "2026-01-18T20:55:57.765Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/31/5efa31346affdac489acade2926989e019e8ca98129658a183e3add7af5e/ormsgpack-1.12.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f3601f19afdbea273ed70b06495e5794606a8b690a568d6c996a90d7255e51c1", size = 203194, upload-time = "2026-01-18T20:56:08.252Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/56/d0087278beef833187e0167f8527235ebe6f6ffc2a143e9de12a98b1ce87/ormsgpack-1.12.2-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:29a9f17a3dac6054c0dce7925e0f4995c727f7c41859adf9b5572180f640d172", size = 210778, upload-time = "2026-01-18T20:55:17.694Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/a2/072343e1413d9443e5a252a8eb591c2d5b1bffbe5e7bfc78c069361b92eb/ormsgpack-1.12.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:39c1bd2092880e413902910388be8715f70b9f15f20779d44e673033a6146f2d", size = 212592, upload-time = "2026-01-18T20:55:32.747Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/8b/a0da3b98a91d41187a63b02dda14267eefc2a74fcb43cc2701066cf1510e/ormsgpack-1.12.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:50b7249244382209877deedeee838aef1542f3d0fc28b8fe71ca9d7e1896a0d7", size = 387164, upload-time = "2026-01-18T20:55:40.853Z" },
+    { url = "https://files.pythonhosted.org/packages/19/bb/6d226bc4cf9fc20d8eb1d976d027a3f7c3491e8f08289a2e76abe96a65f3/ormsgpack-1.12.2-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:5af04800d844451cf102a59c74a841324868d3f1625c296a06cc655c542a6685", size = 482516, upload-time = "2026-01-18T20:55:42.033Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/f1/bb2c7223398543dedb3dbf8bb93aaa737b387de61c5feaad6f908841b782/ormsgpack-1.12.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:cec70477d4371cd524534cd16472d8b9cc187e0e3043a8790545a9a9b296c258", size = 425539, upload-time = "2026-01-18T20:55:24.727Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/e8/0fb45f57a2ada1fed374f7494c8cd55e2f88ccd0ab0a669aa3468716bf5f/ormsgpack-1.12.2-cp313-cp313-win_amd64.whl", hash = "sha256:21f4276caca5c03a818041d637e4019bc84f9d6ca8baa5ea03e5cc8bf56140e9", size = 117459, upload-time = "2026-01-18T20:55:56.876Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/d4/0cfeea1e960d550a131001a7f38a5132c7ae3ebde4c82af1f364ccc5d904/ormsgpack-1.12.2-cp313-cp313-win_arm64.whl", hash = "sha256:baca4b6773d20a82e36d6fd25f341064244f9f86a13dead95dd7d7f996f51709", size = 111577, upload-time = "2026-01-18T20:55:43.605Z" },
+    { url = "https://files.pythonhosted.org/packages/94/16/24d18851334be09c25e87f74307c84950f18c324a4d3c0b41dabdbf19c29/ormsgpack-1.12.2-cp314-cp314-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:bc68dd5915f4acf66ff2010ee47c8906dc1cf07399b16f4089f8c71733f6e36c", size = 378717, upload-time = "2026-01-18T20:55:26.164Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/a2/88b9b56f83adae8032ac6a6fa7f080c65b3baf9b6b64fd3d37bd202991d4/ormsgpack-1.12.2-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:46d084427b4132553940070ad95107266656cb646ea9da4975f85cb1a6676553", size = 203183, upload-time = "2026-01-18T20:55:18.815Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/80/43e4555963bf602e5bdc79cbc8debd8b6d5456c00d2504df9775e74b450b/ormsgpack-1.12.2-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c010da16235806cf1d7bc4c96bf286bfa91c686853395a299b3ddb49499a3e13", size = 210814, upload-time = "2026-01-18T20:55:33.973Z" },
+    { url = "https://files.pythonhosted.org/packages/78/e1/7cfbf28de8bca6efe7e525b329c31277d1b64ce08dcba723971c241a9d60/ormsgpack-1.12.2-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:18867233df592c997154ff942a6503df274b5ac1765215bceba7a231bea2745d", size = 212634, upload-time = "2026-01-18T20:55:28.634Z" },
+    { url = "https://files.pythonhosted.org/packages/95/f8/30ae5716e88d792a4e879debee195653c26ddd3964c968594ddef0a3cc7e/ormsgpack-1.12.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:b009049086ddc6b8f80c76b3955df1aa22a5fbd7673c525cd63bf91f23122ede", size = 387139, upload-time = "2026-01-18T20:56:02.013Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/81/aee5b18a3e3a0e52f718b37ab4b8af6fae0d9d6a65103036a90c2a8ffb5d/ormsgpack-1.12.2-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:1dcc17d92b6390d4f18f937cf0b99054824a7815818012ddca925d6e01c2e49e", size = 482578, upload-time = "2026-01-18T20:55:35.117Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/17/71c9ba472d5d45f7546317f467a5fc941929cd68fb32796ca3d13dcbaec2/ormsgpack-1.12.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:f04b5e896d510b07c0ad733d7fce2d44b260c5e6c402d272128f8941984e4285", size = 425539, upload-time = "2026-01-18T20:56:04.009Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/a6/ac99cd7fe77e822fed5250ff4b86fa66dd4238937dd178d2299f10b69816/ormsgpack-1.12.2-cp314-cp314-win_amd64.whl", hash = "sha256:ae3aba7eed4ca7cb79fd3436eddd29140f17ea254b91604aa1eb19bfcedb990f", size = 117493, upload-time = "2026-01-18T20:56:07.343Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/67/339872846a1ae4592535385a1c1f93614138566d7af094200c9c3b45d1e5/ormsgpack-1.12.2-cp314-cp314-win_arm64.whl", hash = "sha256:118576ea6006893aea811b17429bfc561b4778fad393f5f538c84af70b01260c", size = 111579, upload-time = "2026-01-18T20:55:21.161Z" },
+    { url = "https://files.pythonhosted.org/packages/49/c2/6feb972dc87285ad381749d3882d8aecbde9f6ecf908dd717d33d66df095/ormsgpack-1.12.2-cp314-cp314t-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:7121b3d355d3858781dc40dafe25a32ff8a8242b9d80c692fd548a4b1f7fd3c8", size = 378721, upload-time = "2026-01-18T20:55:52.12Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/9a/900a6b9b413e0f8a471cf07830f9cf65939af039a362204b36bd5b581d8b/ormsgpack-1.12.2-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4ee766d2e78251b7a63daf1cddfac36a73562d3ddef68cacfb41b2af64698033", size = 203170, upload-time = "2026-01-18T20:55:44.469Z" },
+    { url = "https://files.pythonhosted.org/packages/87/4c/27a95466354606b256f24fad464d7c97ab62bce6cc529dd4673e1179b8fb/ormsgpack-1.12.2-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:292410a7d23de9b40444636b9b8f1e4e4b814af7f1ef476e44887e52a123f09d", size = 212816, upload-time = "2026-01-18T20:55:23.501Z" },
+    { url = "https://files.pythonhosted.org/packages/73/cd/29cee6007bddf7a834e6cd6f536754c0535fcb939d384f0f37a38b1cddb8/ormsgpack-1.12.2-cp314-cp314t-win_amd64.whl", hash = "sha256:837dd316584485b72ef451d08dd3e96c4a11d12e4963aedb40e08f89685d8ec2", size = 117232, upload-time = "2026-01-18T20:55:45.448Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.0"
 source = { registry = "https://pypi.org/simple" }
@@ -243,6 +562,74 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pydantic"
+version = "2.12.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/69/44/36f1a6e523abc58ae5f928898e4aca2e0ea509b5aa6f6f392a5d882be928/pydantic-2.12.5.tar.gz", hash = "sha256:4d351024c75c0f085a9febbb665ce8c0c6ec5d30e903bdb6394b7ede26aebb49", size = 821591, upload-time = "2025-11-26T15:11:46.471Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/87/b70ad306ebb6f9b585f114d0ac2137d792b48be34d732d60e597c2f8465a/pydantic-2.12.5-py3-none-any.whl", hash = "sha256:e561593fccf61e8a20fc46dfc2dfe075b8be7d0188df33f221ad1f0139180f9d", size = 463580, upload-time = "2025-11-26T15:11:44.605Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.41.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/71/70/23b021c950c2addd24ec408e9ab05d59b035b39d97cdc1130e1bce647bb6/pydantic_core-2.41.5.tar.gz", hash = "sha256:08daa51ea16ad373ffd5e7606252cc32f07bc72b28284b6bc9c6df804816476e", size = 460952, upload-time = "2025-11-04T13:43:49.098Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/06/8806241ff1f70d9939f9af039c6c35f2360cf16e93c2ca76f184e76b1564/pydantic_core-2.41.5-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:941103c9be18ac8daf7b7adca8228f8ed6bb7a1849020f643b3a14d15b1924d9", size = 2120403, upload-time = "2025-11-04T13:40:25.248Z" },
+    { url = "https://files.pythonhosted.org/packages/94/02/abfa0e0bda67faa65fef1c84971c7e45928e108fe24333c81f3bfe35d5f5/pydantic_core-2.41.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:112e305c3314f40c93998e567879e887a3160bb8689ef3d2c04b6cc62c33ac34", size = 1896206, upload-time = "2025-11-04T13:40:27.099Z" },
+    { url = "https://files.pythonhosted.org/packages/15/df/a4c740c0943e93e6500f9eb23f4ca7ec9bf71b19e608ae5b579678c8d02f/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0cbaad15cb0c90aa221d43c00e77bb33c93e8d36e0bf74760cd00e732d10a6a0", size = 1919307, upload-time = "2025-11-04T13:40:29.806Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/e3/6324802931ae1d123528988e0e86587c2072ac2e5394b4bc2bc34b61ff6e/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:03ca43e12fab6023fc79d28ca6b39b05f794ad08ec2feccc59a339b02f2b3d33", size = 2063258, upload-time = "2025-11-04T13:40:33.544Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/d4/2230d7151d4957dd79c3044ea26346c148c98fbf0ee6ebd41056f2d62ab5/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:dc799088c08fa04e43144b164feb0c13f9a0bc40503f8df3e9fde58a3c0c101e", size = 2214917, upload-time = "2025-11-04T13:40:35.479Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/9f/eaac5df17a3672fef0081b6c1bb0b82b33ee89aa5cec0d7b05f52fd4a1fa/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:97aeba56665b4c3235a0e52b2c2f5ae9cd071b8a8310ad27bddb3f7fb30e9aa2", size = 2332186, upload-time = "2025-11-04T13:40:37.436Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/4e/35a80cae583a37cf15604b44240e45c05e04e86f9cfd766623149297e971/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:406bf18d345822d6c21366031003612b9c77b3e29ffdb0f612367352aab7d586", size = 2073164, upload-time = "2025-11-04T13:40:40.289Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/e3/f6e262673c6140dd3305d144d032f7bd5f7497d3871c1428521f19f9efa2/pydantic_core-2.41.5-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:b93590ae81f7010dbe380cdeab6f515902ebcbefe0b9327cc4804d74e93ae69d", size = 2179146, upload-time = "2025-11-04T13:40:42.809Z" },
+    { url = "https://files.pythonhosted.org/packages/75/c7/20bd7fc05f0c6ea2056a4565c6f36f8968c0924f19b7d97bbfea55780e73/pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:01a3d0ab748ee531f4ea6c3e48ad9dac84ddba4b0d82291f87248f2f9de8d740", size = 2137788, upload-time = "2025-11-04T13:40:44.752Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/8d/34318ef985c45196e004bc46c6eab2eda437e744c124ef0dbe1ff2c9d06b/pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:6561e94ba9dacc9c61bce40e2d6bdc3bfaa0259d3ff36ace3b1e6901936d2e3e", size = 2340133, upload-time = "2025-11-04T13:40:46.66Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/59/013626bf8c78a5a5d9350d12e7697d3d4de951a75565496abd40ccd46bee/pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:915c3d10f81bec3a74fbd4faebe8391013ba61e5a1a8d48c4455b923bdda7858", size = 2324852, upload-time = "2025-11-04T13:40:48.575Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/d9/c248c103856f807ef70c18a4f986693a46a8ffe1602e5d361485da502d20/pydantic_core-2.41.5-cp313-cp313-win32.whl", hash = "sha256:650ae77860b45cfa6e2cdafc42618ceafab3a2d9a3811fcfbd3bbf8ac3c40d36", size = 1994679, upload-time = "2025-11-04T13:40:50.619Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/8b/341991b158ddab181cff136acd2552c9f35bd30380422a639c0671e99a91/pydantic_core-2.41.5-cp313-cp313-win_amd64.whl", hash = "sha256:79ec52ec461e99e13791ec6508c722742ad745571f234ea6255bed38c6480f11", size = 2019766, upload-time = "2025-11-04T13:40:52.631Z" },
+    { url = "https://files.pythonhosted.org/packages/73/7d/f2f9db34af103bea3e09735bb40b021788a5e834c81eedb541991badf8f5/pydantic_core-2.41.5-cp313-cp313-win_arm64.whl", hash = "sha256:3f84d5c1b4ab906093bdc1ff10484838aca54ef08de4afa9de0f5f14d69639cd", size = 1981005, upload-time = "2025-11-04T13:40:54.734Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/28/46b7c5c9635ae96ea0fbb779e271a38129df2550f763937659ee6c5dbc65/pydantic_core-2.41.5-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:3f37a19d7ebcdd20b96485056ba9e8b304e27d9904d233d7b1015db320e51f0a", size = 2119622, upload-time = "2025-11-04T13:40:56.68Z" },
+    { url = "https://files.pythonhosted.org/packages/74/1a/145646e5687e8d9a1e8d09acb278c8535ebe9e972e1f162ed338a622f193/pydantic_core-2.41.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1d1d9764366c73f996edd17abb6d9d7649a7eb690006ab6adbda117717099b14", size = 1891725, upload-time = "2025-11-04T13:40:58.807Z" },
+    { url = "https://files.pythonhosted.org/packages/23/04/e89c29e267b8060b40dca97bfc64a19b2a3cf99018167ea1677d96368273/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:25e1c2af0fce638d5f1988b686f3b3ea8cd7de5f244ca147c777769e798a9cd1", size = 1915040, upload-time = "2025-11-04T13:41:00.853Z" },
+    { url = "https://files.pythonhosted.org/packages/84/a3/15a82ac7bd97992a82257f777b3583d3e84bdb06ba6858f745daa2ec8a85/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:506d766a8727beef16b7adaeb8ee6217c64fc813646b424d0804d67c16eddb66", size = 2063691, upload-time = "2025-11-04T13:41:03.504Z" },
+    { url = "https://files.pythonhosted.org/packages/74/9b/0046701313c6ef08c0c1cf0e028c67c770a4e1275ca73131563c5f2a310a/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4819fa52133c9aa3c387b3328f25c1facc356491e6135b459f1de698ff64d869", size = 2213897, upload-time = "2025-11-04T13:41:05.804Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/cd/6bac76ecd1b27e75a95ca3a9a559c643b3afcd2dd62086d4b7a32a18b169/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2b761d210c9ea91feda40d25b4efe82a1707da2ef62901466a42492c028553a2", size = 2333302, upload-time = "2025-11-04T13:41:07.809Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/d2/ef2074dc020dd6e109611a8be4449b98cd25e1b9b8a303c2f0fca2f2bcf7/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:22f0fb8c1c583a3b6f24df2470833b40207e907b90c928cc8d3594b76f874375", size = 2064877, upload-time = "2025-11-04T13:41:09.827Z" },
+    { url = "https://files.pythonhosted.org/packages/18/66/e9db17a9a763d72f03de903883c057b2592c09509ccfe468187f2a2eef29/pydantic_core-2.41.5-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2782c870e99878c634505236d81e5443092fba820f0373997ff75f90f68cd553", size = 2180680, upload-time = "2025-11-04T13:41:12.379Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/9e/3ce66cebb929f3ced22be85d4c2399b8e85b622db77dad36b73c5387f8f8/pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:0177272f88ab8312479336e1d777f6b124537d47f2123f89cb37e0accea97f90", size = 2138960, upload-time = "2025-11-04T13:41:14.627Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/62/205a998f4327d2079326b01abee48e502ea739d174f0a89295c481a2272e/pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:63510af5e38f8955b8ee5687740d6ebf7c2a0886d15a6d65c32814613681bc07", size = 2339102, upload-time = "2025-11-04T13:41:16.868Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/0d/f05e79471e889d74d3d88f5bd20d0ed189ad94c2423d81ff8d0000aab4ff/pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:e56ba91f47764cc14f1daacd723e3e82d1a89d783f0f5afe9c364b8bb491ccdb", size = 2326039, upload-time = "2025-11-04T13:41:18.934Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/e1/e08a6208bb100da7e0c4b288eed624a703f4d129bde2da475721a80cab32/pydantic_core-2.41.5-cp314-cp314-win32.whl", hash = "sha256:aec5cf2fd867b4ff45b9959f8b20ea3993fc93e63c7363fe6851424c8a7e7c23", size = 1995126, upload-time = "2025-11-04T13:41:21.418Z" },
+    { url = "https://files.pythonhosted.org/packages/48/5d/56ba7b24e9557f99c9237e29f5c09913c81eeb2f3217e40e922353668092/pydantic_core-2.41.5-cp314-cp314-win_amd64.whl", hash = "sha256:8e7c86f27c585ef37c35e56a96363ab8de4e549a95512445b85c96d3e2f7c1bf", size = 2015489, upload-time = "2025-11-04T13:41:24.076Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/bb/f7a190991ec9e3e0ba22e4993d8755bbc4a32925c0b5b42775c03e8148f9/pydantic_core-2.41.5-cp314-cp314-win_arm64.whl", hash = "sha256:e672ba74fbc2dc8eea59fb6d4aed6845e6905fc2a8afe93175d94a83ba2a01a0", size = 1977288, upload-time = "2025-11-04T13:41:26.33Z" },
+    { url = "https://files.pythonhosted.org/packages/92/ed/77542d0c51538e32e15afe7899d79efce4b81eee631d99850edc2f5e9349/pydantic_core-2.41.5-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:8566def80554c3faa0e65ac30ab0932b9e3a5cd7f8323764303d468e5c37595a", size = 2120255, upload-time = "2025-11-04T13:41:28.569Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/3d/6913dde84d5be21e284439676168b28d8bbba5600d838b9dca99de0fad71/pydantic_core-2.41.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:b80aa5095cd3109962a298ce14110ae16b8c1aece8b72f9dafe81cf597ad80b3", size = 1863760, upload-time = "2025-11-04T13:41:31.055Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/f0/e5e6b99d4191da102f2b0eb9687aaa7f5bea5d9964071a84effc3e40f997/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3006c3dd9ba34b0c094c544c6006cc79e87d8612999f1a5d43b769b89181f23c", size = 1878092, upload-time = "2025-11-04T13:41:33.21Z" },
+    { url = "https://files.pythonhosted.org/packages/71/48/36fb760642d568925953bcc8116455513d6e34c4beaa37544118c36aba6d/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:72f6c8b11857a856bcfa48c86f5368439f74453563f951e473514579d44aa612", size = 2053385, upload-time = "2025-11-04T13:41:35.508Z" },
+    { url = "https://files.pythonhosted.org/packages/20/25/92dc684dd8eb75a234bc1c764b4210cf2646479d54b47bf46061657292a8/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5cb1b2f9742240e4bb26b652a5aeb840aa4b417c7748b6f8387927bc6e45e40d", size = 2218832, upload-time = "2025-11-04T13:41:37.732Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/09/f53e0b05023d3e30357d82eb35835d0f6340ca344720a4599cd663dca599/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:bd3d54f38609ff308209bd43acea66061494157703364ae40c951f83ba99a1a9", size = 2327585, upload-time = "2025-11-04T13:41:40Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/4e/2ae1aa85d6af35a39b236b1b1641de73f5a6ac4d5a7509f77b814885760c/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2ff4321e56e879ee8d2a879501c8e469414d948f4aba74a2d4593184eb326660", size = 2041078, upload-time = "2025-11-04T13:41:42.323Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/13/2e215f17f0ef326fc72afe94776edb77525142c693767fc347ed6288728d/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d0d2568a8c11bf8225044aa94409e21da0cb09dcdafe9ecd10250b2baad531a9", size = 2173914, upload-time = "2025-11-04T13:41:45.221Z" },
+    { url = "https://files.pythonhosted.org/packages/02/7a/f999a6dcbcd0e5660bc348a3991c8915ce6599f4f2c6ac22f01d7a10816c/pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:a39455728aabd58ceabb03c90e12f71fd30fa69615760a075b9fec596456ccc3", size = 2129560, upload-time = "2025-11-04T13:41:47.474Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/b1/6c990ac65e3b4c079a4fb9f5b05f5b013afa0f4ed6780a3dd236d2cbdc64/pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:239edca560d05757817c13dc17c50766136d21f7cd0fac50295499ae24f90fdf", size = 2329244, upload-time = "2025-11-04T13:41:49.992Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/02/3c562f3a51afd4d88fff8dffb1771b30cfdfd79befd9883ee094f5b6c0d8/pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:2a5e06546e19f24c6a96a129142a75cee553cc018ffee48a460059b1185f4470", size = 2331955, upload-time = "2025-11-04T13:41:54.079Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/96/5fb7d8c3c17bc8c62fdb031c47d77a1af698f1d7a406b0f79aaa1338f9ad/pydantic_core-2.41.5-cp314-cp314t-win32.whl", hash = "sha256:b4ececa40ac28afa90871c2cc2b9ffd2ff0bf749380fbdf57d165fd23da353aa", size = 1988906, upload-time = "2025-11-04T13:41:56.606Z" },
+    { url = "https://files.pythonhosted.org/packages/22/ed/182129d83032702912c2e2d8bbe33c036f342cc735737064668585dac28f/pydantic_core-2.41.5-cp314-cp314t-win_amd64.whl", hash = "sha256:80aa89cad80b32a912a65332f64a4450ed00966111b6615ca6816153d3585a8c", size = 1981607, upload-time = "2025-11-04T13:41:58.889Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/ed/068e41660b832bb0b1aa5b58011dea2a3fe0ba7861ff38c4d4904c1c1a99/pydantic_core-2.41.5-cp314-cp314t-win_arm64.whl", hash = "sha256:35b44f37a3199f771c3eaa53051bc8a70cd7b54f333531c59e29fd4db5d15008", size = 1974769, upload-time = "2025-11-04T13:42:01.186Z" },
 ]
 
 [[package]]
@@ -321,6 +708,33 @@ wheels = [
 ]
 
 [[package]]
+name = "requests"
+version = "2.32.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload-time = "2025-08-18T20:46:00.542Z" },
+]
+
+[[package]]
+name = "requests-toolbelt"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f3/61/d7545dafb7ac2230c70d38d31cbfe4cc64f7144dc41f6e4e4b78ecd9f5bb/requests-toolbelt-1.0.0.tar.gz", hash = "sha256:7681a0a3d047012b5bdc0ee37d7f8f07ebe76ab08caeccfc3921ce23c88d5bc6", size = 206888, upload-time = "2023-05-01T04:11:33.229Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/51/d4db610ef29373b879047326cbf6fa98b6c1969d6f6dc423279de2b1be2c/requests_toolbelt-1.0.0-py2.py3-none-any.whl", hash = "sha256:cccfdd665f0a24fcf4726e690f65639d272bb0637b9b92dfd91a5568ccf6bd06", size = 54481, upload-time = "2023-05-01T04:11:28.427Z" },
+]
+
+[[package]]
 name = "rich"
 version = "14.3.2"
 source = { registry = "https://pypi.org/simple" }
@@ -368,10 +782,170 @@ wheels = [
 ]
 
 [[package]]
+name = "tenacity"
+version = "9.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/c6/ee486fd809e357697ee8a44d3d69222b344920433d3b6666ccd9b374630c/tenacity-9.1.4.tar.gz", hash = "sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a", size = 49413, upload-time = "2026-02-07T10:45:33.841Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55", size = 28926, upload-time = "2026-02-07T10:45:32.24Z" },
+]
+
+[[package]]
 name = "typing-extensions"
 version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+]
+
+[[package]]
+name = "uuid-utils"
+version = "0.14.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/d1/38a573f0c631c062cf42fa1f5d021d4dd3c31fb23e4376e4b56b0c9fbbed/uuid_utils-0.14.1.tar.gz", hash = "sha256:9bfc95f64af80ccf129c604fb6b8ca66c6f256451e32bc4570f760e4309c9b69", size = 22195, upload-time = "2026-02-20T22:50:38.833Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/b7/add4363039a34506a58457d96d4aa2126061df3a143eb4d042aedd6a2e76/uuid_utils-0.14.1-cp39-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:93a3b5dc798a54a1feb693f2d1cb4cf08258c32ff05ae4929b5f0a2ca624a4f0", size = 604679, upload-time = "2026-02-20T22:50:27.469Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/84/d1d0bef50d9e66d31b2019997c741b42274d53dde2e001b7a83e9511c339/uuid_utils-0.14.1-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:ccd65a4b8e83af23eae5e56d88034b2fe7264f465d3e830845f10d1591b81741", size = 309346, upload-time = "2026-02-20T22:50:31.857Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/ed/b6d6fd52a6636d7c3eddf97d68da50910bf17cd5ac221992506fb56cf12e/uuid_utils-0.14.1-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b56b0cacd81583834820588378e432b0696186683b813058b707aedc1e16c4b1", size = 344714, upload-time = "2026-02-20T22:50:42.642Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/a7/a19a1719fb626fe0b31882db36056d44fe904dc0cf15b06fdf56b2679cf7/uuid_utils-0.14.1-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bb3cf14de789097320a3c56bfdfdd51b1225d11d67298afbedee7e84e3837c96", size = 350914, upload-time = "2026-02-20T22:50:36.487Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/fc/f6690e667fdc3bb1a73f57951f97497771c56fe23e3d302d7404be394d4f/uuid_utils-0.14.1-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:60e0854a90d67f4b0cc6e54773deb8be618f4c9bad98d3326f081423b5d14fae", size = 482609, upload-time = "2026-02-20T22:50:37.511Z" },
+    { url = "https://files.pythonhosted.org/packages/54/6e/dcd3fa031320921a12ec7b4672dea3bd1dd90ddffa363a91831ba834d559/uuid_utils-0.14.1-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ce6743ba194de3910b5feb1a62590cd2587e33a73ab6af8a01b642ceb5055862", size = 345699, upload-time = "2026-02-20T22:50:46.87Z" },
+    { url = "https://files.pythonhosted.org/packages/04/28/e5220204b58b44ac0047226a9d016a113fde039280cc8732d9e6da43b39f/uuid_utils-0.14.1-cp39-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:043fb58fde6cf1620a6c066382f04f87a8e74feb0f95a585e4ed46f5d44af57b", size = 372205, upload-time = "2026-02-20T22:50:28.438Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/d9/3d2eb98af94b8dfffc82b6a33b4dfc87b0a5de2c68a28f6dde0db1f8681b/uuid_utils-0.14.1-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:c915d53f22945e55fe0d3d3b0b87fd965a57f5fd15666fd92d6593a73b1dd297", size = 521836, upload-time = "2026-02-20T22:50:23.057Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/15/0eb106cc6fe182f7577bc0ab6e2f0a40be247f35c5e297dbf7bbc460bd02/uuid_utils-0.14.1-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:0972488e3f9b449e83f006ead5a0e0a33ad4a13e4462e865b7c286ab7d7566a3", size = 625260, upload-time = "2026-02-20T22:50:25.949Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/17/f539507091334b109e7496830af2f093d9fc8082411eafd3ece58af1f8ba/uuid_utils-0.14.1-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:1c238812ae0c8ffe77d8d447a32c6dfd058ea4631246b08b5a71df586ff08531", size = 587824, upload-time = "2026-02-20T22:50:35.225Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/c2/d37a7b2e41f153519367d4db01f0526e0d4b06f1a4a87f1c5dfca5d70a8b/uuid_utils-0.14.1-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:bec8f8ef627af86abf8298e7ec50926627e29b34fa907fcfbedb45aaa72bca43", size = 551407, upload-time = "2026-02-20T22:50:44.915Z" },
+    { url = "https://files.pythonhosted.org/packages/65/36/2d24b2cbe78547c6532da33fb8613debd3126eccc33a6374ab788f5e46e9/uuid_utils-0.14.1-cp39-abi3-win32.whl", hash = "sha256:b54d6aa6252d96bac1fdbc80d26ba71bad9f220b2724d692ad2f2310c22ef523", size = 183476, upload-time = "2026-02-20T22:50:32.745Z" },
+    { url = "https://files.pythonhosted.org/packages/83/92/2d7e90df8b1a69ec4cff33243ce02b7a62f926ef9e2f0eca5a026889cd73/uuid_utils-0.14.1-cp39-abi3-win_amd64.whl", hash = "sha256:fc27638c2ce267a0ce3e06828aff786f91367f093c80625ee21dad0208e0f5ba", size = 187147, upload-time = "2026-02-20T22:50:45.807Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/26/529f4beee17e5248e37e0bc17a2761d34c0fa3b1e5729c88adb2065bae6e/uuid_utils-0.14.1-cp39-abi3-win_arm64.whl", hash = "sha256:b04cb49b42afbc4ff8dbc60cf054930afc479d6f4dd7f1ec3bbe5dbfdde06b7a", size = 188132, upload-time = "2026-02-20T22:50:41.718Z" },
+]
+
+[[package]]
+name = "xxhash"
+version = "3.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/02/84/30869e01909fb37a6cc7e18688ee8bf1e42d57e7e0777636bd47524c43c7/xxhash-3.6.0.tar.gz", hash = "sha256:f0162a78b13a0d7617b2845b90c763339d1f1d82bb04a4b07f4ab535cc5e05d6", size = 85160, upload-time = "2025-10-02T14:37:08.097Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/76/35d05267ac82f53ae9b0e554da7c5e281ee61f3cad44c743f0fcd354f211/xxhash-3.6.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:599e64ba7f67472481ceb6ee80fa3bd828fd61ba59fb11475572cc5ee52b89ec", size = 32738, upload-time = "2025-10-02T14:34:55.839Z" },
+    { url = "https://files.pythonhosted.org/packages/31/a8/3fbce1cd96534a95e35d5120637bf29b0d7f5d8fa2f6374e31b4156dd419/xxhash-3.6.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:7d8b8aaa30fca4f16f0c84a5c8d7ddee0e25250ec2796c973775373257dde8f1", size = 30821, upload-time = "2025-10-02T14:34:57.219Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/ea/d387530ca7ecfa183cb358027f1833297c6ac6098223fd14f9782cd0015c/xxhash-3.6.0-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:d597acf8506d6e7101a4a44a5e428977a51c0fadbbfd3c39650cca9253f6e5a6", size = 194127, upload-time = "2025-10-02T14:34:59.21Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/0c/71435dcb99874b09a43b8d7c54071e600a7481e42b3e3ce1eb5226a5711a/xxhash-3.6.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:858dc935963a33bc33490128edc1c12b0c14d9c7ebaa4e387a7869ecc4f3e263", size = 212975, upload-time = "2025-10-02T14:35:00.816Z" },
+    { url = "https://files.pythonhosted.org/packages/84/7a/c2b3d071e4bb4a90b7057228a99b10d51744878f4a8a6dd643c8bd897620/xxhash-3.6.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ba284920194615cb8edf73bf52236ce2e1664ccd4a38fdb543506413529cc546", size = 212241, upload-time = "2025-10-02T14:35:02.207Z" },
+    { url = "https://files.pythonhosted.org/packages/81/5f/640b6eac0128e215f177df99eadcd0f1b7c42c274ab6a394a05059694c5a/xxhash-3.6.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4b54219177f6c6674d5378bd862c6aedf64725f70dd29c472eaae154df1a2e89", size = 445471, upload-time = "2025-10-02T14:35:03.61Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/1e/3c3d3ef071b051cc3abbe3721ffb8365033a172613c04af2da89d5548a87/xxhash-3.6.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:42c36dd7dbad2f5238950c377fcbf6811b1cdb1c444fab447960030cea60504d", size = 193936, upload-time = "2025-10-02T14:35:05.013Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/bd/4a5f68381939219abfe1c22a9e3a5854a4f6f6f3c4983a87d255f21f2e5d/xxhash-3.6.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f22927652cba98c44639ffdc7aaf35828dccf679b10b31c4ad72a5b530a18eb7", size = 210440, upload-time = "2025-10-02T14:35:06.239Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/37/b80fe3d5cfb9faff01a02121a0f4d565eb7237e9e5fc66e73017e74dcd36/xxhash-3.6.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:b45fad44d9c5c119e9c6fbf2e1c656a46dc68e280275007bbfd3d572b21426db", size = 197990, upload-time = "2025-10-02T14:35:07.735Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/fd/2c0a00c97b9e18f72e1f240ad4e8f8a90fd9d408289ba9c7c495ed7dc05c/xxhash-3.6.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:6f2580ffab1a8b68ef2b901cde7e55fa8da5e4be0977c68f78fc80f3c143de42", size = 210689, upload-time = "2025-10-02T14:35:09.438Z" },
+    { url = "https://files.pythonhosted.org/packages/93/86/5dd8076a926b9a95db3206aba20d89a7fc14dd5aac16e5c4de4b56033140/xxhash-3.6.0-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:40c391dd3cd041ebc3ffe6f2c862f402e306eb571422e0aa918d8070ba31da11", size = 414068, upload-time = "2025-10-02T14:35:11.162Z" },
+    { url = "https://files.pythonhosted.org/packages/af/3c/0bb129170ee8f3650f08e993baee550a09593462a5cddd8e44d0011102b1/xxhash-3.6.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:f205badabde7aafd1a31e8ca2a3e5a763107a71c397c4481d6a804eb5063d8bd", size = 191495, upload-time = "2025-10-02T14:35:12.971Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/3a/6797e0114c21d1725e2577508e24006fd7ff1d8c0c502d3b52e45c1771d8/xxhash-3.6.0-cp313-cp313-win32.whl", hash = "sha256:2577b276e060b73b73a53042ea5bd5203d3e6347ce0d09f98500f418a9fcf799", size = 30620, upload-time = "2025-10-02T14:35:14.129Z" },
+    { url = "https://files.pythonhosted.org/packages/86/15/9bc32671e9a38b413a76d24722a2bf8784a132c043063a8f5152d390b0f9/xxhash-3.6.0-cp313-cp313-win_amd64.whl", hash = "sha256:757320d45d2fbcce8f30c42a6b2f47862967aea7bf458b9625b4bbe7ee390392", size = 31542, upload-time = "2025-10-02T14:35:15.21Z" },
+    { url = "https://files.pythonhosted.org/packages/39/c5/cc01e4f6188656e56112d6a8e0dfe298a16934b8c47a247236549a3f7695/xxhash-3.6.0-cp313-cp313-win_arm64.whl", hash = "sha256:457b8f85dec5825eed7b69c11ae86834a018b8e3df5e77783c999663da2f96d6", size = 27880, upload-time = "2025-10-02T14:35:16.315Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/30/25e5321c8732759e930c555176d37e24ab84365482d257c3b16362235212/xxhash-3.6.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:a42e633d75cdad6d625434e3468126c73f13f7584545a9cf34e883aa1710e702", size = 32956, upload-time = "2025-10-02T14:35:17.413Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/3c/0573299560d7d9f8ab1838f1efc021a280b5ae5ae2e849034ef3dee18810/xxhash-3.6.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:568a6d743219e717b07b4e03b0a828ce593833e498c3b64752e0f5df6bfe84db", size = 31072, upload-time = "2025-10-02T14:35:18.844Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/1c/52d83a06e417cd9d4137722693424885cc9878249beb3a7c829e74bf7ce9/xxhash-3.6.0-cp313-cp313t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:bec91b562d8012dae276af8025a55811b875baace6af510412a5e58e3121bc54", size = 196409, upload-time = "2025-10-02T14:35:20.31Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/8e/c6d158d12a79bbd0b878f8355432075fc82759e356ab5a111463422a239b/xxhash-3.6.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:78e7f2f4c521c30ad5e786fdd6bae89d47a32672a80195467b5de0480aa97b1f", size = 215736, upload-time = "2025-10-02T14:35:21.616Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/68/c4c80614716345d55071a396cf03d06e34b5f4917a467faf43083c995155/xxhash-3.6.0-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:3ed0df1b11a79856df5ffcab572cbd6b9627034c1c748c5566fa79df9048a7c5", size = 214833, upload-time = "2025-10-02T14:35:23.32Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/e9/ae27c8ffec8b953efa84c7c4a6c6802c263d587b9fc0d6e7cea64e08c3af/xxhash-3.6.0-cp313-cp313t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:0e4edbfc7d420925b0dd5e792478ed393d6e75ff8fc219a6546fb446b6a417b1", size = 448348, upload-time = "2025-10-02T14:35:25.111Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/6b/33e21afb1b5b3f46b74b6bd1913639066af218d704cc0941404ca717fc57/xxhash-3.6.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fba27a198363a7ef87f8c0f6b171ec36b674fe9053742c58dd7e3201c1ab30ee", size = 196070, upload-time = "2025-10-02T14:35:26.586Z" },
+    { url = "https://files.pythonhosted.org/packages/96/b6/fcabd337bc5fa624e7203aa0fa7d0c49eed22f72e93229431752bddc83d9/xxhash-3.6.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:794fe9145fe60191c6532fa95063765529770edcdd67b3d537793e8004cabbfd", size = 212907, upload-time = "2025-10-02T14:35:28.087Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/d3/9ee6160e644d660fcf176c5825e61411c7f62648728f69c79ba237250143/xxhash-3.6.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:6105ef7e62b5ac73a837778efc331a591d8442f8ef5c7e102376506cb4ae2729", size = 200839, upload-time = "2025-10-02T14:35:29.857Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/98/e8de5baa5109394baf5118f5e72ab21a86387c4f89b0e77ef3e2f6b0327b/xxhash-3.6.0-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:f01375c0e55395b814a679b3eea205db7919ac2af213f4a6682e01220e5fe292", size = 213304, upload-time = "2025-10-02T14:35:31.222Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/1d/71056535dec5c3177eeb53e38e3d367dd1d16e024e63b1cee208d572a033/xxhash-3.6.0-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:d706dca2d24d834a4661619dcacf51a75c16d65985718d6a7d73c1eeeb903ddf", size = 416930, upload-time = "2025-10-02T14:35:32.517Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/6c/5cbde9de2cd967c322e651c65c543700b19e7ae3e0aae8ece3469bf9683d/xxhash-3.6.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:5f059d9faeacd49c0215d66f4056e1326c80503f51a1532ca336a385edadd033", size = 193787, upload-time = "2025-10-02T14:35:33.827Z" },
+    { url = "https://files.pythonhosted.org/packages/19/fa/0172e350361d61febcea941b0cc541d6e6c8d65d153e85f850a7b256ff8a/xxhash-3.6.0-cp313-cp313t-win32.whl", hash = "sha256:1244460adc3a9be84731d72b8e80625788e5815b68da3da8b83f78115a40a7ec", size = 30916, upload-time = "2025-10-02T14:35:35.107Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/e6/e8cf858a2b19d6d45820f072eff1bea413910592ff17157cabc5f1227a16/xxhash-3.6.0-cp313-cp313t-win_amd64.whl", hash = "sha256:b1e420ef35c503869c4064f4a2f2b08ad6431ab7b229a05cce39d74268bca6b8", size = 31799, upload-time = "2025-10-02T14:35:36.165Z" },
+    { url = "https://files.pythonhosted.org/packages/56/15/064b197e855bfb7b343210e82490ae672f8bc7cdf3ddb02e92f64304ee8a/xxhash-3.6.0-cp313-cp313t-win_arm64.whl", hash = "sha256:ec44b73a4220623235f67a996c862049f375df3b1052d9899f40a6382c32d746", size = 28044, upload-time = "2025-10-02T14:35:37.195Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/5e/0138bc4484ea9b897864d59fce9be9086030825bc778b76cb5a33a906d37/xxhash-3.6.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:a40a3d35b204b7cc7643cbcf8c9976d818cb47befcfac8bbefec8038ac363f3e", size = 32754, upload-time = "2025-10-02T14:35:38.245Z" },
+    { url = "https://files.pythonhosted.org/packages/18/d7/5dac2eb2ec75fd771957a13e5dda560efb2176d5203f39502a5fc571f899/xxhash-3.6.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:a54844be970d3fc22630b32d515e79a90d0a3ddb2644d8d7402e3c4c8da61405", size = 30846, upload-time = "2025-10-02T14:35:39.6Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/71/8bc5be2bb00deb5682e92e8da955ebe5fa982da13a69da5a40a4c8db12fb/xxhash-3.6.0-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:016e9190af8f0a4e3741343777710e3d5717427f175adfdc3e72508f59e2a7f3", size = 194343, upload-time = "2025-10-02T14:35:40.69Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/3b/52badfb2aecec2c377ddf1ae75f55db3ba2d321c5e164f14461c90837ef3/xxhash-3.6.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4f6f72232f849eb9d0141e2ebe2677ece15adfd0fa599bc058aad83c714bb2c6", size = 213074, upload-time = "2025-10-02T14:35:42.29Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/2b/ae46b4e9b92e537fa30d03dbc19cdae57ed407e9c26d163895e968e3de85/xxhash-3.6.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:63275a8aba7865e44b1813d2177e0f5ea7eadad3dd063a21f7cf9afdc7054063", size = 212388, upload-time = "2025-10-02T14:35:43.929Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/80/49f88d3afc724b4ac7fbd664c8452d6db51b49915be48c6982659e0e7942/xxhash-3.6.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3cd01fa2aa00d8b017c97eb46b9a794fbdca53fc14f845f5a328c71254b0abb7", size = 445614, upload-time = "2025-10-02T14:35:45.216Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/ba/603ce3961e339413543d8cd44f21f2c80e2a7c5cfe692a7b1f2cccf58f3c/xxhash-3.6.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0226aa89035b62b6a86d3c68df4d7c1f47a342b8683da2b60cedcddb46c4d95b", size = 194024, upload-time = "2025-10-02T14:35:46.959Z" },
+    { url = "https://files.pythonhosted.org/packages/78/d1/8e225ff7113bf81545cfdcd79eef124a7b7064a0bba53605ff39590b95c2/xxhash-3.6.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c6e193e9f56e4ca4923c61238cdaced324f0feac782544eb4c6d55ad5cc99ddd", size = 210541, upload-time = "2025-10-02T14:35:48.301Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/58/0f89d149f0bad89def1a8dd38feb50ccdeb643d9797ec84707091d4cb494/xxhash-3.6.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:9176dcaddf4ca963d4deb93866d739a343c01c969231dbe21680e13a5d1a5bf0", size = 198305, upload-time = "2025-10-02T14:35:49.584Z" },
+    { url = "https://files.pythonhosted.org/packages/11/38/5eab81580703c4df93feb5f32ff8fa7fe1e2c51c1f183ee4e48d4bb9d3d7/xxhash-3.6.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:c1ce4009c97a752e682b897aa99aef84191077a9433eb237774689f14f8ec152", size = 210848, upload-time = "2025-10-02T14:35:50.877Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/6b/953dc4b05c3ce678abca756416e4c130d2382f877a9c30a20d08ee6a77c0/xxhash-3.6.0-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:8cb2f4f679b01513b7adbb9b1b2f0f9cdc31b70007eaf9d59d0878809f385b11", size = 414142, upload-time = "2025-10-02T14:35:52.15Z" },
+    { url = "https://files.pythonhosted.org/packages/08/a9/238ec0d4e81a10eb5026d4a6972677cbc898ba6c8b9dbaec12ae001b1b35/xxhash-3.6.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:653a91d7c2ab54a92c19ccf43508b6a555440b9be1bc8be553376778be7f20b5", size = 191547, upload-time = "2025-10-02T14:35:53.547Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/ee/3cf8589e06c2164ac77c3bf0aa127012801128f1feebf2a079272da5737c/xxhash-3.6.0-cp314-cp314-win32.whl", hash = "sha256:a756fe893389483ee8c394d06b5ab765d96e68fbbfe6fde7aa17e11f5720559f", size = 31214, upload-time = "2025-10-02T14:35:54.746Z" },
+    { url = "https://files.pythonhosted.org/packages/02/5d/a19552fbc6ad4cb54ff953c3908bbc095f4a921bc569433d791f755186f1/xxhash-3.6.0-cp314-cp314-win_amd64.whl", hash = "sha256:39be8e4e142550ef69629c9cd71b88c90e9a5db703fecbcf265546d9536ca4ad", size = 32290, upload-time = "2025-10-02T14:35:55.791Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/11/dafa0643bc30442c887b55baf8e73353a344ee89c1901b5a5c54a6c17d39/xxhash-3.6.0-cp314-cp314-win_arm64.whl", hash = "sha256:25915e6000338999236f1eb68a02a32c3275ac338628a7eaa5a269c401995679", size = 28795, upload-time = "2025-10-02T14:35:57.162Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/db/0e99732ed7f64182aef4a6fb145e1a295558deec2a746265dcdec12d191e/xxhash-3.6.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:c5294f596a9017ca5a3e3f8884c00b91ab2ad2933cf288f4923c3fd4346cf3d4", size = 32955, upload-time = "2025-10-02T14:35:58.267Z" },
+    { url = "https://files.pythonhosted.org/packages/55/f4/2a7c3c68e564a099becfa44bb3d398810cc0ff6749b0d3cb8ccb93f23c14/xxhash-3.6.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1cf9dcc4ab9cff01dfbba78544297a3a01dafd60f3bde4e2bfd016cf7e4ddc67", size = 31072, upload-time = "2025-10-02T14:35:59.382Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/d9/72a29cddc7250e8a5819dad5d466facb5dc4c802ce120645630149127e73/xxhash-3.6.0-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:01262da8798422d0685f7cef03b2bd3f4f46511b02830861df548d7def4402ad", size = 196579, upload-time = "2025-10-02T14:36:00.838Z" },
+    { url = "https://files.pythonhosted.org/packages/63/93/b21590e1e381040e2ca305a884d89e1c345b347404f7780f07f2cdd47ef4/xxhash-3.6.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:51a73fb7cb3a3ead9f7a8b583ffd9b8038e277cdb8cb87cf890e88b3456afa0b", size = 215854, upload-time = "2025-10-02T14:36:02.207Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/b8/edab8a7d4fa14e924b29be877d54155dcbd8b80be85ea00d2be3413a9ed4/xxhash-3.6.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b9c6df83594f7df8f7f708ce5ebeacfc69f72c9fbaaababf6cf4758eaada0c9b", size = 214965, upload-time = "2025-10-02T14:36:03.507Z" },
+    { url = "https://files.pythonhosted.org/packages/27/67/dfa980ac7f0d509d54ea0d5a486d2bb4b80c3f1bb22b66e6a05d3efaf6c0/xxhash-3.6.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:627f0af069b0ea56f312fd5189001c24578868643203bca1abbc2c52d3a6f3ca", size = 448484, upload-time = "2025-10-02T14:36:04.828Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/63/8ffc2cc97e811c0ca5d00ab36604b3ea6f4254f20b7bc658ca825ce6c954/xxhash-3.6.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:aa912c62f842dfd013c5f21a642c9c10cd9f4c4e943e0af83618b4a404d9091a", size = 196162, upload-time = "2025-10-02T14:36:06.182Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/77/07f0e7a3edd11a6097e990f6e5b815b6592459cb16dae990d967693e6ea9/xxhash-3.6.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:b465afd7909db30168ab62afe40b2fcf79eedc0b89a6c0ab3123515dc0df8b99", size = 213007, upload-time = "2025-10-02T14:36:07.733Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/d8/bc5fa0d152837117eb0bef6f83f956c509332ce133c91c63ce07ee7c4873/xxhash-3.6.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:a881851cf38b0a70e7c4d3ce81fc7afd86fbc2a024f4cfb2a97cf49ce04b75d3", size = 200956, upload-time = "2025-10-02T14:36:09.106Z" },
+    { url = "https://files.pythonhosted.org/packages/26/a5/d749334130de9411783873e9b98ecc46688dad5db64ca6e04b02acc8b473/xxhash-3.6.0-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:9b3222c686a919a0f3253cfc12bb118b8b103506612253b5baeaac10d8027cf6", size = 213401, upload-time = "2025-10-02T14:36:10.585Z" },
+    { url = "https://files.pythonhosted.org/packages/89/72/abed959c956a4bfc72b58c0384bb7940663c678127538634d896b1195c10/xxhash-3.6.0-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:c5aa639bc113e9286137cec8fadc20e9cd732b2cc385c0b7fa673b84fc1f2a93", size = 417083, upload-time = "2025-10-02T14:36:12.276Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/b3/62fd2b586283b7d7d665fb98e266decadf31f058f1cf6c478741f68af0cb/xxhash-3.6.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5c1343d49ac102799905e115aee590183c3921d475356cb24b4de29a4bc56518", size = 193913, upload-time = "2025-10-02T14:36:14.025Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/9a/c19c42c5b3f5a4aad748a6d5b4f23df3bed7ee5445accc65a0fb3ff03953/xxhash-3.6.0-cp314-cp314t-win32.whl", hash = "sha256:5851f033c3030dd95c086b4a36a2683c2ff4a799b23af60977188b057e467119", size = 31586, upload-time = "2025-10-02T14:36:15.603Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d6/4cc450345be9924fd5dc8c590ceda1db5b43a0a889587b0ae81a95511360/xxhash-3.6.0-cp314-cp314t-win_amd64.whl", hash = "sha256:0444e7967dac37569052d2409b00a8860c2135cff05502df4da80267d384849f", size = 32526, upload-time = "2025-10-02T14:36:16.708Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/c9/7243eb3f9eaabd1a88a5a5acadf06df2d83b100c62684b7425c6a11bcaa8/xxhash-3.6.0-cp314-cp314t-win_arm64.whl", hash = "sha256:bb79b1e63f6fd84ec778a4b1916dfe0a7c3fdb986c06addd5db3a0d413819d95", size = 28898, upload-time = "2025-10-02T14:36:17.843Z" },
+]
+
+[[package]]
+name = "zstandard"
+version = "0.25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fd/aa/3e0508d5a5dd96529cdc5a97011299056e14c6505b678fd58938792794b1/zstandard-0.25.0.tar.gz", hash = "sha256:7713e1179d162cf5c7906da876ec2ccb9c3a9dcbdffef0cc7f70c3667a205f0b", size = 711513, upload-time = "2025-09-14T22:15:54.002Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/35/0b/8df9c4ad06af91d39e94fa96cc010a24ac4ef1378d3efab9223cc8593d40/zstandard-0.25.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:ec996f12524f88e151c339688c3897194821d7f03081ab35d31d1e12ec975e94", size = 795735, upload-time = "2025-09-14T22:17:26.042Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/06/9ae96a3e5dcfd119377ba33d4c42a7d89da1efabd5cb3e366b156c45ff4d/zstandard-0.25.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a1a4ae2dec3993a32247995bdfe367fc3266da832d82f8438c8570f989753de1", size = 640440, upload-time = "2025-09-14T22:17:27.366Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/14/933d27204c2bd404229c69f445862454dcc101cd69ef8c6068f15aaec12c/zstandard-0.25.0-cp313-cp313-manylinux2010_i686.manylinux2014_i686.manylinux_2_12_i686.manylinux_2_17_i686.whl", hash = "sha256:e96594a5537722fdfb79951672a2a63aec5ebfb823e7560586f7484819f2a08f", size = 5343070, upload-time = "2025-09-14T22:17:28.896Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/db/ddb11011826ed7db9d0e485d13df79b58586bfdec56e5c84a928a9a78c1c/zstandard-0.25.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:bfc4e20784722098822e3eee42b8e576b379ed72cca4a7cb856ae733e62192ea", size = 5063001, upload-time = "2025-09-14T22:17:31.044Z" },
+    { url = "https://files.pythonhosted.org/packages/db/00/87466ea3f99599d02a5238498b87bf84a6348290c19571051839ca943777/zstandard-0.25.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:457ed498fc58cdc12fc48f7950e02740d4f7ae9493dd4ab2168a47c93c31298e", size = 5394120, upload-time = "2025-09-14T22:17:32.711Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/95/fc5531d9c618a679a20ff6c29e2b3ef1d1f4ad66c5e161ae6ff847d102a9/zstandard-0.25.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:fd7a5004eb1980d3cefe26b2685bcb0b17989901a70a1040d1ac86f1d898c551", size = 5451230, upload-time = "2025-09-14T22:17:34.41Z" },
+    { url = "https://files.pythonhosted.org/packages/63/4b/e3678b4e776db00f9f7b2fe58e547e8928ef32727d7a1ff01dea010f3f13/zstandard-0.25.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8e735494da3db08694d26480f1493ad2cf86e99bdd53e8e9771b2752a5c0246a", size = 5547173, upload-time = "2025-09-14T22:17:36.084Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/d5/ba05ed95c6b8ec30bd468dfeab20589f2cf709b5c940483e31d991f2ca58/zstandard-0.25.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:3a39c94ad7866160a4a46d772e43311a743c316942037671beb264e395bdd611", size = 5046736, upload-time = "2025-09-14T22:17:37.891Z" },
+    { url = "https://files.pythonhosted.org/packages/50/d5/870aa06b3a76c73eced65c044b92286a3c4e00554005ff51962deef28e28/zstandard-0.25.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:172de1f06947577d3a3005416977cce6168f2261284c02080e7ad0185faeced3", size = 5576368, upload-time = "2025-09-14T22:17:40.206Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/35/398dc2ffc89d304d59bc12f0fdd931b4ce455bddf7038a0a67733a25f550/zstandard-0.25.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:3c83b0188c852a47cd13ef3bf9209fb0a77fa5374958b8c53aaa699398c6bd7b", size = 4954022, upload-time = "2025-09-14T22:17:41.879Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/5c/36ba1e5507d56d2213202ec2b05e8541734af5f2ce378c5d1ceaf4d88dc4/zstandard-0.25.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:1673b7199bbe763365b81a4f3252b8e80f44c9e323fc42940dc8843bfeaf9851", size = 5267889, upload-time = "2025-09-14T22:17:43.577Z" },
+    { url = "https://files.pythonhosted.org/packages/70/e8/2ec6b6fb7358b2ec0113ae202647ca7c0e9d15b61c005ae5225ad0995df5/zstandard-0.25.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:0be7622c37c183406f3dbf0cba104118eb16a4ea7359eeb5752f0794882fc250", size = 5433952, upload-time = "2025-09-14T22:17:45.271Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/01/b5f4d4dbc59ef193e870495c6f1275f5b2928e01ff5a81fecb22a06e22fb/zstandard-0.25.0-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:5f5e4c2a23ca271c218ac025bd7d635597048b366d6f31f420aaeb715239fc98", size = 5814054, upload-time = "2025-09-14T22:17:47.08Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/e5/fbd822d5c6f427cf158316d012c5a12f233473c2f9c5fe5ab1ae5d21f3d8/zstandard-0.25.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4f187a0bb61b35119d1926aee039524d1f93aaf38a9916b8c4b78ac8514a0aaf", size = 5360113, upload-time = "2025-09-14T22:17:48.893Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/e0/69a553d2047f9a2c7347caa225bb3a63b6d7704ad74610cb7823baa08ed7/zstandard-0.25.0-cp313-cp313-win32.whl", hash = "sha256:7030defa83eef3e51ff26f0b7bfb229f0204b66fe18e04359ce3474ac33cbc09", size = 436936, upload-time = "2025-09-14T22:17:52.658Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/82/b9c06c870f3bd8767c201f1edbdf9e8dc34be5b0fbc5682c4f80fe948475/zstandard-0.25.0-cp313-cp313-win_amd64.whl", hash = "sha256:1f830a0dac88719af0ae43b8b2d6aef487d437036468ef3c2ea59c51f9d55fd5", size = 506232, upload-time = "2025-09-14T22:17:50.402Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/57/60c3c01243bb81d381c9916e2a6d9e149ab8627c0c7d7abb2d73384b3c0c/zstandard-0.25.0-cp313-cp313-win_arm64.whl", hash = "sha256:85304a43f4d513f5464ceb938aa02c1e78c2943b29f44a750b48b25ac999a049", size = 462671, upload-time = "2025-09-14T22:17:51.533Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/5c/f8923b595b55fe49e30612987ad8bf053aef555c14f05bb659dd5dbe3e8a/zstandard-0.25.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:e29f0cf06974c899b2c188ef7f783607dbef36da4c242eb6c82dcd8b512855e3", size = 795887, upload-time = "2025-09-14T22:17:54.198Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/09/d0a2a14fc3439c5f874042dca72a79c70a532090b7ba0003be73fee37ae2/zstandard-0.25.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:05df5136bc5a011f33cd25bc9f506e7426c0c9b3f9954f056831ce68f3b6689f", size = 640658, upload-time = "2025-09-14T22:17:55.423Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/7c/8b6b71b1ddd517f68ffb55e10834388d4f793c49c6b83effaaa05785b0b4/zstandard-0.25.0-cp314-cp314-manylinux2010_i686.manylinux_2_12_i686.manylinux_2_28_i686.whl", hash = "sha256:f604efd28f239cc21b3adb53eb061e2a205dc164be408e553b41ba2ffe0ca15c", size = 5379849, upload-time = "2025-09-14T22:17:57.372Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/86/a48e56320d0a17189ab7a42645387334fba2200e904ee47fc5a26c1fd8ca/zstandard-0.25.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:223415140608d0f0da010499eaa8ccdb9af210a543fac54bce15babbcfc78439", size = 5058095, upload-time = "2025-09-14T22:17:59.498Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/ad/eb659984ee2c0a779f9d06dbfe45e2dc39d99ff40a319895df2d3d9a48e5/zstandard-0.25.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2e54296a283f3ab5a26fc9b8b5d4978ea0532f37b231644f367aa588930aa043", size = 5551751, upload-time = "2025-09-14T22:18:01.618Z" },
+    { url = "https://files.pythonhosted.org/packages/61/b3/b637faea43677eb7bd42ab204dfb7053bd5c4582bfe6b1baefa80ac0c47b/zstandard-0.25.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ca54090275939dc8ec5dea2d2afb400e0f83444b2fc24e07df7fdef677110859", size = 6364818, upload-time = "2025-09-14T22:18:03.769Z" },
+    { url = "https://files.pythonhosted.org/packages/31/dc/cc50210e11e465c975462439a492516a73300ab8caa8f5e0902544fd748b/zstandard-0.25.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e09bb6252b6476d8d56100e8147b803befa9a12cea144bbe629dd508800d1ad0", size = 5560402, upload-time = "2025-09-14T22:18:05.954Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/ae/56523ae9c142f0c08efd5e868a6da613ae76614eca1305259c3bf6a0ed43/zstandard-0.25.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a9ec8c642d1ec73287ae3e726792dd86c96f5681eb8df274a757bf62b750eae7", size = 4955108, upload-time = "2025-09-14T22:18:07.68Z" },
+    { url = "https://files.pythonhosted.org/packages/98/cf/c899f2d6df0840d5e384cf4c4121458c72802e8bda19691f3b16619f51e9/zstandard-0.25.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:a4089a10e598eae6393756b036e0f419e8c1d60f44a831520f9af41c14216cf2", size = 5269248, upload-time = "2025-09-14T22:18:09.753Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/c0/59e912a531d91e1c192d3085fc0f6fb2852753c301a812d856d857ea03c6/zstandard-0.25.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:f67e8f1a324a900e75b5e28ffb152bcac9fbed1cc7b43f99cd90f395c4375344", size = 5430330, upload-time = "2025-09-14T22:18:11.966Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1d/7e31db1240de2df22a58e2ea9a93fc6e38cc29353e660c0272b6735d6669/zstandard-0.25.0-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:9654dbc012d8b06fc3d19cc825af3f7bf8ae242226df5f83936cb39f5fdc846c", size = 5811123, upload-time = "2025-09-14T22:18:13.907Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/49/fac46df5ad353d50535e118d6983069df68ca5908d4d65b8c466150a4ff1/zstandard-0.25.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:4203ce3b31aec23012d3a4cf4a2ed64d12fea5269c49aed5e4c3611b938e4088", size = 5359591, upload-time = "2025-09-14T22:18:16.465Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/38/f249a2050ad1eea0bb364046153942e34abba95dd5520af199aed86fbb49/zstandard-0.25.0-cp314-cp314-win32.whl", hash = "sha256:da469dc041701583e34de852d8634703550348d5822e66a0c827d39b05365b12", size = 444513, upload-time = "2025-09-14T22:18:20.61Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/43/241f9615bcf8ba8903b3f0432da069e857fc4fd1783bd26183db53c4804b/zstandard-0.25.0-cp314-cp314-win_amd64.whl", hash = "sha256:c19bcdd826e95671065f8692b5a4aa95c52dc7a02a4c5a0cac46deb879a017a2", size = 516118, upload-time = "2025-09-14T22:18:17.849Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/ef/da163ce2450ed4febf6467d77ccb4cd52c4c30ab45624bad26ca0a27260c/zstandard-0.25.0-cp314-cp314-win_arm64.whl", hash = "sha256:d7541afd73985c630bafcd6338d2518ae96060075f9463d7dc14cfb33514383d", size = 476940, upload-time = "2025-09-14T22:18:19.088Z" },
 ]


### PR DESCRIPTION
## Problem
The Python SDK did not expose an official LangChain tool-boundary integration, so adoption guidance and smoke coverage for that path were incomplete.

## Changes
- add `GaitLangChainMiddleware` and `GaitLangChainCallbackHandler` to the Python SDK as the official optional LangChain surface
- add LangChain middleware tests, fixtures, and package extras for the SDK
- add a deterministic LangChain integration example plus adoption/parity smoke coverage and docs updates

## Validation
- `go run ./cmd/gait doctor --json`
- `make prepush-full`
- `git push -u origin codex/adhoc-epic-w3` (repo pre-push hook ran `make prepush`)
