### PR TITLE
docs: sync W5 launch and onboarding surfaces

### DIFF
--- a/.agents/skills/ci-failure-triage/SKILL.md
+++ b/.agents/skills/ci-failure-triage/SKILL.md
@@ -9,7 +9,7 @@ Use this skill to isolate failing CI causes with deterministic artifact checks.
 
 ## Gait Context
 
-Gait is an offline-first runtime for AI agents that enforces tool-boundary policy, emits signed and verifiable evidence artifacts, and supports deterministic regressions.
+Gait is the offline-first policy-as-code runtime for AI agent tool calls. It enforces tool-boundary policy, emits signed and verifiable evidence artifacts, and supports deterministic regressions.
 
 Use this skill when:
 - incident triage requires artifact-first root-cause isolation
@@ -39,7 +39,8 @@ Do not use this skill when:
 3. Enter an isolated triage workspace:
    - `mkdir -p <workdir> && cd <workdir>`
 4. If failure came from regress grading, bind reruns to the requested target:
-   - `gait regress init --from <failure_target_ref> --json`
+   - explicit path: `gait capture --from <failure_target_ref> --json`
+   - then `gait regress add --from ./gait-out/capture.json --json`
    - `gait regress run --json`
 5. If baseline evidence exists, compute deterministic diff:
    - `gait pack diff <baseline_target_ref> <failure_target_ref> --json`
@@ -65,14 +66,15 @@ gait demo --json
 gait verify run_demo --json
 failure_target_ref="$(python3 -c 'import os,sys; v=sys.argv[1]; print(os.path.abspath(v) if os.path.exists(v) else v)' run_demo)"
 mkdir -p ./triage && cd ./triage
-gait regress init --from "${failure_target_ref}" --json
+gait capture --from "${failure_target_ref}" --json
+gait regress add --from ./gait-out/capture.json --json
 gait regress run --json
 gait doctor --json
 ```
 
 Expected result:
 - verify output reports integrity status for the target artifact
-- regress init output references the requested `failure_target`
+- fixture creation output references the requested `failure_target`
 - doctor output reports actionable diagnostics
 - regress output reports stable pass/fail status and failures
 

--- a/.agents/skills/gait-incident-to-regression/SKILL.md
+++ b/.agents/skills/gait-incident-to-regression/SKILL.md
@@ -9,7 +9,7 @@ Execute this workflow to transform an observed run into repeatable CI checks.
 
 ## Gait Context
 
-Gait is an offline-first runtime for AI agents that enforces tool-boundary policy, emits signed and verifiable evidence artifacts, and supports deterministic regressions.
+Gait is the offline-first policy-as-code runtime for AI agent tool calls. It enforces tool-boundary policy, emits signed and verifiable evidence artifacts, and supports deterministic regressions.
 
 Use this skill when:
 - incident triage needs repeatable fixture creation
@@ -25,7 +25,9 @@ Do not use this skill when:
 1. Resolve source run artifact:
    - use `<run_id>` or `<runpack_path>`
 2. Initialize fixture deterministically (required):
-   - `gait regress init --from <run_id_or_path> --json`
+   - explicit path: `gait capture --from <run_id_or_path> --json`
+   - then `gait regress add --from ./gait-out/capture.json --json`
+   - legacy fallback: `gait regress init --from <run_id_or_path> --json`
 3. Parse and report:
    - `ok`, `run_id`, `fixture_name`, `fixture_dir`, `config_path`, `next_commands`
 4. Run regression suite (required):
@@ -49,6 +51,6 @@ Do not use this skill when:
 
 ## Determinism Rules
 
-- Always run `regress init` before `regress run` for new incidents.
+- Always create a deterministic fixture before `regress run` for new incidents.
 - Always consume `--json` output fields for decisions.
 - Keep fixture names stable and explicit when user provides naming constraints.

--- a/.agents/skills/incident-to-regression/SKILL.md
+++ b/.agents/skills/incident-to-regression/SKILL.md
@@ -9,7 +9,7 @@ Use this skill to transform an observed incident into deterministic regression c
 
 ## Gait Context
 
-Gait is an offline-first runtime for AI agents that enforces tool-boundary policy, emits signed and verifiable evidence artifacts, and supports deterministic regressions.
+Gait is the offline-first policy-as-code runtime for AI agent tool calls. It enforces tool-boundary policy, emits signed and verifiable evidence artifacts, and supports deterministic regressions.
 
 Use this skill when:
 - incident triage needs repeatable regression fixtures
@@ -22,7 +22,7 @@ Do not use this skill when:
 
 ## Required Inputs
 
-- `run_source`: run id, runpack path, or equivalent source accepted by `gait regress init`.
+- `run_source`: run id, runpack path, or equivalent source accepted by `gait capture` / `gait regress add` / `gait regress init`.
 - `workdir`: writable working directory where fixtures and outputs will be created.
 
 ## Workflow
@@ -33,9 +33,11 @@ Do not use this skill when:
    - `run_source_ref="$(python3 -c 'import os,sys; v=sys.argv[1]; print(os.path.abspath(v) if os.path.exists(v) else v)' <run_source>)"`
 2. Enter the declared working directory before generating artifacts:
    - `mkdir -p <workdir> && cd <workdir>`
-3. Initialize deterministic fixture from the incident source:
-   - `gait regress init --from <run_source_ref> --json`
-4. Parse fields from init output and record them:
+3. Create deterministic fixture from the incident source:
+   - explicit path: `gait capture --from <run_source_ref> --json`
+   - then `gait regress add --from ./gait-out/capture.json --json`
+   - legacy fallback: `gait regress init --from <run_source_ref> --json`
+4. Parse fields from the fixture-creation output and record them:
    - `ok`, `run_id`, `fixture_name`, `fixture_dir`, `config_path`, `next_commands`
 5. Execute regression graders:
    - `gait regress run --json`
@@ -60,13 +62,14 @@ Do not use this skill when:
 run_source_ref="$(python3 -c 'import os,sys; v=sys.argv[1]; print(os.path.abspath(v) if os.path.exists(v) else v)' run_demo)"
 mkdir -p ./regress-workdir && cd ./regress-workdir
 gait demo --json
-gait regress init --from "${run_source_ref}" --json
+gait capture --from "${run_source_ref}" --json
+gait regress add --from ./gait-out/capture.json --json
 mkdir -p ./artifacts
 gait regress run --json --junit ./artifacts/junit.xml
 ```
 
 Expected result:
-- init output includes `ok=true` and a `fixture_dir`
+- fixture creation output includes `ok=true` and a `fixture_dir`
 - run output includes stable `status` and grader failure details
 - JUnit file exists at `./artifacts/junit.xml`
 
@@ -75,7 +78,8 @@ Expected result:
 ```bash
 mkdir -p ./regress-workdir && cd ./regress-workdir
 gait demo --json
-gait regress init --from run_demo --json
+gait capture --from run_demo --json
+gait regress add --from ./gait-out/capture.json --json
 mkdir -p ./artifacts
 gait regress run --json > ./artifacts/regress_result.json
 python3 - <<'PY'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,14 +4,14 @@ This file gives coding assistants and contributors the project-wide rules for bu
 
 ## What Gait is
 
-Gait is an offline-first durable agent runtime that dispatches long-running jobs, captures signed evidence, and enforces fail-closed policy at the tool boundary.
+Gait is the offline-first policy-as-code runtime for AI agent tool calls. It bootstraps repo policy with `gait init` and `gait check`, captures signed evidence, and enforces fail-closed policy at the tool boundary.
 
 Core primitives:
 
 - **Jobs**: dispatch multi-step agent work with checkpoints, pause/resume/cancel, approval gates, and deterministic stop reasons (`gait job submit/status/checkpoint/pause/resume/cancel/approve/inspect`)
 - **Packs**: unified portable artifact envelope (PackSpec v1) for run, job, and call evidence with Ed25519 signatures and SHA-256 manifest (`gait pack verify/diff`)
 - **Gate**: evaluate structured tool-call intent against YAML policy with fail-closed enforcement (`gait gate eval`)
-- **Regress**: convert incidents into deterministic CI regression fixtures with JUnit output (`gait regress bootstrap`)
+- **Regress**: convert incidents into deterministic CI regression fixtures with JUnit output (`gait capture`, `gait regress add`, `gait regress bootstrap`)
 - **Voice**: gate high-stakes spoken commitments before utterance via signed SayToken capability tokens and callpack artifacts (`gait voice token mint/verify`, `gait voice pack build/verify/diff`)
 - **Context Evidence**: deterministic proof of what context the model was working from, with privacy-aware envelopes and fail-closed enforcement when evidence is missing
 - **Doctor**: first-5-minutes diagnostics (stable JSON + fixes) (`gait doctor --json`)

--- a/README.md
+++ b/README.md
@@ -1,25 +1,34 @@
-# Gait — Policy-as-Code Control and Evidence for Production AI Agent Tool Calls
+# Gait — Policy-as-Code for AI Agent Tool Calls
 
-## Overview
+Use Gait when an agent can cause real side effects and you need an execution-time verdict plus portable proof.
 
-Use Gait when an AI agent can cause real side effects and you need policy-as-code control plus portable proof.
+Gait is an offline-first CLI and runtime boundary. It is not an agent framework, not a hosted dashboard, and not a model host.
 
-Gait is not an agent framework, not a model host, and not a dashboard. It is an offline-first Go CLI that sits at the tool boundary.
-
-Bootstrap a repo with `gait init` and `gait check`. Enforce fail-closed policy before high-risk actions execute. Capture incidents into portable evidence and turn them into CI regressions without changing existing regress or project-default contracts.
+Start with `gait init` and `gait check`, evaluate structured tool-call intent with `gait gate eval`, and turn incidents into deterministic CI regressions with `gait capture`, `gait regress add`, or `gait regress bootstrap`.
 
 Docs: [clyra-ai.github.io/gait](https://clyra-ai.github.io/gait/) | Install: [`docs/install.md`](docs/install.md) | Homebrew: [`docs/homebrew.md`](docs/homebrew.md)
 
-Managed/preloaded agent note: managed agents can use Gait at the tool boundary, but Gait does not host the model or replace your agent runtime.
+## Overview
 
-## Integration First (New or Existing Agent Flows)
+Gait gives you a truthful first-run path: bootstrap `.gait.yaml`, inspect the live policy contract, gate real tool execution, and keep portable evidence.
 
-The integration contract is simple:
+Managed/preloaded agent note: managed agents can use Gait at the tool boundary, but Gait does not host the model or replace your runtime.
 
-1. normalize a tool call into intent
-2. call Gait for a verdict
-3. execute real side effects only on `allow`
-4. keep the signed trace/artifact
+## Why Gait
+
+- Enforce `allow` / `block` / `require_approval` at the tool boundary before real side effects execute.
+- Keep signed traces, packs, and callpacks as ticket-ready evidence instead of dashboard-only screenshots.
+- Convert failures into deterministic CI regressions with stable exit codes and offline verification.
+- Add durable jobs, MCP trust preflight, and voice gating on the same artifact and policy contract.
+
+## The Boundary Contract
+
+The integration rule is simple:
+
+1. normalize a real tool action into structured intent
+2. ask Gait for a verdict
+3. execute the side effect only when `verdict == "allow"`
+4. keep the resulting signed trace or pack
 
 ```python
 def dispatch_tool(tool_call):
@@ -29,222 +38,201 @@ def dispatch_tool(tool_call):
     return {"executed": True, "result": execute_real_tool(tool_call)}
 ```
 
-Pick the adoption lane that matches your stack:
+Official onboarding lanes:
 
-- Inline runtime wrapper (any language): call `gait gate eval` in your dispatcher before tool execution.
-- MCP sidecar/transport lane: `gait mcp verify` (trust preflight), `gait mcp proxy` (one-shot), or `gait mcp serve` (long-running) at the boundary.
-- Python SDK lane: use `sdk/python/gait` for ergonomics; it is intentionally a thin subprocess wrapper over the local Go `gait` binary.
-- Observe-only onboarding lane: `gait trace --json -- <child command...>` for integrations that already emit Gait trace references.
+- Inline wrapper or sidecar: call `gait gate eval` in your dispatcher before real execution.
+- MCP boundary: use `gait mcp verify` for trust preflight, then `gait mcp proxy` or `gait mcp serve`.
+- Python SDK: thin subprocess ergonomics over the local Go binary, including official LangChain middleware with optional callback correlation.
+- Observe-only path: `gait trace --json -- <child command...>` for integrations that already emit Gait trace references.
 
-If you do not want Python subprocess boundaries, call `gait` directly from your runtime or use the MCP sidecar path.
+Other frameworks are named publicly only when an in-repo lane exists and clears the integration scorecard threshold.
 
 Start here:
 
-- Blessed lane: [`examples/integrations/openai_agents/`](examples/integrations/openai_agents/)
-- Quickstart script: `examples/integrations/openai_agents/quickstart.py`
-- Integration boundary guide: [`docs/agent_integration_boundary.md`](docs/agent_integration_boundary.md)
-- Integration checklist: [`docs/integration_checklist.md`](docs/integration_checklist.md)
-- MCP capability matrix: [`docs/mcp_capability_matrix.md`](docs/mcp_capability_matrix.md)
-- Python SDK contract: [`docs/sdk/python.md`](docs/sdk/python.md)
+- [`examples/integrations/openai_agents/`](examples/integrations/openai_agents/)
+- [`examples/integrations/langchain/`](examples/integrations/langchain/)
+- [`docs/integration_checklist.md`](docs/integration_checklist.md)
+- [`docs/agent_integration_boundary.md`](docs/agent_integration_boundary.md)
+- [`docs/mcp_capability_matrix.md`](docs/mcp_capability_matrix.md)
+- [`docs/sdk/python.md`](docs/sdk/python.md)
 
 ## When To Use Gait
 
 - Tool-calling AI agents need enforceable allow/block/approval decisions.
-- You need signed, portable evidence artifacts for PRs, incidents, or audits.
-- You want offline, deterministic regressions that fail CI with stable exit behavior.
-- You run multi-step jobs and need checkpoints, pause/resume/cancel, and inspectable state.
+- You need signed portable evidence for PRs, incidents, tickets, or audits.
+- You want deterministic regressions that fail CI with stable exit behavior.
+- You need additive durable jobs, MCP trust preflight, or voice gating on the same contract.
 
 ## When Not To Use Gait
 
-- No local Gait CLI or Gait artifacts are available in the execution path.
-- Your workflow only needs prompt orchestration without tool-side effects or evidence contracts.
+- No local Gait CLI or Gait artifact path exists in the execution environment.
+- Your workflow has no tool-side effects and no evidence requirements.
 - You only need hosted observability dashboards and do not need offline verification or deterministic replay.
 
-## Try It (Offline, <60s)
+## Quickstart (Real Commands, Under 60 Seconds)
 
 ### Fast 20-Second Proof
 
 ```bash
-# Install (checksums at docs/install.md)
+# Install
 curl -fsSL https://raw.githubusercontent.com/Clyra-AI/gait/main/scripts/install.sh | bash
 
-# Create a signed pack from a synthetic agent run
-gait demo
-
-# Prove it's intact
-gait verify run_demo
-
-# Turn it into a CI regression gate — one command
-gait regress bootstrap --from run_demo --junit ./gait-out/junit.xml
-```
-
-No account. No API key. No internet. You now have a verified artifact and a permanent regression test.
-
-## Dev vs Prod
-
-Development quickstart:
-
-- `gait demo`
-- `gait verify run_demo`
-
-Production hardening baseline:
-
-```bash
+# Bootstrap repo policy-as-code
 gait init --json
-cat > .gait/config.yaml <<'YAML'
-gate:
-  policy: .gait.yaml
-  profile: oss-prod
-  key_mode: prod
-  private_key_env: GAIT_PRIVATE_KEY
-  credential_broker: env
-  credential_env_prefix: GAIT_BROKER_TOKEN_
-  rate_limit_state: ./gait-out/gate_rate_limits.json
-
-mcp_serve:
-  enabled: true
-  listen: 127.0.0.1:8787
-  auth_mode: token
-  auth_token_env: GAIT_MCP_TOKEN
-  max_request_bytes: 1048576
-  http_verdict_status: strict
-  allow_client_artifact_paths: false
-
-retention:
-  trace_ttl: 168h
-  session_ttl: 336h
-  export_ttl: 168h
-YAML
 gait check --json
-gait doctor --production-readiness --json
+
+# Create a portable demo artifact and verify it
+gait demo
+gait verify run_demo --json
+
+# Turn the same artifact into a CI gate
+gait regress bootstrap --from run_demo --json --junit ./gait-out/junit.xml
 ```
 
-Use production mode when gating real side effects in shared or customer-facing environments.
+`gait init --json` writes `.gait.yaml` and returns a real scaffold summary like:
 
-Local UI playground: [`docs/ui_localhost.md`](docs/ui_localhost.md) | Launch with `gait ui`
+```json
+{
+  "ok": true,
+  "policy_path": ".gait.yaml",
+  "template": "baseline-highrisk",
+  "next_commands": [
+    "gait check --policy .gait.yaml --json",
+    "gait policy validate .gait.yaml --json",
+    "gait gate eval --policy .gait.yaml --intent examples/policy/intents/intent_delete.json --json"
+  ]
+}
+```
 
-## See It
+`gait check --json` validates the repo policy contract and reports the live policy shape:
 
-### Simple End-To-End Scenario
+```json
+{
+  "ok": true,
+  "policy_path": ".gait.yaml",
+  "default_verdict": "block",
+  "rule_count": 7,
+  "summary": "policy ok: default_verdict=block rules=7 gap_warnings=1"
+}
+```
 
-![Gait simple end-to-end tool-boundary scenario](docs/assets/gait_demo_simple_e2e_60s.gif)
+`gait demo` prints a portable proof trail:
 
-Video: [`gait_demo_simple_e2e_60s.mp4`](docs/assets/gait_demo_simple_e2e_60s.mp4) | Scenario walkthrough: [`docs/scenarios/simple_agent_tool_boundary.md`](docs/scenarios/simple_agent_tool_boundary.md) | Output legend: [`docs/demo_output_legend.md`](docs/demo_output_legend.md)
+```text
+run_id=run_demo
+ticket_footer=GAIT run_id=run_demo ...
+verify=ok
+next=gait verify run_demo --json,gait regress bootstrap --from run_demo --json --junit ./gait-out/junit.xml,...
+```
 
-See: [2,880 tool calls gate-checked in 24 hours](docs/blog/openclaw_24h_boundary_enforcement.md)
+No account. No API key. No hosted dependency.
 
-## What You Get
+## Simple End-To-End Scenario
 
-**Signed packs** — every run and job emits a tamper-evident artifact (Ed25519 + SHA-256 manifest). Verify offline. Attach to PRs, incidents, audits. One artifact is the entire proof. Export OTEL-style JSONL and deterministic PostgreSQL index SQL with `gait pack export`.
+See [`docs/scenarios/simple_agent_tool_boundary.md`](docs/scenarios/simple_agent_tool_boundary.md) and the promoted wrapper quickstart at `examples/integrations/openai_agents/quickstart.py`.
 
-**Fail-closed policy enforcement** — `gait gate eval` evaluates a structured tool-call intent against YAML policy before the side effect runs. Non-allow means non-execute. Signed trace proves the decision. Script mode supports deterministic step rollups, optional Wrkr context enrichment, and signed approved-script fast-path allow.
+## What Ships In OSS
 
-**Incident → CI gate with explicit capture** — `gait capture` records the portable source you are acting on, `gait regress add` lands it on the same deterministic fixture contract as `gait regress init`, and `gait regress bootstrap` remains the one-command path. Exit 0 = pass, exit 5 = drift. Never debug the same failure twice.
+**Gate** — evaluate structured tool-call intent against YAML policy with fail-closed enforcement. Non-allow means non-execute.
 
-**Durable jobs** — dispatch long-running agent work that survives failures. Checkpoints, pause/resume/stop/cancel, approval gates, deterministic stop reasons, and emergency preemption for queued dispatches. No more lost state at step 47.
+**Evidence** — signed traces, runpacks, packs, and callpacks you can verify, diff, and attach to tickets, PRs, audits, and incidents.
 
-**Destructive safety boundary** — enforce phase-aware plan/apply behavior (`plan` stays non-destructive, destructive `apply` requires approval), plus fail-closed destructive budgets and bounded approval token scopes (`max-targets`, `max-ops`).
+**Regress** — `gait capture`, `gait regress add`, and `gait regress bootstrap` turn incidents into deterministic CI gates with JUnit output.
 
-**Deterministic replay and diff** — replay an agent run using recorded results as stubs (no real API calls). Diff two packs to see what changed, including context drift classification.
+**Durable jobs** — checkpointed long-running work with pause/resume/cancel, approvals, and deterministic stop reasons.
 
-**Voice agent gating** — gate high-stakes spoken commitments (refunds, quotes, eligibility) before they're uttered. Signed `SayToken` capability + callpack artifacts for voice boundaries.
+**MCP trust** — evaluate local trust snapshots with `gait mcp verify`, then enforce via `gait mcp proxy` or `gait mcp serve`.
 
-**Risk ranking** — rank highest-risk actions across runs and traces by tool class and blast radius. Offline, no dashboard.
+**Voice and context evidence** — fail-closed gating for spoken commitments and missing-context high-risk decisions.
 
-## Additional Adapters
+## Differentiation
 
-[LangChain](examples/integrations/langchain/) · [AutoGen](examples/integrations/autogen/) · [AutoGPT](examples/integrations/autogpt/) · [OpenClaw](examples/integrations/openclaw/) · [Gastown](examples/integrations/gastown/) · [Voice](examples/integrations/voice_reference/)
+Gait is complementary to observability products.
 
-## CI Adoption (One PR)
+- Observability tools help you inspect what happened after the fact.
+- Gait decides whether a tool action may execute, emits a signed trace for that decision, and makes the artifact reusable in CI.
+- External scanners and registries can feed Gait. Gait enforces at the action boundary; it does not replace the scanner.
+
+## CI Adoption
 
 ```bash
 gait regress bootstrap --from run_demo --json --junit ./gait-out/junit.xml
 ```
 
-- exit `0` = pass, exit `5` = regression failed
-- Template: [`.github/workflows/adoption-regress-template.yml`](.github/workflows/adoption-regress-template.yml)
-- Drop-in action: [`.github/actions/gait-regress/README.md`](.github/actions/gait-regress/README.md)
-- GitLab/Jenkins/Circle: [`docs/ci_regress_kit.md`](docs/ci_regress_kit.md)
-- Canonical copy-paste guide: [`docs/adopt_in_one_pr.md`](docs/adopt_in_one_pr.md)
-- Threat model: [`docs/threat_model.md`](docs/threat_model.md)
-- Failure taxonomy and exits: [`docs/failure_taxonomy_exit_codes.md`](docs/failure_taxonomy_exit_codes.md)
+- exit `0` means pass
+- exit `5` means regression drift
+- GitHub Actions template: [`.github/workflows/adoption-regress-template.yml`](.github/workflows/adoption-regress-template.yml)
+- GitLab, Jenkins, CircleCI, and hook guidance: [`docs/ci_regress_kit.md`](docs/ci_regress_kit.md)
+- Copy-paste rollout: [`docs/adopt_in_one_pr.md`](docs/adopt_in_one_pr.md)
 
-## Contract Commitments
+## Compliance And Evidence
 
-- **determinism**: verify, diff, and stub replay produce identical results on identical artifacts
-- **offline-first**: core workflows do not require network
-- **fail-closed**: high-risk paths block on policy or approval ambiguity
-- **schema stability**: versioned artifacts with backward-compatible readers
-- **stable exit codes**: `0` success · `1` internal/runtime failure · `2` verification failure · `3` policy block · `4` approval required · `5` regress failed · `6` invalid input · `7` dependency missing · `8` unsafe operation blocked
+Put this copy at the bottom of launch surfaces: Gait produces signed evidence artifacts for operational proof.
 
-Normative spec: [`docs/contracts/primitive_contract.md`](docs/contracts/primitive_contract.md) | PackSpec v1: [`docs/contracts/packspec_v1.md`](docs/contracts/packspec_v1.md) | Intent+receipt: [`docs/contracts/intent_receipt_conformance.md`](docs/contracts/intent_receipt_conformance.md)
+- `gait verify`, `gait pack verify`, and `gait trace verify` work offline.
+- Packs use Ed25519 signatures plus SHA-256 manifests.
+- Artifacts are versioned, deterministic, and designed for change control, audit trails, PRs, and incident handoff.
 
-Hardening: [`docs/hardening/v2_2_contract.md`](docs/hardening/v2_2_contract.md) | Runbook: [`docs/hardening/prime_time_runbook.md`](docs/hardening/prime_time_runbook.md)
+Normative references:
+
+- [`docs/contracts/primitive_contract.md`](docs/contracts/primitive_contract.md)
+- [`docs/contracts/packspec_v1.md`](docs/contracts/packspec_v1.md)
+- [`docs/contracts/intent_receipt_conformance.md`](docs/contracts/intent_receipt_conformance.md)
+- [`docs/failure_taxonomy_exit_codes.md`](docs/failure_taxonomy_exit_codes.md)
+
+Stable exit codes:
+
+- `0` success
+- `1` internal/runtime failure
+- `2` verification failure
+- `3` policy block
+- `4` approval required
+- `5` regress failed
+- `6` invalid input
+- `7` dependency missing
+- `8` unsafe operation blocked
 
 ## Documentation
 
-1. [`docs/README.md`](docs/README.md) — ownership map
-2. [`docs/concepts/mental_model.md`](docs/concepts/mental_model.md) — how Gait works
-3. [`docs/architecture.md`](docs/architecture.md) — component boundaries
-4. [`docs/flows.md`](docs/flows.md) — end-to-end sequences
-5. [`docs/durable_jobs.md`](docs/durable_jobs.md) — durable job lifecycle and differentiation
-6. [`docs/contracts/primitive_contract.md`](docs/contracts/primitive_contract.md) — normative spec
-
-Public docs: [clyra-ai.github.io/gait](https://clyra-ai.github.io/gait/) | Wiki: [github.com/Clyra-AI/gait/wiki](https://github.com/Clyra-AI/gait/wiki) | Changelog: [CHANGELOG.md](CHANGELOG.md)
+1. [`docs/README.md`](docs/README.md)
+2. [`docs/policy_authoring.md`](docs/policy_authoring.md)
+3. [`docs/integration_checklist.md`](docs/integration_checklist.md)
+4. [`docs/agent_integration_boundary.md`](docs/agent_integration_boundary.md)
+5. [`docs/ci_regress_kit.md`](docs/ci_regress_kit.md)
+6. [`docs/mcp_capability_matrix.md`](docs/mcp_capability_matrix.md)
 
 ## Developer Workflow
 
 ![CI](https://github.com/Clyra-AI/gait/actions/workflows/ci.yml/badge.svg)
 ![CodeQL](https://github.com/Clyra-AI/gait/actions/workflows/codeql.yml/badge.svg)
-![Intent+Receipt Conformance](https://github.com/Clyra-AI/gait/actions/workflows/intent-receipt-conformance.yml/badge.svg)
 
 ```bash
 make fmt && make lint && make test
-make test-e2e
-make test-hardening-acceptance
-make test-uat-local
+make test-docs-consistency
+make test-docs-storyline
 ```
 
-Push hooks: `make hooks` | Full gate: `GAIT_PREPUSH_MODE=full git push` | Branch protection: `make github-guardrails`
-
-Contributor guide: [`CONTRIBUTING.md`](CONTRIBUTING.md)
+Hooks: `make hooks` | Contributor guide: [`CONTRIBUTING.md`](CONTRIBUTING.md)
 
 ## Command Surface
 
 ```text
-gait demo                                         Create a signed pack offline
-gait tour                                         Interactive walkthrough
-gait verify <run_id|path>                          Verify integrity offline
-gait verify chain|session-chain                    Multi-artifact chain verification
-gait job submit|status|checkpoint|pause|resume     Durable job lifecycle
-gait job stop|approve|cancel|inspect               Emergency stop, approval, and inspection
-gait pack build|verify|inspect|diff|export         Unified pack operations + OTEL/Postgres sinks
 gait init|check                                    Repo policy bootstrap and validation
+gait gate eval                                     Policy enforcement + signed trace
 gait test|enforce                                  Bounded wrappers for explicit Gait-aware integrations
 gait capture                                       Persist portable capture receipt from explicit source
-gait regress add|init|bootstrap|run                Incident → CI gate
-gait gate eval                                     Policy enforcement + signed trace
-gait approve-script                                Mint signed approved-script registry entries
-gait approve                                       Mint signed approval tokens
-gait list-scripts                                  Inspect approved-script registry status
-gait delegate mint|verify                          Delegation token lifecycle
-gait report top                                    Rank highest-risk actions
+gait regress add|init|bootstrap|run                Incident -> CI gate
+gait mcp verify|proxy|bridge|serve                 MCP trust preflight and transport adapters
+gait trace|trace verify                            Observe-only trace wrapper and trace integrity verification
+gait demo|verify                                   First artifact and offline verification
+gait pack build|verify|inspect|diff|export         Unified pack operations
+gait job submit|status|checkpoint|pause|resume     Durable job lifecycle
+gait job stop|approve|cancel|inspect               Emergency stop, approval, and inspection
 gait voice token mint|verify                       Voice commitment gating
 gait voice pack build|verify|inspect|diff          Voice callpack operations
-gait run record|inspect|replay|diff|receipt        Run recording and replay
-gait run session start|append|status|checkpoint|compact  Session journaling
-gait run reduce                                    Reduce runpack by predicate
-gait mcp verify|proxy|bridge|serve                 MCP trust preflight and transport adapters
-gait gateway ingest                                Ingest MCP gateway logs into signed policy-enforcement proof records
-gait policy init|validate|fmt|simulate|test        Policy authoring and explicit scaffold workflows
 gait doctor [--production-readiness] [adoption]    Diagnostics + readiness
+gait policy init|validate|fmt|simulate|test        Policy authoring workflows
 gait keys init|rotate|verify                       Signing key lifecycle
-gait scout snapshot|diff|signal                    Drift and adoption signals
-gait guard pack|verify|retain|encrypt|decrypt      Evidence and encryption
-gait trace|trace verify                            Observe-only trace wrapper and trace integrity verification
-gait incident pack                                 Build incident evidence pack
-gait registry install|list|verify                  Signed skill-pack registry
-gait migrate                                       Migrate legacy artifacts to v1
 gait ui                                            Local playground
 gait version                                       Print version
 ```

--- a/docs-site/public/llm/contracts.md
+++ b/docs-site/public/llm/contracts.md
@@ -6,7 +6,9 @@ Stable OSS contracts include:
   - includes first-class export surfaces: `gait pack export --otel-out ...` and `--postgres-sql-out ...` for observability and metadata indexing.
 - **ContextSpec v1**: Deterministic context evidence envelopes with privacy-aware modes and fail-closed enforcement.
 - **Primitive Contract**: Four deterministic primitives — capture, enforce, regress, diagnose.
+- **Repo Policy Contract**: `gait init` writes `.gait.yaml`; `gait check` reports the live contract (`default_verdict`, `rule_count`, `gap_warnings`).
 - **MCP Trust + Trace Onboarding**: local MCP trust snapshots and observe-only `gait trace` are additive onboarding contracts over the same signed trace and policy surfaces.
+  - `mcp_trust.snapshot` must point at a local file; scanners and registries remain complementary inputs.
 - **Script Governance Contract**: Script intent steps, deterministic `script_hash`, Wrkr-derived context matching fields, and signed approved-script registry entries.
 - **Intent+Receipt Spec**: Structured tool-call intent with deterministic receipt generation.
 - **Endpoint Action Model**: Maps tool-call intent to policy-evaluated action outcomes.

--- a/docs-site/public/llm/faq.md
+++ b/docs-site/public/llm/faq.md
@@ -2,7 +2,11 @@
 
 ## What is the primary job of Gait?
 
-Gait dispatches durable agent jobs, captures signed evidence at the tool boundary, and enforces fail-closed policy before side effects execute.
+Gait enforces fail-closed policy before agent tool side effects execute and keeps signed evidence you can verify offline.
+
+## What should teams run first?
+
+Run `gait init --json`, `gait check --json`, `gait demo`, `gait verify run_demo --json`, and `gait regress bootstrap --from run_demo --json --junit ./gait-out/junit.xml`.
 
 ## What problem does Gait solve for long-running agent work?
 
@@ -18,15 +22,15 @@ At tool-call execution intent, not prompt text alone. Non-allow gate outcomes do
 
 ## What is the tool boundary in concrete terms?
 
-The tool boundary is the exact call site in your wrapper/adapter where a real tool side effect is about to execute. The adapter sends structured intent to Gait and only executes the tool when verdict is `allow`.
+The tool boundary is the exact call site in your wrapper or adapter where a real tool side effect is about to execute. The adapter sends structured intent to Gait and only executes the tool when verdict is `allow`.
 
 ## How do I turn a failed agent run into a CI gate?
 
-Run `gait regress bootstrap --from <run_id> --junit output.xml`. This converts the run into a permanent regression fixture. Exit 0 means pass, exit 5 means the same drift was detected. Wire the JUnit output into any CI system.
+Run `gait regress bootstrap --from <run_id> --junit output.xml`. This converts the run into a permanent regression fixture. Exit 0 means pass, exit 5 means drift. Wire the JUnit output into any CI system.
 
 ## Can Gait gate voice agent actions?
 
-Yes. Voice mode gates high-stakes spoken commitments (refunds, quotes, eligibility) before they are uttered. A signed SayToken capability token must be present for gated speech, and every call produces a signed callpack artifact.
+Yes. Voice mode gates high-stakes spoken commitments before they are uttered. A signed SayToken capability token must be present for gated speech, and every call produces a signed callpack artifact.
 
 ## What is context evidence?
 
@@ -38,7 +42,7 @@ Yes. `gait run replay` uses recorded results as deterministic stubs so you can d
 
 ## How does Gait integrate with agent frameworks?
 
-Gait provides three integration modes: wrapper/sidecar pattern, Python SDK, and MCP server (`gait mcp serve`). The integration checklist covers the path from first demo to production enforcement.
+Gait provides wrapper or sidecar, Python SDK, and MCP boundary modes. The official LangChain surface is middleware with optional callback correlation; enforcement still happens only at the tool boundary.
 
 ## Can Gait pre-approve known multi-step scripts?
 
@@ -46,4 +50,4 @@ Yes. Use `gait approve-script` to mint signed registry entries bound to policy d
 
 ## How should teams start?
 
-Run `gait tour` for a guided walkthrough, then `gait demo` to create and verify a signed pack. Wire one integration path from the integration checklist to move toward production enforcement.
+Bootstrap `.gait.yaml` with `gait init` and `gait check`, then run `gait demo` and wire one integration seam from the integration checklist.

--- a/docs-site/public/llm/product.md
+++ b/docs-site/public/llm/product.md
@@ -1,14 +1,14 @@
 # Gait Product Summary
 
-Gait is an offline-first policy-as-code runtime for production AI agents that dispatches durable jobs, captures signed evidence, and enforces fail-closed policy at the tool boundary.
+Gait is the offline-first policy-as-code runtime for AI agent tool calls. It bootstraps repo policy with `gait init` and `gait check`, enforces fail-closed verdicts at the tool boundary, captures signed evidence, and turns incidents into deterministic CI regressions.
 
 It provides seven OSS primitives:
 
-1. **Jobs**: Dispatch multi-step, multi-hour agent work with checkpoints, pause/resume/stop/cancel, approval gates, deterministic stop reasons, and emergency-stop preemption evidence.
-2. **Packs**: Unified portable artifact envelope (PackSpec v1) for run, job, and call evidence with Ed25519 signatures and SHA-256 manifest.
-3. **Gate**: Evaluate structured tool-call intent against YAML policy with fail-closed enforcement. Supports phase-aware destructive plan/apply boundaries, destructive budgets, multi-step script rollups, Wrkr context enrichment, and signed approved-script fast-path allow.
-4. **Regress**: Convert any incident or failed run into a deterministic CI regression fixture with JUnit output and stable exit codes.
-5. **Voice**: Gate high-stakes spoken commitments (refunds, quotes, eligibility) before they are uttered. Signed SayToken capability tokens and callpack artifacts for voice boundaries.
+1. **Gate**: Evaluate structured tool-call intent against YAML policy with fail-closed enforcement. Supports destructive plan/apply boundaries, destructive budgets, multi-step script rollups, Wrkr context enrichment, and signed approved-script fast-path allow.
+2. **Evidence**: Signed traces, runpacks, packs, and callpacks with Ed25519 signatures and SHA-256 manifests.
+3. **Regress**: Convert incidents into deterministic CI regression fixtures with JUnit output and stable exit codes through `gait capture`, `gait regress add`, and `gait regress bootstrap`.
+4. **Jobs**: Dispatch multi-step, multi-hour agent work with checkpoints, pause/resume/stop/cancel, approval gates, deterministic stop reasons, and emergency-stop preemption evidence.
+5. **Voice**: Gate high-stakes spoken commitments before they are uttered with SayToken capability tokens and callpack artifacts.
 6. **Context Evidence**: Deterministic proof of what context the model was working from at decision time. Privacy-aware envelopes with fail-closed enforcement when evidence is missing.
 7. **Doctor**: Diagnose first-run environment issues with stable JSON output.
 
@@ -16,6 +16,7 @@ Secondary boundary surfaces:
 
 - **MCP Trust**: evaluate local trust snapshots for MCP server admission with `gait mcp verify`, `gait mcp proxy`, and `gait mcp serve`.
 - **Trace**: observe-only wrapper mode with `gait trace` for integrations that already emit Gait trace references.
+- **LangChain Middleware**: official Python middleware with optional callback correlation; callbacks never decide allow or block behavior.
 
 Gait is vendor-neutral and offline-first for core workflows: capture, verify, diff, policy evaluation, regressions, and voice/context verification all run without network dependencies.
 
@@ -30,18 +31,20 @@ When to use:
 - agent tool calls can cause side effects and need fail-closed control
 - incidents must become deterministic CI regressions
 - teams need signed portable evidence instead of dashboard-only traces
+- teams want truthful repo bootstrap commands before wiring a full integration
 
 When not to use:
 
 - no Gait CLI/artifact path is available in the runtime
 - workflow has no tool-side effects and no evidence requirements
+- you only want a hosted observability dashboard without offline verification or deterministic replay
 
 Canonical docs:
 
-- `/docs/adopt_in_one_pr/`
-- `/docs/durable_jobs/`
+- `/docs/policy_authoring/`
 - `/docs/integration_checklist/`
-- `/docs/architecture/`
-- `/docs/flows/`
-- `/docs/threat_model/`
+- `/docs/agent_integration_boundary/`
+- `/docs/adopt_in_one_pr/`
+- `/docs/ci_regress_kit/`
+- `/docs/mcp_capability_matrix/`
 - `/docs/failure_taxonomy_exit_codes/`

--- a/docs-site/public/llm/quickstart.md
+++ b/docs-site/public/llm/quickstart.md
@@ -1,13 +1,10 @@
 # Gait Quickstart
 
-Use this when you need deterministic control + evidence at agent tool boundaries.
+Use this when you need deterministic control plus evidence at agent tool boundaries.
 
 ```bash
 # Install
 curl -fsSL https://raw.githubusercontent.com/Clyra-AI/gait/main/scripts/install.sh | bash
-
-# Guided tour
-gait tour
 
 # Bootstrap repo policy-as-code
 gait init --json
@@ -17,31 +14,44 @@ gait check --json
 gait demo
 
 # Prove it's intact
-gait verify run_demo
-
-# Export OTEL + Postgres index SQL from the same pack
-gait pack build --type run --from run_demo --out ./gait-out/pack_run_demo.zip
-gait pack export ./gait-out/pack_run_demo.zip --otel-out ./gait-out/pack_run_demo.otel.jsonl --postgres-sql-out ./gait-out/pack_index.sql
+gait verify run_demo --json
 
 # Turn it into a CI regression gate
-gait regress bootstrap --from run_demo --junit ./gait-out/junit.xml
+gait regress bootstrap --from run_demo --json --junit ./gait-out/junit.xml
+```
 
-# Try durable jobs, wrappers, and policy demos
-gait demo --durable
-gait demo --policy
+Expected bootstrap shape:
+
+```json
+{"ok":true,"policy_path":".gait.yaml","template":"baseline-highrisk"}
+{"ok":true,"policy_path":".gait.yaml","default_verdict":"block","rule_count":7}
+```
+
+Expected demo shape:
+
+```text
+run_id=run_demo
+ticket_footer=GAIT run_id=run_demo ...
+verify=ok
+```
+
+Then continue with one integration seam:
+
+- one-PR CI adoption: `/docs/adopt_in_one_pr/`
+- durable jobs lifecycle: `/docs/durable_jobs/`
+- production integration checklist: `/docs/integration_checklist/`
+- LangChain middleware contract: `/docs/sdk/python/`
+
+Use `gait policy test` and `gait gate eval --simulate` before enforce rollout on high-risk tool-call boundaries. `gait enforce` is a bounded wrapper for integrations that already emit Gait trace references.
+
+Wrapper lane example:
+
+```bash
 gait test --json -- python3 examples/integrations/openai_agents/quickstart.py --scenario allow
 gait trace --json -- python3 examples/integrations/openai_agents/quickstart.py --scenario allow
 gait capture --from run_demo --json
 gait regress add --from ./gait-out/capture.json --json
 ```
-
-Then continue with:
-
-- one-PR CI adoption: `/docs/adopt_in_one_pr/`
-- durable jobs lifecycle: `/docs/durable_jobs/`
-- production integration checklist: `/docs/integration_checklist/`
-
-Use `gait policy test` and `gait gate eval --simulate` before enforce rollout on high-risk tool-call boundaries. `gait enforce` is a bounded wrapper for integrations that already emit Gait trace references.
 
 For MCP server admission, keep trust inputs local:
 

--- a/docs-site/public/llm/security.md
+++ b/docs-site/public/llm/security.md
@@ -13,6 +13,7 @@
 - Context evidence envelopes with fail-closed enforcement when evidence is missing for high-risk actions.
 - Durable jobs with deterministic stop reasons and checkpoint integrity.
 - No hosted service dependency required for core operation.
+- MCP trust inputs remain local-file based and complementary to external scanners or registries; Gait enforces, it does not become the scanner.
 
 Operational references:
 

--- a/docs-site/public/llms.txt
+++ b/docs-site/public/llms.txt
@@ -1,58 +1,40 @@
 # Gait
 
-> Offline-first policy-as-code runtime: bootstrap repo policy with `gait init`/`gait check`, gate tool calls and voice commitments with fail-closed policy, capture signed evidence, and turn incidents into deterministic CI regressions.
+> Offline-first policy-as-code runtime for AI agent tool calls: bootstrap `.gait.yaml` with `gait init` and `gait check`, enforce fail-closed verdicts at the execution boundary, keep signed evidence, and turn incidents into deterministic CI regressions.
 
 ## Canonical
 - https://github.com/Clyra-AI/gait
 - https://clyra-ai.github.io/gait/
 
 ## Core Commands
-- gait demo
-- gait demo --durable
-- gait demo --policy
 - gait init --json
 - gait check --json
-- gait tour
+- gait gate eval --policy <policy.yaml> --intent <intent.json>
+- gait demo
 - gait verify <run_id|path>
 - gait test -- <child command...>
 - gait enforce -- <child command...>
 - gait capture --from <run_id|path>
 - gait regress add --from <capture.json|run_id|path>
-- gait run replay <run_id>
-- gait pack verify <pack.zip>
-- gait pack diff <left.zip> <right.zip>
-- gait pack export <pack.zip> --otel-out <otel.jsonl>
 - gait regress bootstrap --from <run_id|path> --junit <path>
 - gait regress run --json --junit <path>
 - gait policy test <policy.yaml> <intent.json>
-- gait gate eval --policy <policy.yaml> --intent <intent.json>
 - gait mcp verify --policy <policy.yaml> --server <server.json>
 - gait trace -- <child command...>
-- gait gate eval --policy <policy.yaml> --intent <intent.json> --wrkr-inventory <inventory.json>
-- gait approve-script --policy <policy.yaml> --intent <script_intent.json> --registry <registry.json> --approver <id>
-- gait list-scripts --registry <registry.json>
+- gait pack verify <pack.zip>
+- gait pack diff <left.zip> <right.zip>
+- gait pack export <pack.zip> --otel-out <otel.jsonl>
+- gait run replay <run_id>
 - gait job submit --id <job_id> --policy <policy.yaml> --identity <id>
-- gait job status --id <job_id>
-- gait job checkpoint add --id <job_id> --type <type> --summary <text>
-- gait job checkpoint list --id <job_id>
-- gait job pause --id <job_id>
-- gait job stop --id <job_id>
-- gait job resume --id <job_id> --policy <policy.yaml> [--identity-revocations <path>]
-- gait job cancel --id <job_id>
-- gait gateway ingest --source <kong|docker|mintmcp> --log-path <path>
 - gait voice token mint --intent <intent.json> --policy <policy.yaml>
-- gait voice token verify --token <token.json>
-- gait voice pack build --from <call_record.json>
-- gait voice pack verify <callpack.zip>
-- gait voice pack diff <left.zip> <right.zip>
 - gait doctor --json
-- gait doctor --summary
 - gait ui
 
 ## Tool Boundary
 - Boundary location: the exact adapter call site before real tool side effects execute.
 - Input: structured intent payload.
 - Rule: `verdict != allow` means no tool execution.
+- Official LangChain lane: middleware with optional callback correlation, not a separate policy engine.
 
 ## When To Use
 - You need enforceable policy decisions before agent tool side effects.
@@ -62,30 +44,26 @@
 ## When Not To Use
 - No local Gait CLI/artifact path exists.
 - No tool side effects or evidence requirements exist.
+- You only want a hosted observability dashboard without offline verification.
 
 ## Safety Model
 - Fail-closed by default for ambiguous high-risk policy outcomes.
-- Out-of-band emergency stop preemption blocks post-stop dispatches (`emergency_stop_preempted`).
+- `gait init` writes `.gait.yaml`; `gait check` reports the live policy contract and gap warnings.
 - Offline verification for packs, runpacks, and traces.
-- Destructive operations support phase-aware plan/apply boundaries and fail-closed destructive budgets.
-- Structured intent model for policy decisions (not free-form prompt filtering).
+- Structured intent model for policy decisions, not free-form prompt filtering.
 - SayToken capability tokens for voice agent commitment gating.
 - Context evidence envelopes with fail-closed enforcement when evidence is missing.
-- Signed traces and explicit reason codes for blocked actions.
 - MCP trust stays file-based and offline-first: external tool finds, Gait enforces.
-- No hosted service dependency required for core operation.
 
 ## Canonical Docs
-- /docs/adopt_in_one_pr/
-- /docs/durable_jobs/
+- /docs/policy_authoring/
 - /docs/integration_checklist/
-- /docs/architecture/
-- /docs/flows/
-- /docs/threat_model/
-- /docs/failure_taxonomy_exit_codes/
+- /docs/agent_integration_boundary/
+- /docs/adopt_in_one_pr/
+- /docs/ci_regress_kit/
+- /docs/mcp_capability_matrix/
 - /docs/contracts/packspec_v1/
-- /docs/contracts/pack_producer_kit/
-- /docs/contracts/compatibility_matrix/
+- /docs/failure_taxonomy_exit_codes/
 
 ## LLM Resources
 - /llms-full.txt

--- a/docs-site/src/app/page.tsx
+++ b/docs-site/src/app/page.tsx
@@ -3,9 +3,9 @@ import type { Metadata } from 'next';
 import { canonicalUrl } from '@/lib/site';
 
 export const metadata: Metadata = {
-  title: 'Gait | Durable Agent Runtime with Signed Proof',
+  title: 'Gait | Policy-as-Code for Agent Tool Calls',
   description:
-    'Gait is an offline-first runtime for production AI agents: durable jobs, signed packs, voice agent gating, context evidence, deterministic regressions, and fail-closed policy gates.',
+    'Gait is the offline-first policy-as-code runtime for AI agent tool calls: repo bootstrap with gait init/check, fail-closed tool-boundary verdicts, signed evidence, deterministic regressions, MCP trust, and durable jobs.',
   alternates: {
     canonical: canonicalUrl('/'),
   },
@@ -14,14 +14,23 @@ export const metadata: Metadata = {
 const QUICKSTART = `# Install
 curl -fsSL https://raw.githubusercontent.com/Clyra-AI/gait/main/scripts/install.sh | bash
 
-# Create a signed pack from a synthetic agent run
-gait demo
+# Bootstrap repo policy-as-code
+gait init --json
+gait check --json
 
-# Prove it's intact
-gait verify run_demo
+# Create a signed artifact and verify it
+gait demo
+gait verify run_demo --json
 
 # Turn it into a CI regression gate
-gait regress bootstrap --from run_demo --junit ./gait-out/junit.xml`;
+gait regress bootstrap --from run_demo --json --junit ./gait-out/junit.xml`;
+
+const POLICY_SHAPE = `{
+  "ok": true,
+  "policy_path": ".gait.yaml",
+  "default_verdict": "block",
+  "rule_count": 7
+}`;
 
 const INTEGRATION_SNIPPET = `def dispatch_tool(tool_call):
     decision = gait_evaluate(tool_call)
@@ -31,77 +40,77 @@ const INTEGRATION_SNIPPET = `def dispatch_tool(tool_call):
 
 const features = [
   {
-    title: 'Durable Jobs: Run Without Losing State',
-    description: 'Dispatch multi-step, multi-hour agent work with checkpoints, pause/resume/cancel, approval gates, and deterministic stop reasons.',
-    href: '/docs/flows',
-  },
-  {
-    title: 'Signed Packs: Portable Proof',
-    description: 'Every run and job emits a signed pack you can verify, diff, and inspect offline. Attach it to PRs, incidents, and audits.',
-    href: '/docs/contracts/packspec_v1',
-  },
-  {
-    title: 'Regress: Incident to CI Gate',
-    description: 'One command converts a failure into a permanent regression test with JUnit output and stable exit codes.',
-    href: '/docs/ci_regress_kit',
-  },
-  {
-    title: 'Gate: Fail-Closed Policy Enforcement',
-    description: 'Evaluate structured tool-call intent against policy before side effects execute. Non-allow means non-execute.',
+    title: 'Gate Before Tool Execution',
+    description: 'Evaluate structured intent with fail-closed YAML policy. Any verdict other than allow is non-executing.',
     href: '/docs/policy_authoring',
   },
   {
-    title: 'Voice Agent Gating',
-    description: 'Gate high-stakes spoken commitments before they are uttered. Signed SayToken capability tokens and callpack artifacts for voice boundaries.',
-    href: '/docs/voice_mode',
+    title: 'Signed Evidence You Can Reuse',
+    description: 'Keep signed traces, runpacks, packs, and callpacks you can verify offline and attach to PRs, incidents, and audits.',
+    href: '/docs/contracts/packspec_v1',
   },
   {
-    title: 'Context Evidence',
-    description: 'Deterministic proof of what context the model was working from. Privacy-aware envelopes with fail-closed enforcement when evidence is missing.',
-    href: '/docs/contracts/contextspec_v1',
+    title: 'Incident to CI Gate',
+    description: 'Use gait capture, gait regress add, or gait regress bootstrap to turn a failure into a permanent regression with stable exit codes.',
+    href: '/docs/ci_regress_kit',
+  },
+  {
+    title: 'LangChain Middleware, Truthfully Scoped',
+    description: 'The official LangChain lane is middleware with optional callback correlation. Enforcement still happens only at wrap_tool_call.',
+    href: '/docs/sdk/python',
+  },
+  {
+    title: 'MCP Trust Is Complementary',
+    description: 'Use gait mcp verify on local trust snapshots before proxy or serve. External scanners find; Gait enforces.',
+    href: '/docs/mcp_capability_matrix',
+  },
+  {
+    title: 'Durable Jobs and Voice Stay Additive',
+    description: 'Checkpointed jobs, voice commitment gating, and context evidence ride on the same artifact and policy contracts.',
+    href: '/docs/flows',
   },
 ];
 
 const faqs = [
+  {
+    question: 'What should teams run first?',
+    answer:
+      'Run gait init --json, gait check --json, gait demo, gait verify run_demo --json, then gait regress bootstrap --from run_demo --json --junit ./gait-out/junit.xml.',
+  },
+  {
+    question: 'Where does Gait enforce policy?',
+    answer:
+      'At the exact tool boundary where your runtime is about to execute a real side effect. Only allow executes. Block and require_approval stay non-executing.',
+  },
+  {
+    question: 'What does Gait do that logs do not?',
+    answer:
+      'Gait produces signed traces and packs with deterministic verification, so incidents are portable, independently verifiable evidence rather than best-effort log interpretation.',
+  },
+  {
+    question: 'Does Gait require a hosted service?',
+    answer:
+      'No. Core workflows are offline-first and run locally: capture, verify, diff, policy evaluation, regressions, and voice/context verification can run without a network dependency.',
+  },
   {
     question: 'What problem does Gait solve for long-running agent work?',
     answer:
       'Multi-step and multi-hour agent jobs fail mid-flight, losing state and provenance. Gait dispatches durable jobs with checkpointed state, pause/resume/cancel, and deterministic stop reasons so work survives failures and stays auditable.',
   },
   {
-    question: 'What does Gait do that logs do not?',
-    answer:
-      'Gait produces signed packs and traces with deterministic verification, so incidents are portable, independently verifiable evidence rather than best-effort log interpretation.',
-  },
-  {
-    question: 'Does Gait require a hosted service?',
-    answer:
-      'No. Core workflows are offline-first and run locally: capture, verify, diff, policy evaluation, and regressions can run without a network dependency.',
-  },
-  {
-    question: 'How does Gait handle prompt-injection style risk?',
-    answer:
-      'Gate evaluates structured tool-call intent at execution time and blocks or requires approval based on policy. Non-allow outcomes do not execute side effects.',
-  },
-  {
     question: 'Can Gait gate voice agent actions?',
     answer:
-      'Yes. Voice mode gates high-stakes spoken commitments (refunds, quotes, eligibility) before they are uttered. A signed SayToken capability token must be present for gated speech, and every call produces a signed callpack artifact.',
+      'Yes. Voice mode gates high-stakes spoken commitments before they are uttered. A signed SayToken capability token must be present for gated speech, and every call produces a signed callpack artifact.',
   },
   {
     question: 'What is context evidence?',
     answer:
-      'Context evidence is a deterministic proof of what context material the model was working from at decision time. Gait captures privacy-aware context envelopes and enforces fail-closed policy when evidence is missing for high-risk actions.',
+      'Context evidence is deterministic proof of what context material the model was working from at decision time. Gait captures privacy-aware context envelopes and enforces fail-closed policy when evidence is missing for high-risk actions.',
   },
   {
     question: 'How do I turn a failed agent run into a CI gate?',
     answer:
-      'Run gait regress bootstrap --from <run_id> --junit output.xml. This converts the run into a permanent regression fixture. Exit 0 means pass, exit 5 means the same drift was detected. Wire the JUnit output into any CI system.',
-  },
-  {
-    question: 'Can I replay an agent run without re-executing real API calls?',
-    answer:
-      'Yes. gait run replay uses recorded results as deterministic stubs so you can debug safely. gait pack diff then shows exactly what changed between two runs, including context drift classification.',
+      'Run gait regress bootstrap --from <run_id> --junit output.xml. This converts the run into a permanent regression fixture. Exit 0 means pass, exit 5 means drift.',
   },
 ];
 
@@ -112,7 +121,7 @@ const softwareApplicationJsonLd = {
   applicationCategory: 'DeveloperApplication',
   operatingSystem: 'Linux, macOS, Windows',
   description:
-    'Offline-first runtime for production AI agents: durable jobs with checkpointed state, signed packs, voice agent gating, context evidence, deterministic regressions, and fail-closed policy gates at the tool boundary.',
+    'Offline-first policy-as-code runtime for AI agent tool calls: fail-closed tool-boundary policy, signed evidence, deterministic regressions, MCP trust preflight, durable jobs, and voice/context proof.',
   url: 'https://clyra-ai.github.io/gait/',
   softwareHelp: 'https://clyra-ai.github.io/gait/docs/',
   codeRepository: 'https://github.com/Clyra-AI/gait',
@@ -142,140 +151,147 @@ export default function HomePage() {
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(softwareApplicationJsonLd) }} />
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }} />
 
-      <div className="text-center py-12 lg:py-20">
-        <h1 className="text-4xl lg:text-6xl font-bold text-white mb-6">
-          Run Durable Agent Jobs.
-          <span className="bg-gradient-to-r from-cyan-400 to-blue-500 bg-clip-text text-transparent"> Prove What Happened.</span>
+      <div className="py-12 text-center lg:py-20">
+        <h1 className="mb-6 text-4xl font-bold text-white lg:text-6xl">
+          Policy-as-Code for Agent Tool Calls.
+          <span className="bg-gradient-to-r from-cyan-400 to-blue-500 bg-clip-text text-transparent"> Portable proof for every verdict.</span>
         </h1>
-        <p className="text-xl text-gray-400 max-w-3xl mx-auto mb-8">
-          Gait is an offline-first runtime that dispatches durable agent jobs, captures state-changing tool calls,
-          and emits signed packs you can verify, diff, and turn into deterministic CI regressions.
+        <p className="mx-auto mb-8 max-w-3xl text-xl text-gray-400">
+          Bootstrap repo policy with <code>gait init</code> and <code>gait check</code>, evaluate structured intent before real tool execution,
+          and turn incidents into deterministic CI regressions without a hosted control plane.
         </p>
-        <div className="flex flex-col sm:flex-row gap-4 justify-center">
-          <Link href="/docs/install" className="px-6 py-3 bg-cyan-500 hover:bg-cyan-400 text-gray-900 font-semibold rounded-lg transition-colors">
+        <div className="flex flex-col justify-center gap-4 sm:flex-row">
+          <Link href="/docs/install" className="rounded-lg bg-cyan-500 px-6 py-3 font-semibold text-gray-900 transition-colors hover:bg-cyan-400">
             Start Here
           </Link>
-          <Link href="/docs/integration_checklist" className="px-6 py-3 bg-gray-800 hover:bg-gray-700 text-gray-100 font-semibold rounded-lg border border-gray-700 transition-colors">
-            Integrate in 30-120 Minutes
+          <Link
+            href="/docs/integration_checklist"
+            className="rounded-lg border border-gray-700 bg-gray-800 px-6 py-3 font-semibold text-gray-100 transition-colors hover:bg-gray-700"
+          >
+            Integration Checklist
           </Link>
         </div>
       </div>
 
-      <div className="max-w-3xl mx-auto mb-16">
-        <h2 className="text-2xl font-bold text-white mb-4 text-center">Integrate Into Existing Agent Flows</h2>
-        <p className="text-sm text-gray-300 text-center mb-4">
-          Put Gait at the tool boundary: normalize intent, evaluate verdict, execute side effects only on <code>allow</code>, keep signed trace artifacts.
+      <div className="mx-auto mb-16 max-w-3xl">
+        <h2 className="mb-4 text-center text-2xl font-bold text-white">Put Gait at the Tool Boundary</h2>
+        <p className="mb-4 text-center text-sm text-gray-300">
+          Normalize intent, evaluate a verdict, execute side effects only on <code>allow</code>, and keep signed trace artifacts.
         </p>
-        <div className="grid md:grid-cols-3 gap-4 mb-5 text-sm">
+        <div className="mb-5 grid gap-4 text-sm md:grid-cols-3">
           <div className="rounded-lg border border-gray-700 bg-gray-900/40 p-4">
-            <h3 className="font-semibold text-white mb-2">Inline Wrapper</h3>
-            <p className="text-gray-300">
-              Call <code>gait gate eval</code> in your dispatcher before real tool execution.
-            </p>
+            <h3 className="mb-2 font-semibold text-white">Inline Wrapper</h3>
+            <p className="text-gray-300">Call <code>gait gate eval</code> in your dispatcher before real tool execution.</p>
           </div>
           <div className="rounded-lg border border-gray-700 bg-gray-900/40 p-4">
-            <h3 className="font-semibold text-white mb-2">MCP Sidecar</h3>
-            <p className="text-gray-300">
-              Use <code>gait mcp proxy</code> for one-shot calls or <code>gait mcp serve</code> for long-running boundaries.
-            </p>
+            <h3 className="mb-2 font-semibold text-white">LangChain Middleware</h3>
+            <p className="text-gray-300">Official middleware with optional callback correlation. Enforcement still happens in <code>wrap_tool_call</code>.</p>
           </div>
           <div className="rounded-lg border border-gray-700 bg-gray-900/40 p-4">
-            <h3 className="font-semibold text-white mb-2">Python SDK</h3>
-            <p className="text-gray-300">
-              Thin ergonomics layer over the local Go binary via subprocess. Prefer inline CLI or MCP path if you do not want subprocess boundaries.
-            </p>
+            <h3 className="mb-2 font-semibold text-white">MCP Boundary</h3>
+            <p className="text-gray-300">Preflight server trust with <code>gait mcp verify</code>, then use <code>gait mcp proxy</code> or <code>gait mcp serve</code>.</p>
           </div>
         </div>
-        <div className="bg-gray-900/60 rounded-lg border border-gray-700 p-4 overflow-x-auto mb-5">
-          <pre><code className="text-cyan-300 text-sm">{INTEGRATION_SNIPPET}</code></pre>
+        <div className="mb-5 overflow-x-auto rounded-lg border border-gray-700 bg-gray-900/60 p-4">
+          <pre>
+            <code className="text-sm text-cyan-300">{INTEGRATION_SNIPPET}</code>
+          </pre>
         </div>
-        <div className="bg-gray-800/50 rounded-lg border border-gray-700 p-4 overflow-x-auto">
-          <pre><code className="text-cyan-300 text-sm">{QUICKSTART}</code></pre>
+        <div className="mb-4 overflow-x-auto rounded-lg border border-gray-700 bg-gray-800/50 p-4">
+          <pre>
+            <code className="text-sm text-cyan-300">{QUICKSTART}</code>
+          </pre>
         </div>
-        <p className="text-xs text-gray-500 mt-3">
+        <div className="overflow-x-auto rounded-lg border border-gray-700 bg-gray-900/60 p-4">
+          <pre>
+            <code className="text-sm text-emerald-300">{POLICY_SHAPE}</code>
+          </pre>
+        </div>
+        <p className="mt-3 text-xs text-gray-500">
           Start with <Link href="/docs/integration_checklist" className="text-cyan-300 hover:text-cyan-200">integration checklist</Link>,{' '}
           <Link href="/docs/agent_integration_boundary" className="text-cyan-300 hover:text-cyan-200">boundary guide</Link>, and{' '}
-          <Link href="/docs/sdk/python" className="text-cyan-300 hover:text-cyan-200">Python SDK contract</Link>.
+          <Link href="/docs/sdk/python" className="text-cyan-300 hover:text-cyan-200">Python SDK contract</Link>. The example JSON shape above matches a real{' '}
+          <code>gait check --json</code> run.
         </p>
       </div>
 
-      <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6 mb-16">
+      <div className="mb-16 grid gap-6 md:grid-cols-2 lg:grid-cols-3">
         {features.map((feature) => (
           <Link
             key={feature.title}
             href={feature.href}
-            className="block p-6 bg-gray-800/30 hover:bg-gray-800/50 rounded-lg border border-gray-700 hover:border-gray-600 transition-colors"
+            className="block rounded-lg border border-gray-700 bg-gray-800/30 p-6 transition-colors hover:border-gray-600 hover:bg-gray-800/50"
           >
-            <h3 className="text-lg font-semibold text-white mb-2">{feature.title}</h3>
+            <h3 className="mb-2 text-lg font-semibold text-white">{feature.title}</h3>
             <p className="text-sm text-gray-400">{feature.description}</p>
           </Link>
         ))}
       </div>
 
       <div className="mb-16 overflow-x-auto">
-        <h2 className="text-2xl font-bold text-white mb-6 text-center">Why Teams Adopt Gait</h2>
+        <h2 className="mb-6 text-center text-2xl font-bold text-white">Why Teams Adopt Gait</h2>
         <table className="w-full text-sm">
           <thead>
             <tr className="border-b border-gray-700">
-              <th className="text-left py-3 px-4 text-gray-400"></th>
-              <th className="text-left py-3 px-4 text-gray-400">Without Gait</th>
-              <th className="text-left py-3 px-4 text-cyan-400">With Gait</th>
+              <th className="px-4 py-3 text-left text-gray-400"></th>
+              <th className="px-4 py-3 text-left text-gray-400">Without Gait</th>
+              <th className="px-4 py-3 text-left text-cyan-400">With Gait</th>
             </tr>
           </thead>
           <tbody className="divide-y divide-gray-800">
             <tr>
-              <td className="py-3 px-4 text-gray-300 font-medium">Long-running agent work</td>
-              <td className="py-3 px-4 text-gray-500">fails mid-flight, lost state</td>
-              <td className="py-3 px-4 text-gray-300">durable jobs with checkpoints + resume</td>
+              <td className="px-4 py-3 font-medium text-gray-300">Tool-call control</td>
+              <td className="px-4 py-3 text-gray-500">best-effort prompt checks</td>
+              <td className="px-4 py-3 text-gray-300">fail-closed structured verdicts at execution time</td>
             </tr>
             <tr>
-              <td className="py-3 px-4 text-gray-300 font-medium">Incident evidence</td>
-              <td className="py-3 px-4 text-gray-500">logs + screenshots</td>
-              <td className="py-3 px-4 text-gray-300">signed pack + ticket footer</td>
+              <td className="px-4 py-3 font-medium text-gray-300">Incident evidence</td>
+              <td className="px-4 py-3 text-gray-500">logs + screenshots</td>
+              <td className="px-4 py-3 text-gray-300">signed trace or pack + ticket footer</td>
             </tr>
             <tr>
-              <td className="py-3 px-4 text-gray-300 font-medium">Regression loop</td>
-              <td className="py-3 px-4 text-gray-500">manual repro, often skipped</td>
-              <td className="py-3 px-4 text-gray-300">deterministic fixture + CI gate</td>
+              <td className="px-4 py-3 font-medium text-gray-300">Regression loop</td>
+              <td className="px-4 py-3 text-gray-500">manual repro, often skipped</td>
+              <td className="px-4 py-3 text-gray-300">deterministic fixture + CI gate</td>
             </tr>
             <tr>
-              <td className="py-3 px-4 text-gray-300 font-medium">High-risk tool calls</td>
-              <td className="py-3 px-4 text-gray-500">best-effort guardrails</td>
-              <td className="py-3 px-4 text-gray-300">fail-closed policy + approvals</td>
+              <td className="px-4 py-3 font-medium text-gray-300">MCP trust</td>
+              <td className="px-4 py-3 text-gray-500">ad hoc server trust decisions</td>
+              <td className="px-4 py-3 text-gray-300">local snapshot preflight + policy enforcement</td>
             </tr>
             <tr>
-              <td className="py-3 px-4 text-gray-300 font-medium">Voice agent commitments</td>
-              <td className="py-3 px-4 text-gray-500">hope they say the right thing</td>
-              <td className="py-3 px-4 text-gray-300">gated before speech + signed callpack</td>
+              <td className="px-4 py-3 font-medium text-gray-300">Long-running agent work</td>
+              <td className="px-4 py-3 text-gray-500">fails mid-flight, lost state</td>
+              <td className="px-4 py-3 text-gray-300">durable jobs with checkpoints + resume</td>
             </tr>
             <tr>
-              <td className="py-3 px-4 text-gray-300 font-medium">Audit posture</td>
-              <td className="py-3 px-4 text-gray-500">incomplete reconstruction</td>
-              <td className="py-3 px-4 text-gray-300">offline verifiable signed artifacts</td>
+              <td className="px-4 py-3 font-medium text-gray-300">Voice commitments</td>
+              <td className="px-4 py-3 text-gray-500">hope they say the right thing</td>
+              <td className="px-4 py-3 text-gray-300">gated before speech + signed callpack</td>
             </tr>
           </tbody>
         </table>
       </div>
 
       <div className="mb-16">
-        <h2 className="text-2xl font-bold text-white mb-6 text-center">Frequently Asked Questions</h2>
-        <div className="grid md:grid-cols-2 gap-4">
+        <h2 className="mb-6 text-center text-2xl font-bold text-white">Frequently Asked Questions</h2>
+        <div className="grid gap-4 md:grid-cols-2">
           {faqs.map((entry) => (
             <div key={entry.question} className="rounded-lg border border-gray-700 bg-gray-900/40 p-5">
-              <h3 className="text-base font-semibold text-gray-100 mb-2">{entry.question}</h3>
+              <h3 className="mb-2 text-base font-semibold text-gray-100">{entry.question}</h3>
               <p className="text-sm text-gray-300">{entry.answer}</p>
             </div>
           ))}
         </div>
       </div>
 
-      <div className="text-center py-12 border-t border-gray-800">
-        <h2 className="text-2xl font-bold text-white mb-4">First pack in 60 seconds. Durable jobs, voice gating, and policy enforcement included.</h2>
-        <p className="text-gray-400 mb-6">Install, create a signed artifact, and turn it into a permanent CI gate — all offline.</p>
-        <Link href="/docs/install" className="inline-block px-6 py-3 bg-cyan-500 hover:bg-cyan-400 text-gray-900 font-semibold rounded-lg transition-colors">
+      <div className="border-t border-gray-800 py-12 text-center">
+        <h2 className="mb-4 text-2xl font-bold text-white">Start with policy bootstrap. Add evidence, CI, MCP trust, and jobs as needed.</h2>
+        <p className="mb-6 text-gray-400">The first five commands are real: init, check, demo, verify, regress bootstrap.</p>
+        <Link href="/docs/install" className="inline-block rounded-lg bg-cyan-500 px-6 py-3 font-semibold text-gray-900 transition-colors hover:bg-cyan-400">
           Open Install Guide
         </Link>
-        <p className="text-sm text-gray-500 mt-5">
+        <p className="mt-5 text-sm text-gray-500">
           For assistant and crawler discovery resources, use{' '}
           <Link href="/llms" className="text-cyan-300 hover:text-cyan-200">
             LLM Context

--- a/docs-site/src/lib/navigation.ts
+++ b/docs-site/src/lib/navigation.ts
@@ -10,40 +10,15 @@ export const navigation: NavItem[] = [
     href: '/docs',
     children: [
       { title: 'Install', href: '/docs/install' },
+      { title: 'Policy Authoring', href: '/docs/policy_authoring' },
+      { title: 'Integration Checklist', href: '/docs/integration_checklist' },
       { title: 'Adopt In One PR', href: '/docs/adopt_in_one_pr' },
       { title: 'Mental Model', href: '/docs/concepts/mental_model' },
+      { title: 'Simple Scenario', href: '/docs/scenarios/simple_agent_tool_boundary' },
       { title: 'Architecture', href: '/docs/architecture' },
       { title: 'Flows', href: '/docs/flows' },
-      { title: 'Simple Scenario', href: '/docs/scenarios/simple_agent_tool_boundary' },
       { title: 'Demo Output Legend', href: '/docs/demo_output_legend' },
       { title: 'Local UI Playground', href: '/docs/ui_localhost' },
-    ],
-  },
-  {
-    title: 'Durable Jobs & Packs',
-    href: '/docs/durable_jobs',
-    children: [
-      { title: 'Durable Jobs', href: '/docs/durable_jobs' },
-      { title: 'PackSpec v1', href: '/docs/contracts/packspec_v1' },
-      { title: 'PackSpec TCK', href: '/docs/contracts/packspec_tck' },
-      { title: 'Pack Producer Kit', href: '/docs/contracts/pack_producer_kit' },
-      { title: 'Compatibility Matrix', href: '/docs/contracts/compatibility_matrix' },
-      { title: 'Artifact Graph', href: '/docs/contracts/artifact_graph' },
-      { title: 'Skill Provenance', href: '/docs/contracts/skill_provenance' },
-    ],
-  },
-  {
-    title: 'Voice Mode',
-    href: '/docs/voice_mode',
-    children: [
-      { title: 'Voice Mode Guide', href: '/docs/voice_mode' },
-    ],
-  },
-  {
-    title: 'Context Evidence',
-    href: '/docs/contracts/contextspec_v1',
-    children: [
-      { title: 'ContextSpec v1', href: '/docs/contracts/contextspec_v1' },
     ],
   },
   {
@@ -68,6 +43,29 @@ export const navigation: NavItem[] = [
       { title: 'Cloud Runtime Patterns', href: '/docs/deployment/cloud_runtime_patterns' },
       { title: 'CI Regress Kit', href: '/docs/ci_regress_kit' },
     ],
+  },
+  {
+    title: 'Evidence, Jobs & Replay',
+    href: '/docs/durable_jobs',
+    children: [
+      { title: 'Durable Jobs', href: '/docs/durable_jobs' },
+      { title: 'PackSpec v1', href: '/docs/contracts/packspec_v1' },
+      { title: 'PackSpec TCK', href: '/docs/contracts/packspec_tck' },
+      { title: 'Pack Producer Kit', href: '/docs/contracts/pack_producer_kit' },
+      { title: 'Compatibility Matrix', href: '/docs/contracts/compatibility_matrix' },
+      { title: 'Artifact Graph', href: '/docs/contracts/artifact_graph' },
+      { title: 'Skill Provenance', href: '/docs/contracts/skill_provenance' },
+    ],
+  },
+  {
+    title: 'Voice Mode',
+    href: '/docs/voice_mode',
+    children: [{ title: 'Voice Mode Guide', href: '/docs/voice_mode' }],
+  },
+  {
+    title: 'Context Evidence',
+    href: '/docs/contracts/contextspec_v1',
+    children: [{ title: 'ContextSpec v1', href: '/docs/contracts/contextspec_v1' }],
   },
   {
     title: 'Hardening',
@@ -95,9 +93,7 @@ export const navigation: NavItem[] = [
   {
     title: 'Blog',
     href: '/docs/blog/openclaw_24h_boundary_enforcement',
-    children: [
-      { title: '2,880 Tool Calls Gate-Checked', href: '/docs/blog/openclaw_24h_boundary_enforcement' },
-    ],
+    children: [{ title: '2,880 Tool Calls Gate-Checked', href: '/docs/blog/openclaw_24h_boundary_enforcement' }],
   },
   {
     title: 'Ecosystem',

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,14 +19,17 @@ Extended first-class surfaces:
 
 ## Start Here
 
-1. `README.md` for product overview and first win
-2. `docs/concepts/mental_model.md` for terminology and execution model
-3. `docs/architecture.md` for component boundaries
-4. `docs/flows.md` for end-to-end runtime and ops sequences
-5. `docs/contracts/primitive_contract.md` for normative behavior
+1. `README.md` for the product wedge and first five commands
+2. `docs/policy_authoring.md` for `.gait.yaml`, validation, and rollout workflow
+3. `docs/integration_checklist.md` for shipped wrapper, MCP, and SDK lanes
+4. `docs/agent_integration_boundary.md` for tool-boundary placement rules
+5. `docs/ci_regress_kit.md` for incident-to-CI adoption
 
 ## Core Product Docs
 
+- Policy bootstrap and authoring: `docs/policy_authoring.md`
+- Integration checklist: `docs/integration_checklist.md`
+- Integration boundary: `docs/agent_integration_boundary.md`
 - Architecture: `docs/architecture.md`
 - Runtime flows: `docs/flows.md`
 - Durable jobs lifecycle: `docs/durable_jobs.md`
@@ -90,12 +93,12 @@ Extended first-class surfaces:
 - Marketplace action publishing path: `docs/marketplace_action_publishing.md`
 - Canonical MCP boundary demo: `docs/scenarios/mcp_canonical_boundary.md`
 - Content cadence plan (v2.6): `docs/launch/content_cadence_v2_6.md`
-- Hero demo asset review (v2.6): `docs/launch/hero_demo_asset_review_v2_6.md`
+- Hero GIF/script alignment decision log (v2.6): `docs/launch/hero_demo_asset_review_v2_6.md`
 
 ## Ownership Rules
 
 - `docs/contracts/*` are normative. If any other doc conflicts, contracts win.
-- `README.md` is onboarding and positioning, not a full runbook dump.
+- `README.md` is the truthful onboarding surface for `gait init`, `gait check`, `gait demo`, and the first CI regression path.
 - Ops procedures belong in runbooks (`approval_runbook`, `policy_rollout`, `ci_regress_kit`, hardening docs).
 - Wiki (`docs/wiki/*`) is a convenience layer; `docs/*` remains authoritative.
 

--- a/docs/adopt_in_one_pr.md
+++ b/docs/adopt_in_one_pr.md
@@ -13,6 +13,8 @@ It does three things in one workflow:
 2. verifies artifact integrity
 3. fails the PR on a forced deterministic regression (`exit 5`)
 
+For GitLab, Jenkins, and CircleCI variants using the same contract, see `examples/ci/portability/README.md`.
+
 Copy this file into `.github/workflows/gait-adopt-one-pr.yml`:
 
 ```yaml
@@ -149,3 +151,9 @@ Expected PR behavior:
   - `junit.xml`
 
 If you want a passing lane after validating setup, remove the forced-drift step.
+
+Local hook reminder:
+
+- `pre-commit install`
+- `pre-commit run --all-files`
+- pre-push runs `make prepush` from `.pre-commit-config.yaml`

--- a/docs/agent_integration_boundary.md
+++ b/docs/agent_integration_boundary.md
@@ -82,7 +82,7 @@ What Gait cannot do (without interception):
 
 - Tier A quickstart: `examples/integrations/openai_agents/quickstart.py`
 - Tier A/B transport path: `gait mcp serve`
-- Tier C fallback: `gait report top`, `gait regress init`, `gait regress run`
+- Tier C fallback: `gait report top`, `gait capture`, `gait regress add`, `gait regress run` (or `gait regress bootstrap` for the one-command path)
 
 ## Related Docs
 

--- a/docs/ci_regress_kit.md
+++ b/docs/ci_regress_kit.md
@@ -54,7 +54,8 @@ Deterministic artifact root:
 - `gait-out/adoption_regress/`
   - `regress_result.json`
   - `junit.xml`
-  - `regress_init_result.json` (only when fallback init runs)
+  - `capture.json` and `regress_add_result.json` (when using the explicit handoff path)
+  - `regress_init_result.json` (only when legacy fallback init runs)
   - `pack_verify_fixture.json` (fixture integrity evidence)
 
 ## Composite Action Contract
@@ -105,6 +106,40 @@ The portability templates are wrappers around this script and must preserve:
 - identical regress exit handling (`0`, `5`, passthrough)
 - identical artifact root (`gait-out/adoption_regress/`)
 - identical fixture fallback behavior (`run_demo` init path)
+
+## Explicit Capture vs One-Command Bootstrap
+
+Use one of these two truthful paths:
+
+1. Explicit handoff artifact:
+   - `gait capture --from <run_id> --json`
+   - `gait regress add --from ./gait-out/capture.json --json`
+   - `gait regress run --json --junit <path>`
+2. One-command bootstrap:
+   - `gait regress bootstrap --from <run_id> --json --junit <path>`
+
+Both paths preserve the same stable exit and artifact contract.
+
+## Pre-Commit and Pre-Push Hooks
+
+The repo-local hook contract lives in `.pre-commit-config.yaml`.
+
+Use:
+
+```bash
+pre-commit install
+pre-commit run --all-files
+```
+
+Current hook coverage includes:
+
+- standard hygiene checks
+- Go formatting and module tidy
+- `golangci-lint`
+- Ruff and Ruff format for Python
+- `site-stack-lint` on docs-site and `ui/local/`
+- pre-push `site-stack-build`
+- pre-push `make prepush`
 
 ## Downstream Reuse Example
 

--- a/docs/external_tool_registry_policy.md
+++ b/docs/external_tool_registry_policy.md
@@ -19,6 +19,19 @@ Use this when an external source such as Snyk or an internal registry produces t
 3. Preflight with `gait mcp verify`.
 4. Enforce the same trust policy through `gait mcp proxy` or `gait mcp serve`.
 
+Example policy contract:
+
+```yaml
+mcp_trust:
+  enabled: true
+  snapshot: ./examples/integrations/mcp_trust/trust_snapshot.json
+  action: block
+  required_risk_classes: [high, critical]
+  min_score: 0.8
+  max_age: 168h
+  require_registry: true
+```
+
 ```bash
 python3 scripts/render_mcp_trust_snapshot.py \
   --input examples/integrations/mcp_trust/snyk_mcp_report.json \

--- a/docs/integration_checklist.md
+++ b/docs/integration_checklist.md
@@ -1,6 +1,6 @@
 ---
 title: "Integration Checklist"
-description: "Step-by-step checklist for integrating Gait with agent frameworks including OpenAI Agents, LangChain, and AutoGen."
+description: "Step-by-step checklist for integrating Gait at the tool boundary with the shipped OpenAI Agents lane, official LangChain middleware, and reference adapters."
 ---
 
 # Gait Integration Checklist
@@ -31,6 +31,7 @@ Blessed default lane:
 Expansion policy:
 
 - no new official lane is added unless scorecard threshold is met
+- do not name additional frameworks publicly (for example CrewAI) until the scorecard threshold is met and an in-repo lane exists
 - scorecard command:
 
 ```bash
@@ -83,22 +84,26 @@ Run these first. Stop if expected output is missing.
 5. Wrapper non-allow path:
 - run wrapper block or approval scenario
 - expect `executed=false`
-6. Regress fixture init:
-- `gait regress init --from run_demo --json`
-- expect fixture created
+6. Explicit capture path:
+- `gait capture --from run_demo --json`
+- `gait regress add --from ./gait-out/capture.json --json`
+- expect deterministic fixture created
 7. Regress gate run:
 - `gait regress run --json --junit ./gait-out/junit.xml`
 - expect `status=pass` and exit `0`
-8. CI parity:
+8. One-command shortcut:
+- `gait regress bootstrap --from run_demo --json --junit ./gait-out/junit.xml`
+- expect the same stable regress contract without a separate capture handoff
+9. CI parity:
 - wire `.github/workflows/adoption-regress-template.yml`
 - confirm local/CI fixture parity
-9. Activation timing report:
+10. Activation timing report:
 - run `gait doctor adoption --from ./gait-out/adoption.jsonl --json`
 - confirm `activation_timing_ms` and `activation_medians_ms` present
-10. Observe->enforce rollout baseline:
+11. Observe->enforce rollout baseline:
 - observe: `gait gate eval ... --simulate --json`
 - enforce: `gait gate eval ... --json`
-11. Approved script registry path (if script automation is used):
+12. Approved script registry path (if script automation is used):
 - mint entry: `gait approve-script --policy <policy.yaml> --intent <script_intent.json> --registry <registry.json> --approver <id> --key-mode prod --private-key <path> --json`
 - inspect entry: `gait list-scripts --registry <registry.json> --json`
 - enforce with registry: `gait gate eval ... --approved-script-registry <registry.json> --approved-script-public-key <path> --json`
@@ -173,14 +178,19 @@ Contract docs:
 
 ### Adapter Parity / Secondary Lanes
 
-Supported references:
+Official lanes:
 
+- `examples/integrations/openai_agents/`
 - `examples/integrations/langchain/` (official middleware with optional callback correlation)
+
+Reference adapters:
+
 - `examples/integrations/autogen/`
 - `examples/integrations/openclaw/`
 - `examples/integrations/autogpt/`
 - `examples/integrations/gastown/`
 - `examples/integrations/voice_reference/`
+- `examples/integrations/claude_code/`
 - sidecar path: `examples/sidecar/gate_sidecar.py`
 - MCP proxy/serve: `gait mcp proxy`, `gait mcp serve`
 
@@ -251,7 +261,7 @@ Default path (GitHub Actions):
 
 Required parity:
 
-- same fixture source (`fixtures/run_demo/runpack.zip` + `gait.yaml` or `gait regress init` fallback)
+- same fixture source (`fixtures/run_demo/runpack.zip` + `gait.yaml` or the explicit `gait capture` + `gait regress add` path)
 - same stable exit handling (`0` pass, `5` deterministic failure)
 - same retained artifacts (`regress_result.json`, `junit.xml`, fixture files)
 
@@ -273,7 +283,7 @@ First deterministic wrapper integration targets 15 minutes. Full production roll
 
 ### Does Gait work with LangChain?
 
-Yes. See `examples/integrations/langchain/` for a maintained adapter that wraps tool calls through gate evaluation.
+Yes. See `examples/integrations/langchain/` for the official middleware lane. The correct wording is middleware with optional callback correlation; callbacks do not decide allow or block outcomes.
 
 ### What if I cannot intercept tool calls?
 
@@ -281,7 +291,7 @@ If your agent runtime is fully hosted with no interception point, Gait can still
 
 ### Which integration path should I start with?
 
-The blessed lane is OpenAI Agents (`examples/integrations/openai_agents/`). All adapters follow the same wrapper pattern and emit the same artifacts.
+The blessed lane is OpenAI Agents (`examples/integrations/openai_agents/`). LangChain is the official middleware lane. Other adapters are reference parity lanes on the same contract.
 
 ### Do I need to modify my agent code?
 

--- a/docs/launch/README.md
+++ b/docs/launch/README.md
@@ -10,6 +10,7 @@ Current safe-default rollout note:
 - ship `baseline-highrisk` destructive budget defaults for fail-closed bursts
 - stage rollout: monitor -> approval -> enforce
 - when citing MCP trust, show local snapshot + `gait mcp verify`, not a hosted scanner replacement story
+- keep category language fixed: policy-as-code for agent tool calls, not control plane, dashboard, or framework replacement
 
 ## Contents
 
@@ -53,6 +54,7 @@ Generated artifacts:
 
 1. run `scripts/demo_90s.sh`
 2. run `scripts/test_v2_3_acceptance.sh ./gait` and confirm `release_gate_passed=true`
+3. confirm first-run copy still matches `gait init`, `gait check`, `gait demo`, `gait verify`, and `gait regress bootstrap`
 3. generate ecosystem release notes:
 
 ```bash

--- a/docs/launch/faq_objections.md
+++ b/docs/launch/faq_objections.md
@@ -5,6 +5,8 @@
 Framework-native controls help, but most production stacks are multi-framework and multi-model.
 Gait keeps one execution-boundary and artifact contract across all of them.
 
+It is also not a framework replacement. The framework keeps planning and orchestration; Gait owns the execution verdict and evidence contract.
+
 ## "Is this another prompt-injection scanner?"
 
 No. Gait enforces policy at tool-call execution boundary.

--- a/docs/launch/github_release_template.md
+++ b/docs/launch/github_release_template.md
@@ -8,7 +8,7 @@ Use this structure for tagged releases.
 
 ## Header
 
-Gait is the offline-first Agent Control Plane for production tool actions.
+Gait is the offline-first policy-as-code runtime for AI agent tool calls.
 
 ## What Shipped
 
@@ -21,11 +21,11 @@ Gait is the offline-first Agent Control Plane for production tool actions.
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/Clyra-AI/gait/main/scripts/install.sh | bash
-gait doctor --json
+gait init --json
+gait check --json
 gait demo
-gait verify run_demo
-gait regress init --from run_demo --json
-gait regress run --json --junit ./gait-out/junit.xml
+gait verify run_demo --json
+gait regress bootstrap --from run_demo --json --junit ./gait-out/junit.xml
 ```
 
 ## Security Boundary Example

--- a/docs/launch/hn_post.md
+++ b/docs/launch/hn_post.md
@@ -4,30 +4,30 @@ Use this as a baseline for launch threads. Keep it factual and concrete.
 
 ## Candidate Titles
 
-- Show HN: Gait - offline-first control plane for production agent tool calls
+- Show HN: Gait - policy-as-code for production agent tool calls
 - Show HN: Gait - deterministic incident-to-regress workflow for AI agents
 - Launch HN: Gait - policy enforcement + verifiable receipts for agent actions
 
 ## Post Body Template
 
 ```
-We are launching Gait, an offline-first CLI that makes production AI agent actions controllable and debuggable by default.
+We are launching Gait, an offline-first CLI for policy-as-code at AI agent tool boundaries.
 
 Core loop:
-- capture a run artifact (`runpack_<run_id>.zip`)
-- verify/replay/diff deterministically
-- enforce policy at tool-call boundary (`gate`)
-- turn incidents into deterministic CI regressions (`regress`)
+- bootstrap repo policy (`gait init`, `gait check`)
+- enforce policy at tool-call boundary (`gait gate eval`)
+- capture signed evidence
+- turn incidents into deterministic CI regressions
 
 It is intentionally artifact-first and vendor-neutral.
 No hosted service required for core workflows.
 
 Quick first win:
-1) gait doctor --json
-2) gait demo
-3) gait verify run_demo
-4) gait regress init --from run_demo --json
-5) gait regress run --json
+1) gait init --json
+2) gait check --json
+3) gait demo
+4) gait verify run_demo --json
+5) gait regress bootstrap --from run_demo --json --junit ./gait-out/junit.xml
 
 Repo: https://github.com/Clyra-AI/gait
 ```
@@ -45,7 +45,8 @@ Expected:
 
 And here is the incident-to-regress path:
 
-gait regress init --from run_demo --json
+gait capture --from run_demo --json
+gait regress add --from ./gait-out/capture.json --json
 gait regress run --json --junit ./gait-out/junit.xml
 ```
 

--- a/docs/launch/narrative_one_liner.md
+++ b/docs/launch/narrative_one_liner.md
@@ -4,11 +4,11 @@ Use one primary line and one supporting line. Do not switch category language mi
 
 ## Core Category Line
 
-Gait is the offline-first policy-as-code runtime for production tool actions.
+Gait is the offline-first policy-as-code runtime for AI agent tool calls.
 
 ## Product Promise Line
 
-Bootstrap with `gait init` and `gait check`, enforce at the tool boundary, and turn incidents into deterministic CI regressions.
+Bootstrap `.gait.yaml` with `gait init` and `gait check`, enforce at the tool boundary, and turn incidents into deterministic CI regressions.
 
 ## Audience Variants
 
@@ -22,7 +22,7 @@ Security:
 
 Developer:
 
-- `gait demo` to deterministic regressions in minutes, with no hosted dependency.
+- `gait init` and `gait check` to a real tool-boundary regression path in minutes, with no hosted dependency.
 
 Compliance:
 

--- a/docs/mcp_capability_matrix.md
+++ b/docs/mcp_capability_matrix.md
@@ -47,7 +47,7 @@ if verdict != allow: do not execute side effects
 
 MCP modes do not replace operator/CI workflows such as:
 
-- `gait regress init` / `gait regress run`
+- `gait capture` / `gait regress add` / `gait regress run`
 - `gait doctor`
 - `gait pack inspect` / `gait pack diff`
 - release and CI contract gates

--- a/docs/policy_authoring.md
+++ b/docs/policy_authoring.md
@@ -34,6 +34,80 @@ Interpretation:
 - `policy test` evaluates one intent fixture and returns verdict, reason codes, and `matched_rule`.
 - `policy simulate` compares baseline vs candidate verdicts over fixture corpora and recommends rollout stage (`observe`, `require_approval`, `enforce`).
 
+## Repo-Root Policy Contract
+
+The default onboarding contract is the repo-root file `.gait.yaml`.
+
+`gait init --json` writes that file and returns:
+
+- `policy_path`
+- `template`
+- `next_commands`
+
+`gait check --json` reads `.gait.yaml` and reports the live contract, including:
+
+- `default_verdict`
+- `rule_count`
+- `gap_warnings`
+
+Use `gait policy init --out gait.policy.yaml --json` only when you intentionally want a non-default path.
+
+## Common Top-Level Fields
+
+The schema for `.gait.yaml` is `schemas/v1/gate/policy.schema.json`.
+
+Most policies start with these fields:
+
+- `schema_id`: must be `gait.gate.policy`
+- `schema_version`: currently `1.0.0`
+- `default_verdict`: one of `allow`, `block`, `dry_run`, `require_approval`
+- `fail_closed`: optional high-risk missing-data rules
+- `mcp_trust`: optional local trust-snapshot contract for MCP server admission
+- `rules`: ordered rule list
+
+Example:
+
+```yaml
+schema_id: gait.gate.policy
+schema_version: 1.0.0
+default_verdict: block
+fail_closed:
+  enabled: true
+  risk_classes: [critical]
+  required_fields: [targets, arg_provenance]
+mcp_trust:
+  enabled: true
+  snapshot: ./examples/integrations/mcp_trust/trust_snapshot.json
+  action: block
+  required_risk_classes: [high, critical]
+  min_score: 0.8
+rules:
+  - name: require-approval-tool-write
+    priority: 20
+    effect: require_approval
+    min_approvals: 2
+    match:
+      tool_names: [tool.write]
+    reason_codes: [approval_required_for_write]
+```
+
+## Common Rule Fields
+
+Rules usually combine:
+
+- `name`, `priority`, and `effect`
+- `match.tool_name` or `match.tool_names`
+- `match.risk_classes`, `match.target_kinds`, `match.identities`, or other structured selectors
+- `reason_codes` and optional `violations`
+
+Additional rule features are available when needed:
+
+- `endpoint` for path/domain and destructive endpoint controls
+- `destructive_budget` and `rate_limit` for bounded execution
+- `require_context_evidence` for context-proof gating
+- `require_broker_credential` for broker-backed approval flows
+- script-specific controls via `approved-script-registry` on `gait gate eval`
+
 ## Failure Semantics
 
 - exit `0`: valid / allow path
@@ -71,6 +145,7 @@ This gives fast feedback for enum values and unknown keys before runtime.
 - Run `policy simulate` against representative fixture sets before changing rollout stage.
 - Keep policy files formatted by `policy fmt --write` before review.
 - Review policy changes with fixture deltas and matched-rule evidence, not raw YAML diff alone.
+- Keep the repo-default contract truthful: if docs say `.gait.yaml`, examples should use `.gait.yaml` unless a custom path is the point of the example.
 
 ## Signing Key Lifecycle (Local)
 

--- a/docs/positioning.md
+++ b/docs/positioning.md
@@ -4,24 +4,25 @@ Use this file when writing website copy, docs, release notes, talks, or sales ma
 
 ## Core Message
 
-Gait is an artifact-first policy-as-code runtime for production tool execution.
+Gait is the offline-first policy-as-code runtime for production AI agent tool calls.
 
 Runtime governance is often observational; Gait is execution-time decision and proof.
 
 It combines:
 
 - execution-boundary policy enforcement (`gate`)
-- verifiable run artifacts (`runpack`)
+- verifiable traces and run artifacts (`trace`, `runpack`, `pack`)
 - deterministic incident-to-regression workflows (`regress`)
 
 ## What To Claim
 
-- Deterministic verification/diff/stub replay for the same artifacts.
+- Deterministic verification, diff, and stub replay for the same artifacts.
 - Offline-first core workflows.
 - Default-safe evidence model (reference receipts by default).
 - Stable artifact schemas and exit codes as integration contracts.
 - Vendor-neutral adapter model across agent frameworks.
 - Truthful onboarding surface: `gait init`, `gait check`, `gait capture`, and `gait regress add` are thin wrappers over shipped Go authority, not alternate policy engines.
+- Official LangChain wording: "middleware with optional callback correlation."
 
 ## What Not To Claim
 
@@ -29,12 +30,14 @@ It combines:
 - Prompt-layer filtering as a complete control model.
 - Hosted governance dashboard capabilities in OSS core.
 - Real-time fleet control plane features that are not shipped in OSS v1.
+- Unscored framework support claims (for example CrewAI) without an in-repo lane and scorecard evidence.
 
 ## Product Boundary Language
 
 Prefer:
 
 - "execution boundary"
+- "policy-as-code for agent tool calls"
 - "verifiable receipts"
 - "deterministic regressions"
 - "incident to regression in one path"

--- a/docs/scenarios/simple_agent_tool_boundary.md
+++ b/docs/scenarios/simple_agent_tool_boundary.md
@@ -77,7 +77,8 @@ Expected:
 ## Step 3: Convert Incident/Evidence to Regression
 
 ```bash
-gait regress init --from run_demo --json
+gait capture --from run_demo --json
+gait regress add --from ./gait-out/capture.json --json
 gait regress run --json --junit ./gait-out/junit.xml
 ```
 
@@ -85,6 +86,7 @@ Expected:
 
 - deterministic `status=pass` on known-good fixture
 - CI-ready `junit.xml`
+- same result is available via `gait regress bootstrap --from run_demo --json --junit ./gait-out/junit.xml`
 
 ## Optional: One-Shot Policy Check From Fixture Intent
 

--- a/docs/sdk/python.md
+++ b/docs/sdk/python.md
@@ -121,6 +121,19 @@ The official surface is `GaitLangChainMiddleware`, and enforcement only happens 
 - callback handlers never decide allow or block behavior
 - the official example lane is `examples/integrations/langchain/quickstart.py`
 
+Minimal snippet:
+
+```python
+from gait.langchain import GaitLangChainMiddleware, GaitLangChainCallbackHandler
+
+middleware = [
+    GaitLangChainMiddleware(
+        policy_path="examples/integrations/langchain/policy_allow.yaml",
+        callback_handler=GaitLangChainCallbackHandler(),
+    )
+]
+```
+
 ### What happens if the Gait binary is not found?
 
 The SDK raises a clear error with install instructions and PATH guidance instead of an opaque FileNotFoundError.

--- a/docs/sdk/python.md
+++ b/docs/sdk/python.md
@@ -124,11 +124,14 @@ The official surface is `GaitLangChainMiddleware`, and enforcement only happens 
 Minimal snippet:
 
 ```python
+from gait import ToolAdapter
 from gait.langchain import GaitLangChainMiddleware, GaitLangChainCallbackHandler
+
+adapter = ToolAdapter(policy_path="examples/integrations/langchain/policy_allow.yaml")
 
 middleware = [
     GaitLangChainMiddleware(
-        policy_path="examples/integrations/langchain/policy_allow.yaml",
+        adapter=adapter,
         callback_handler=GaitLangChainCallbackHandler(),
     )
 ]

--- a/docs/wiki/Integration-Cookbook.md
+++ b/docs/wiki/Integration-Cookbook.md
@@ -11,8 +11,8 @@ Use one boundary pattern only: wrapper or sidecar. Execute tools only on `allow`
 
 ## Framework Recipes
 
-- OpenAI Agents: `examples/integrations/openai_agents/`
-- LangChain: `examples/integrations/langchain/`
+- OpenAI Agents (blessed lane): `examples/integrations/openai_agents/`
+- LangChain (official middleware with optional callback correlation): `examples/integrations/langchain/`
 - AutoGen: `examples/integrations/autogen/`
 - OpenClaw: `examples/integrations/openclaw/`
 - AutoGPT: `examples/integrations/autogpt/`

--- a/docs/wiki/Operator-FAQ.md
+++ b/docs/wiki/Operator-FAQ.md
@@ -7,7 +7,7 @@ Gate evaluates intent, policy, approvals, and provenance before side effects exe
 
 ## Is Gait offline-first?
 
-Yes for core workflows. Recording, verifying, diffing, replay, policy test, and regression run locally.
+Yes for core workflows. Policy bootstrap, recording, verifying, diffing, replay, policy test, and regression run locally.
 
 ## Is fail-open supported?
 
@@ -20,6 +20,7 @@ Use traces, runpacks, verification output, and ticket footer artifacts. These ar
 ## How do we prevent framework lock-in?
 
 Use one contract across adapters. No framework receives privileged bypass behavior.
+Gait is not a framework replacement; it owns the execution verdict and evidence contract while the framework keeps orchestration.
 
 ## How do we keep reports deterministic?
 

--- a/examples/ci/portability/README.md
+++ b/examples/ci/portability/README.md
@@ -1,5 +1,7 @@
 # CI Portability Templates
 
+GitHub Actions is the primary lane through `.github/workflows/adoption-regress-template.yml`.
+
 These templates wrap the same CI contract script:
 
 - `scripts/ci_regress_contract.sh`
@@ -15,3 +17,4 @@ All templates preserve:
 - stable regress exit handling (`0`, `5`, passthrough)
 - deterministic artifacts under `gait-out/adoption_regress/`
 - deterministic fixture fallback init from `run_demo`
+- parity with the explicit `gait capture` + `gait regress add` handoff flow

--- a/examples/integrations/README.md
+++ b/examples/integrations/README.md
@@ -2,10 +2,13 @@
 
 This directory contains framework adapters that demonstrate the same Gait execution contract across runtimes.
 
-Current adapters:
+Official lanes:
 
 - `openai_agents`
 - `langchain` (official middleware with optional callback correlation)
+
+Reference adapters:
+
 - `autogen`
 - `openclaw`
 - `autogpt`
@@ -13,6 +16,8 @@ Current adapters:
 - `claude_code`
 - `voice_reference`
 - `template` (canonical copy/paste template)
+
+Do not promote an adapter into public launch copy until it has an in-repo lane and clears the integration scorecard threshold.
 
 ## Contract (Must Stay Identical)
 


### PR DESCRIPTION
## Problem
Epic W5 in `product/PLAN_NEXT.md` still had launch, docs-site, LLM, wiki, and contributor surfaces drifting from the shipped policy-as-code wedge and the current onboarding command path.

## Changes
- rewrote the README, docs-site home, navigation, and LLM summaries around the shipped `gait init` / `gait check` / `gait demo` / `gait regress bootstrap` flow
- expanded policy, integration, CI portability, MCP trust, and SDK docs to describe the real contract and official LangChain middleware wording
- synced launch, wiki, AGENTS, and relevant skills to the same public category language and capture/add/bootstrap guidance
- added governance wording so unsupported framework claims such as CrewAI stay out of public copy until a real lane and scorecard evidence exist

## Validation
- `./gait doctor --json`
- `make test-docs-consistency`
- `make test-docs-storyline`
- `cd docs-site && npm run build`
- `make docs-site-check`
- `bash scripts/test_ci_regress_template.sh`
- `bash scripts/test_ci_portability_templates.sh`
- `python3 scripts/validate_repo_skills.py`
- `make test-contracts`
- `make test-adoption`
- `make test-adapter-parity`
- `make prepush-full`
