### PR TITLE
hotfix: install uv in parity CI lanes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -389,6 +389,8 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.13"
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
       - name: Run adoption smoke suite
         shell: bash
         run: |
@@ -541,6 +543,8 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.13"
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
       - name: Run adapter parity suite
         shell: bash
         run: |


### PR DESCRIPTION
## Problem
The post-merge `main` CI for PR #74 failed in the `adapter-parity` and `adoption-smoke` jobs because `scripts/test_adapter_parity.sh` now invokes `uv` for the LangChain optional dependency path, but those CI jobs did not install `uv`.

## Changes
- install `uv` in the `adoption-smoke` job
- install `uv` in the `adapter-parity` job

## Validation
- `make prepush-full`
- branch push hook `make prepush`
