### PR TITLE
feat: enforce context evidence boundary

### DIFF
--- a/.agents/skills/commit-push/SKILL.md
+++ b/.agents/skills/commit-push/SKILL.md
@@ -77,7 +77,7 @@ If preconditions fail, stop and report.
 - once `eyes` is observed, assume a terminal Codex signal should follow soon and continue polling every `30s` for up to `15 minutes` before declaring the gate blocked
 - once `eyes` is observed, wait for a terminal Codex signal (`actionable`, `approved`, `thumbs_up`, explicit service/quota failure, or a new actionable comment/review on the latest head) before deciding the gate result
 - Use a two-stage gate:
-- Stage A: for the first `5 minutes`, look for latest-head Codex terminal signals or an `eyes` in-progress signal
+- Stage A: for the first `15 minutes`, look for latest-head Codex terminal signals or an `eyes` in-progress signal
 - Stage B: if `eyes` was observed during Stage A or later, continue polling every `30s` for up to `15 minutes` from the first observed `eyes` on the current review cycle
 - If no terminal Codex signal appears within that `15 minute` Stage B window, stop and report a blocked Codex review gate
 - If no latest-head terminal signal appears and no `eyes` in-progress signal is seen during Stage A, fall back to PR-wide Codex review inventory:
@@ -183,7 +183,7 @@ Never use inline `--body "..."` for multi-line PR text.
 - Required local gate before push: `make prepush-full` (includes CodeQL in this repo).
 - PR CI watch timeout: `25 minutes`.
 - Codex review settle polling interval: `15 seconds`.
-- Codex review settle initial window: `5 minutes` to find latest-head terminal signals or an `eyes` in-progress signal.
+- Codex review settle initial window: `15 minutes` to find latest-head terminal signals or an `eyes` in-progress signal.
 - Codex review settle after `eyes`: poll every `30 seconds` for up to `15 minutes` before blocking if no terminal signal appears.
 - Pre-merge comment-fix loop cap: `2`.
 - Post-merge main CI watch timeout: `25 minutes`.

--- a/cmd/gait/approved_script_test.go
+++ b/cmd/gait/approved_script_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Clyra-AI/gait/core/contextproof"
+	schemacontext "github.com/Clyra-AI/gait/core/schema/v1/context"
 	schemagate "github.com/Clyra-AI/gait/core/schema/v1/gate"
 )
 
@@ -121,6 +123,108 @@ rules:
 	}
 	if evalOut.Verdict != "allow" || !evalOut.PreApproved || evalOut.PatternID == "" {
 		t.Fatalf("expected pre-approved allow output, got %#v", evalOut)
+	}
+}
+
+func TestGateEvalApprovedScriptFastPathDisabledForContextPolicies(t *testing.T) {
+	workDir := t.TempDir()
+	withWorkingDir(t, workDir)
+
+	policyPath := filepath.Join(workDir, "policy_context.yaml")
+	intentPath := filepath.Join(workDir, "script_intent.json")
+	registryPath := filepath.Join(workDir, "approved_scripts.json")
+	privateKeyPath := filepath.Join(workDir, "approved_script_private.key")
+	envelopePath := filepath.Join(workDir, "context_envelope.json")
+
+	mustWriteFile(t, policyPath, `
+default_verdict: block
+rules:
+  - name: allow-write-with-context
+    effect: allow
+    require_context_evidence: true
+    max_context_age_seconds: 30
+    match:
+      tool_names: [tool.write]
+`)
+	mustWriteScriptIntentFixture(t, intentPath)
+	writePrivateKey(t, privateKeyPath)
+
+	envelope, err := contextproof.BuildEnvelope([]schemacontext.ReferenceRecord{
+		{
+			RefID:         "ctx-1",
+			SourceType:    "doc",
+			SourceLocator: "file:///repo/context.md",
+			QueryDigest:   strings.Repeat("1", 64),
+			ContentDigest: strings.Repeat("2", 64),
+			RetrievedAt:   time.Now().UTC().Add(-5 * time.Second),
+			RedactionMode: contextproof.PrivacyModeHashes,
+			Immutability:  "immutable",
+		},
+	}, contextproof.BuildEnvelopeOptions{
+		ContextSetID:    "ctx-set-1",
+		EvidenceMode:    contextproof.EvidenceModeRequired,
+		ProducerVersion: "test",
+		CreatedAt:       time.Now().UTC(),
+	})
+	if err != nil {
+		t.Fatalf("build envelope: %v", err)
+	}
+	rawEnvelope, err := json.MarshalIndent(envelope, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal envelope: %v", err)
+	}
+	mustWriteFile(t, envelopePath, string(rawEnvelope)+"\n")
+
+	if code := runApproveScript([]string{
+		"--policy", policyPath,
+		"--intent", intentPath,
+		"--registry", registryPath,
+		"--approver", "secops",
+		"--key-mode", "prod",
+		"--private-key", privateKeyPath,
+		"--json",
+	}); code != exitOK {
+		t.Fatalf("runApproveScript expected %d got %d", exitOK, code)
+	}
+
+	rawBlocked := captureStdout(t, func() {
+		if code := runGateEval([]string{
+			"--policy", policyPath,
+			"--intent", intentPath,
+			"--approved-script-registry", registryPath,
+			"--json",
+		}); code != exitPolicyBlocked {
+			t.Fatalf("runGateEval without context envelope expected %d got %d", exitPolicyBlocked, code)
+		}
+	})
+	var blockedOut gateEvalOutput
+	if err := json.Unmarshal([]byte(rawBlocked), &blockedOut); err != nil {
+		t.Fatalf("decode blocked output: %v raw=%q", err, rawBlocked)
+	}
+	if blockedOut.PreApproved {
+		t.Fatalf("expected approved-script fast-path to be disabled, got %#v", blockedOut)
+	}
+
+	rawAllowed := captureStdout(t, func() {
+		if code := runGateEval([]string{
+			"--policy", policyPath,
+			"--intent", intentPath,
+			"--approved-script-registry", registryPath,
+			"--context-envelope", envelopePath,
+			"--json",
+		}); code != exitOK {
+			t.Fatalf("runGateEval with verified context envelope expected %d got %d", exitOK, code)
+		}
+	})
+	var allowedOut gateEvalOutput
+	if err := json.Unmarshal([]byte(rawAllowed), &allowedOut); err != nil {
+		t.Fatalf("decode allowed output: %v raw=%q", err, rawAllowed)
+	}
+	if allowedOut.PreApproved {
+		t.Fatalf("expected normal policy evaluation instead of fast-path, got %#v", allowedOut)
+	}
+	if allowedOut.Verdict != "allow" {
+		t.Fatalf("expected allow with verified context envelope, got %#v", allowedOut)
 	}
 }
 

--- a/cmd/gait/gate.go
+++ b/cmd/gait/gate.go
@@ -12,62 +12,64 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Clyra-AI/gait/core/contextproof"
 	"github.com/Clyra-AI/gait/core/credential"
 	"github.com/Clyra-AI/gait/core/gate"
 	"github.com/Clyra-AI/gait/core/projectconfig"
+	schemacontext "github.com/Clyra-AI/gait/core/schema/v1/context"
 	schemagate "github.com/Clyra-AI/gait/core/schema/v1/gate"
 	sign "github.com/Clyra-AI/proof/signing"
 )
 
 type gateEvalOutput struct {
-	OK                     bool                          `json:"ok"`
-	Profile                string                        `json:"profile,omitempty"`
-	Verdict                string                        `json:"verdict,omitempty"`
-	ReasonCodes            []string                      `json:"reason_codes,omitempty"`
-	Violations             []string                      `json:"violations,omitempty"`
-	ApprovalRef            string                        `json:"approval_ref,omitempty"`
-	RequiredApprovals      int                           `json:"required_approvals,omitempty"`
-	ValidApprovals         int                           `json:"valid_approvals,omitempty"`
-	ApprovalAuditPath      string                        `json:"approval_audit_path,omitempty"`
-	DelegationRef          string                        `json:"delegation_ref,omitempty"`
-	DelegationRequired     bool                          `json:"delegation_required,omitempty"`
-	ValidDelegations       int                           `json:"valid_delegations,omitempty"`
-	DelegationAuditPath    string                        `json:"delegation_audit_path,omitempty"`
-	TraceID                string                        `json:"trace_id,omitempty"`
-	TracePath              string                        `json:"trace_path,omitempty"`
-	PolicyDigest           string                        `json:"policy_digest,omitempty"`
-	IntentDigest           string                        `json:"intent_digest,omitempty"`
-	ContextSetDigest       string                        `json:"context_set_digest,omitempty"`
-	ContextEvidenceMode    string                        `json:"context_evidence_mode,omitempty"`
-	ContextRefCount        int                           `json:"context_ref_count,omitempty"`
-	ContextSource          string                        `json:"context_source,omitempty"`
-	Script                 bool                          `json:"script,omitempty"`
-	StepCount              int                           `json:"step_count,omitempty"`
-	ScriptHash             string                        `json:"script_hash,omitempty"`
-	CompositeRiskClass     string                        `json:"composite_risk_class,omitempty"`
-	StepVerdicts           []schemagate.TraceStepVerdict `json:"step_verdicts,omitempty"`
-	PreApproved            bool                          `json:"pre_approved,omitempty"`
-	PatternID              string                        `json:"pattern_id,omitempty"`
-	RegistryReason         string                        `json:"registry_reason,omitempty"`
-	MatchedRule            string                        `json:"matched_rule,omitempty"`
-	Phase                  string                        `json:"phase,omitempty"`
-	RateLimitScope         string                        `json:"rate_limit_scope,omitempty"`
-	RateLimitKey           string                        `json:"rate_limit_key,omitempty"`
-	RateLimitUsed          int                           `json:"rate_limit_used,omitempty"`
-	RateLimitRemaining     int                           `json:"rate_limit_remaining,omitempty"`
-	DestructiveBudgetScope     string                    `json:"destructive_budget_scope,omitempty"`
-	DestructiveBudgetKey       string                    `json:"destructive_budget_key,omitempty"`
-	DestructiveBudgetUsed      int                       `json:"destructive_budget_used,omitempty"`
-	DestructiveBudgetRemaining int                       `json:"destructive_budget_remaining,omitempty"`
-	CredentialIssuer       string                        `json:"credential_issuer,omitempty"`
-	CredentialRef          string                        `json:"credential_ref,omitempty"`
-	CredentialEvidencePath string                        `json:"credential_evidence_path,omitempty"`
-	SimulateMode           bool                          `json:"simulate_mode,omitempty"`
-	WouldHaveBlocked       bool                          `json:"would_have_blocked,omitempty"`
-	SimulatedVerdict       string                        `json:"simulated_verdict,omitempty"`
-	SimulatedReasonCodes   []string                      `json:"simulated_reason_codes,omitempty"`
-	Warnings               []string                      `json:"warnings,omitempty"`
-	Error                  string                        `json:"error,omitempty"`
+	OK                         bool                          `json:"ok"`
+	Profile                    string                        `json:"profile,omitempty"`
+	Verdict                    string                        `json:"verdict,omitempty"`
+	ReasonCodes                []string                      `json:"reason_codes,omitempty"`
+	Violations                 []string                      `json:"violations,omitempty"`
+	ApprovalRef                string                        `json:"approval_ref,omitempty"`
+	RequiredApprovals          int                           `json:"required_approvals,omitempty"`
+	ValidApprovals             int                           `json:"valid_approvals,omitempty"`
+	ApprovalAuditPath          string                        `json:"approval_audit_path,omitempty"`
+	DelegationRef              string                        `json:"delegation_ref,omitempty"`
+	DelegationRequired         bool                          `json:"delegation_required,omitempty"`
+	ValidDelegations           int                           `json:"valid_delegations,omitempty"`
+	DelegationAuditPath        string                        `json:"delegation_audit_path,omitempty"`
+	TraceID                    string                        `json:"trace_id,omitempty"`
+	TracePath                  string                        `json:"trace_path,omitempty"`
+	PolicyDigest               string                        `json:"policy_digest,omitempty"`
+	IntentDigest               string                        `json:"intent_digest,omitempty"`
+	ContextSetDigest           string                        `json:"context_set_digest,omitempty"`
+	ContextEvidenceMode        string                        `json:"context_evidence_mode,omitempty"`
+	ContextRefCount            int                           `json:"context_ref_count,omitempty"`
+	ContextSource              string                        `json:"context_source,omitempty"`
+	Script                     bool                          `json:"script,omitempty"`
+	StepCount                  int                           `json:"step_count,omitempty"`
+	ScriptHash                 string                        `json:"script_hash,omitempty"`
+	CompositeRiskClass         string                        `json:"composite_risk_class,omitempty"`
+	StepVerdicts               []schemagate.TraceStepVerdict `json:"step_verdicts,omitempty"`
+	PreApproved                bool                          `json:"pre_approved,omitempty"`
+	PatternID                  string                        `json:"pattern_id,omitempty"`
+	RegistryReason             string                        `json:"registry_reason,omitempty"`
+	MatchedRule                string                        `json:"matched_rule,omitempty"`
+	Phase                      string                        `json:"phase,omitempty"`
+	RateLimitScope             string                        `json:"rate_limit_scope,omitempty"`
+	RateLimitKey               string                        `json:"rate_limit_key,omitempty"`
+	RateLimitUsed              int                           `json:"rate_limit_used,omitempty"`
+	RateLimitRemaining         int                           `json:"rate_limit_remaining,omitempty"`
+	DestructiveBudgetScope     string                        `json:"destructive_budget_scope,omitempty"`
+	DestructiveBudgetKey       string                        `json:"destructive_budget_key,omitempty"`
+	DestructiveBudgetUsed      int                           `json:"destructive_budget_used,omitempty"`
+	DestructiveBudgetRemaining int                           `json:"destructive_budget_remaining,omitempty"`
+	CredentialIssuer           string                        `json:"credential_issuer,omitempty"`
+	CredentialRef              string                        `json:"credential_ref,omitempty"`
+	CredentialEvidencePath     string                        `json:"credential_evidence_path,omitempty"`
+	SimulateMode               bool                          `json:"simulate_mode,omitempty"`
+	WouldHaveBlocked           bool                          `json:"would_have_blocked,omitempty"`
+	SimulatedVerdict           string                        `json:"simulated_verdict,omitempty"`
+	SimulatedReasonCodes       []string                      `json:"simulated_reason_codes,omitempty"`
+	Warnings                   []string                      `json:"warnings,omitempty"`
+	Error                      string                        `json:"error,omitempty"`
 }
 
 type gateEvalProfile string
@@ -104,6 +106,7 @@ func runGateEval(arguments []string) int {
 
 	var policyPath string
 	var intentPath string
+	var contextEnvelopePath string
 	var tracePath string
 	var approvalTokenRef string
 	var approvalTokenPath string
@@ -144,6 +147,7 @@ func runGateEval(arguments []string) int {
 
 	flagSet.StringVar(&policyPath, "policy", "", "path to policy yaml")
 	flagSet.StringVar(&intentPath, "intent", "", "path to intent request json")
+	flagSet.StringVar(&contextEnvelopePath, "context-envelope", "", "path to verified context evidence envelope JSON")
 	flagSet.StringVar(&tracePath, "trace-out", "", "path to emitted trace JSON (default trace_<trace_id>.json)")
 	flagSet.StringVar(&approvalTokenRef, "approval-token-ref", "", "optional approval token reference")
 	flagSet.StringVar(&approvalTokenPath, "approval-token", "", "path to signed approval token")
@@ -244,9 +248,29 @@ func runGateEval(arguments []string) int {
 	if err != nil {
 		return writeGateEvalOutput(jsonOutput, gateEvalOutput{OK: false, Error: err.Error()}, exitCodeForError(err, exitInvalidInput))
 	}
+	var verifiedContextEnvelope *schemacontext.Envelope
 	startupWarnings := []string{}
 	wrkrInventory := map[string]gate.WrkrToolMetadata{}
 	wrkrSource := ""
+	if strings.TrimSpace(contextEnvelopePath) != "" {
+		trimmedEnvelopePath := filepath.Clean(strings.TrimSpace(contextEnvelopePath))
+		if trimmedEnvelopePath == "" {
+			return writeGateEvalOutput(jsonOutput, gateEvalOutput{OK: false, Error: "context envelope path is required"}, exitInvalidInput)
+		}
+		if !filepath.IsAbs(trimmedEnvelopePath) && !filepath.IsLocal(trimmedEnvelopePath) {
+			return writeGateEvalOutput(jsonOutput, gateEvalOutput{OK: false, Error: "context envelope path must be a local filesystem path"}, exitInvalidInput)
+		}
+		// #nosec G304 -- context envelope path is explicit local user input.
+		rawEnvelope, loadErr := os.ReadFile(trimmedEnvelopePath)
+		if loadErr != nil {
+			return writeGateEvalOutput(jsonOutput, gateEvalOutput{OK: false, Error: fmt.Errorf("read context envelope: %w", loadErr).Error()}, exitCodeForError(loadErr, exitInvalidInput))
+		}
+		envelope, parseErr := contextproof.ParseEnvelope(rawEnvelope)
+		if parseErr != nil {
+			return writeGateEvalOutput(jsonOutput, gateEvalOutput{OK: false, Error: parseErr.Error()}, exitCodeForError(parseErr, exitInvalidInput))
+		}
+		verifiedContextEnvelope = &envelope
+	}
 	if strings.TrimSpace(wrkrInventoryPath) != "" {
 		inventory, loadErr := gate.LoadWrkrInventory(wrkrInventoryPath)
 		if loadErr != nil {
@@ -349,36 +373,42 @@ func runGateEval(arguments []string) int {
 	registryReason := ""
 	preApprovedFastPath := false
 	if approvedRegistryConfigured && len(approvedRegistryEntries) > 0 {
-		policyDigestForRegistry, digestErr := gate.PolicyDigest(policy)
-		if digestErr != nil {
-			return writeGateEvalOutput(jsonOutput, gateEvalOutput{OK: false, Error: digestErr.Error()}, exitCodeForError(digestErr, exitInvalidInput))
-		}
-		match, matchErr := gate.MatchApprovedScript(intent, policyDigestForRegistry, approvedRegistryEntries, time.Now().UTC())
-		if matchErr != nil {
-			riskClass := strings.ToLower(strings.TrimSpace(intent.Context.RiskClass))
-			if resolvedProfile == gateProfileOSSProd || riskClass == "high" || riskClass == "critical" {
-				return writeGateEvalOutput(jsonOutput, gateEvalOutput{
-					OK:    false,
-					Error: "approved script fast-path evaluation failed in fail-closed mode: " + matchErr.Error(),
-				}, exitPolicyBlocked)
-			}
-			startupWarnings = append(startupWarnings, "approved script fast-path evaluation failed; continuing with policy evaluation")
-		} else if match.Matched {
-			preApprovedOutcome, preApproveErr := buildPreApprovedOutcome(intent, version, match)
-			if preApproveErr != nil {
-				return writeGateEvalOutput(jsonOutput, gateEvalOutput{OK: false, Error: preApproveErr.Error()}, exitCodeForError(preApproveErr, exitInvalidInput))
-			}
-			outcome = preApprovedOutcome
-			preApprovedFastPath = true
+		if gate.PolicyRequiresContextEvidence(policy) {
+			startupWarnings = append(startupWarnings, "approved script fast-path disabled because policy requires authenticated context evidence")
 		} else {
-			registryReason = match.Reason
+			policyDigestForRegistry, digestErr := gate.PolicyDigest(policy)
+			if digestErr != nil {
+				return writeGateEvalOutput(jsonOutput, gateEvalOutput{OK: false, Error: digestErr.Error()}, exitCodeForError(digestErr, exitInvalidInput))
+			}
+			match, matchErr := gate.MatchApprovedScript(intent, policyDigestForRegistry, approvedRegistryEntries, time.Now().UTC())
+			if matchErr != nil {
+				riskClass := strings.ToLower(strings.TrimSpace(intent.Context.RiskClass))
+				if resolvedProfile == gateProfileOSSProd || riskClass == "high" || riskClass == "critical" {
+					return writeGateEvalOutput(jsonOutput, gateEvalOutput{
+						OK:    false,
+						Error: "approved script fast-path evaluation failed in fail-closed mode: " + matchErr.Error(),
+					}, exitPolicyBlocked)
+				}
+				startupWarnings = append(startupWarnings, "approved script fast-path evaluation failed; continuing with policy evaluation")
+			} else if match.Matched {
+				preApprovedOutcome, preApproveErr := buildPreApprovedOutcome(intent, version, match)
+				if preApproveErr != nil {
+					return writeGateEvalOutput(jsonOutput, gateEvalOutput{OK: false, Error: preApproveErr.Error()}, exitCodeForError(preApproveErr, exitInvalidInput))
+				}
+				outcome = preApprovedOutcome
+				preApprovedFastPath = true
+			} else {
+				registryReason = match.Reason
+			}
 		}
 	}
 	if !preApprovedFastPath {
 		outcome, err = gate.EvaluatePolicyDetailed(policy, intent, gate.EvalOptions{
-			ProducerVersion: version,
-			WrkrInventory:   wrkrInventory,
-			WrkrSource:      wrkrSource,
+			ProducerVersion:         version,
+			WrkrInventory:           wrkrInventory,
+			WrkrSource:              wrkrSource,
+			VerifiedContextEnvelope: verifiedContextEnvelope,
+			ContextEvidenceNow:      time.Now().UTC(),
 		})
 		if err != nil {
 			return writeGateEvalOutput(jsonOutput, gateEvalOutput{OK: false, Error: err.Error()}, exitCodeForError(err, exitInvalidInput))
@@ -387,13 +417,17 @@ func runGateEval(arguments []string) int {
 			outcome.RegistryReason = registryReason
 		}
 	}
+	preparedIntent := outcome.PreparedIntent
+	if preparedIntent.SchemaID == "" {
+		preparedIntent = intent
+	}
 	result := outcome.Result
 	evalLatencyMS := time.Since(evalStart).Seconds() * 1000
-	policyDigestForContext, intentDigestForContext, requiredApprovalScope, err := gate.ApprovalContext(policy, intent)
+	policyDigestForContext, intentDigestForContext, requiredApprovalScope, err := gate.ApprovalContext(policy, preparedIntent)
 	if err != nil {
 		return writeGateEvalOutput(jsonOutput, gateEvalOutput{OK: false, Error: err.Error()}, exitCodeForError(err, exitInvalidInput))
 	}
-	delegationBindingDigest, err := gate.DelegationBindingDigest(intent)
+	delegationBindingDigest, err := gate.DelegationBindingDigest(preparedIntent)
 	if err != nil {
 		return writeGateEvalOutput(jsonOutput, gateEvalOutput{OK: false, Error: err.Error()}, exitCodeForError(err, exitInvalidInput))
 	}
@@ -401,7 +435,7 @@ func runGateEval(arguments []string) int {
 	var rateDecision gate.RateLimitDecision
 	var destructiveBudgetDecision gate.RateLimitDecision
 	if outcome.RateLimit.Requests > 0 {
-		rateDecision, err = gate.EnforceRateLimit(rateLimitState, outcome.RateLimit, intent, time.Now().UTC())
+		rateDecision, err = gate.EnforceRateLimit(rateLimitState, outcome.RateLimit, preparedIntent, time.Now().UTC())
 		if err != nil {
 			return writeGateEvalOutput(jsonOutput, gateEvalOutput{OK: false, Error: err.Error()}, exitCodeForError(err, exitInvalidInput))
 		}
@@ -411,9 +445,9 @@ func runGateEval(arguments []string) int {
 			result.Violations = mergeUniqueSorted(result.Violations, []string{"rate_limit_exceeded"})
 		}
 	}
-	if outcome.DestructiveBudget.Requests > 0 && gateIntentContainsDestructiveTarget(intent) {
-		budgetIntent := intent
-		budgetIntent.ToolName = "destructive_budget|" + strings.TrimSpace(intent.ToolName)
+	if outcome.DestructiveBudget.Requests > 0 && gateIntentContainsDestructiveTarget(preparedIntent) {
+		budgetIntent := preparedIntent
+		budgetIntent.ToolName = "destructive_budget|" + strings.TrimSpace(preparedIntent.ToolName)
 		destructiveBudgetDecision, err = gate.EnforceRateLimit(rateLimitState, outcome.DestructiveBudget, budgetIntent, time.Now().UTC())
 		if err != nil {
 			return writeGateEvalOutput(jsonOutput, gateEvalOutput{OK: false, Error: err.Error()}, exitCodeForError(err, exitInvalidInput))
@@ -482,10 +516,10 @@ func runGateEval(arguments []string) int {
 		} else {
 			expectedDelegator := ""
 			expectedDelegate := ""
-			if intent.Delegation != nil {
-				expectedDelegate = intent.Delegation.RequesterIdentity
-				if len(intent.Delegation.Chain) > 0 {
-					last := intent.Delegation.Chain[len(intent.Delegation.Chain)-1]
+			if preparedIntent.Delegation != nil {
+				expectedDelegate = preparedIntent.Delegation.RequesterIdentity
+				if len(preparedIntent.Delegation.Chain) > 0 {
+					last := preparedIntent.Delegation.Chain[len(preparedIntent.Delegation.Chain)-1]
 					expectedDelegator = last.DelegatorIdentity
 					if expectedDelegate == "" {
 						expectedDelegate = last.DelegateIdentity
@@ -597,8 +631,8 @@ func runGateEval(arguments []string) int {
 					ExpectedPolicyDigest:            policyDigestForContext,
 					ExpectedDelegationBindingDigest: delegationBindingDigest,
 					RequiredScope:                   requiredApprovalScope,
-					TargetCount:                     gateIntentTargetCount(intent),
-					OperationCount:                  gateIntentOperationCount(intent),
+					TargetCount:                     gateIntentTargetCount(preparedIntent),
+					OperationCount:                  gateIntentOperationCount(preparedIntent),
 				})
 				if err != nil {
 					reasonCode := gate.ApprovalCodeSchemaInvalid
@@ -665,11 +699,11 @@ func runGateEval(arguments []string) int {
 			credentialReferenceUsed = reference
 			credentialScopesUsed = scope
 			issued, issueErr := credential.Issue(resolvedBroker, credential.Request{
-				ToolName:  intent.ToolName,
-				Identity:  intent.Context.Identity,
-				Workspace: intent.Context.Workspace,
-				SessionID: intent.Context.SessionID,
-				RequestID: intent.Context.RequestID,
+				ToolName:  preparedIntent.ToolName,
+				Identity:  preparedIntent.Context.Identity,
+				Workspace: preparedIntent.Context.Workspace,
+				SessionID: preparedIntent.Context.SessionID,
+				RequestID: preparedIntent.Context.RequestID,
 				Reference: reference,
 				Scope:     scope,
 			})
@@ -705,7 +739,7 @@ func runGateEval(arguments []string) int {
 	}
 	exitCode = gateEvalExitCodeForVerdict(result.Verdict, exitCode)
 
-	traceResult, err := gate.EmitSignedTrace(policy, intent, result, gate.EmitTraceOptions{
+	traceResult, err := gate.EmitSignedTrace(policy, preparedIntent, result, gate.EmitTraceOptions{
 		ProducerVersion:       version,
 		CorrelationID:         currentCorrelationID(),
 		ApprovalTokenRef:      resolvedApprovalRef,
@@ -758,7 +792,7 @@ func runGateEval(arguments []string) int {
 			ProducerVersion: version,
 			TraceID:         traceResult.Trace.TraceID,
 			ToolName:        traceResult.Trace.ToolName,
-			Identity:        intent.Context.Identity,
+			Identity:        preparedIntent.Context.Identity,
 			Broker:          credentialIssuer,
 			Reference:       credentialReferenceUsed,
 			Scope:           credentialScopesUsed,
@@ -794,53 +828,53 @@ func runGateEval(arguments []string) int {
 	}
 
 	return writeGateEvalOutput(jsonOutput, gateEvalOutput{
-		OK:                     true,
-		Profile:                string(resolvedProfile),
-		Verdict:                result.Verdict,
-		ReasonCodes:            result.ReasonCodes,
-		Violations:             result.Violations,
-		ApprovalRef:            resolvedApprovalRef,
-		RequiredApprovals:      requiredApprovals,
-		ValidApprovals:         validApprovals,
-		ApprovalAuditPath:      resolvedApprovalAuditPath,
-		DelegationRef:          resolvedDelegationRef,
-		DelegationRequired:     delegationRequired,
-		ValidDelegations:       validDelegations,
-		DelegationAuditPath:    resolvedDelegationAuditPath,
-		TraceID:                traceResult.Trace.TraceID,
-		TracePath:              traceResult.TracePath,
-		PolicyDigest:           traceResult.PolicyDigest,
-		IntentDigest:           traceResult.IntentDigest,
-		ContextSetDigest:       intent.Context.ContextSetDigest,
-		ContextEvidenceMode:    intent.Context.ContextEvidenceMode,
-		ContextRefCount:        len(intent.Context.ContextRefs),
-		ContextSource:          outcome.ContextSource,
-		Script:                 outcome.Script,
-		StepCount:              outcome.StepCount,
-		ScriptHash:             outcome.ScriptHash,
-		CompositeRiskClass:     outcome.CompositeRiskClass,
-		StepVerdicts:           outcome.StepVerdicts,
-		PreApproved:            outcome.PreApproved,
-		PatternID:              outcome.PatternID,
-		RegistryReason:         outcome.RegistryReason,
-		MatchedRule:            outcome.MatchedRule,
-		Phase:                  intent.Context.Phase,
-		RateLimitScope:         rateDecision.Scope,
-		RateLimitKey:           rateDecision.Key,
-		RateLimitUsed:          rateDecision.Used,
-		RateLimitRemaining:     rateDecision.Remaining,
+		OK:                         true,
+		Profile:                    string(resolvedProfile),
+		Verdict:                    result.Verdict,
+		ReasonCodes:                result.ReasonCodes,
+		Violations:                 result.Violations,
+		ApprovalRef:                resolvedApprovalRef,
+		RequiredApprovals:          requiredApprovals,
+		ValidApprovals:             validApprovals,
+		ApprovalAuditPath:          resolvedApprovalAuditPath,
+		DelegationRef:              resolvedDelegationRef,
+		DelegationRequired:         delegationRequired,
+		ValidDelegations:           validDelegations,
+		DelegationAuditPath:        resolvedDelegationAuditPath,
+		TraceID:                    traceResult.Trace.TraceID,
+		TracePath:                  traceResult.TracePath,
+		PolicyDigest:               traceResult.PolicyDigest,
+		IntentDigest:               traceResult.IntentDigest,
+		ContextSetDigest:           traceResult.Trace.ContextSetDigest,
+		ContextEvidenceMode:        traceResult.Trace.ContextEvidenceMode,
+		ContextRefCount:            traceResult.Trace.ContextRefCount,
+		ContextSource:              outcome.ContextSource,
+		Script:                     outcome.Script,
+		StepCount:                  outcome.StepCount,
+		ScriptHash:                 outcome.ScriptHash,
+		CompositeRiskClass:         outcome.CompositeRiskClass,
+		StepVerdicts:               outcome.StepVerdicts,
+		PreApproved:                outcome.PreApproved,
+		PatternID:                  outcome.PatternID,
+		RegistryReason:             outcome.RegistryReason,
+		MatchedRule:                outcome.MatchedRule,
+		Phase:                      preparedIntent.Context.Phase,
+		RateLimitScope:             rateDecision.Scope,
+		RateLimitKey:               rateDecision.Key,
+		RateLimitUsed:              rateDecision.Used,
+		RateLimitRemaining:         rateDecision.Remaining,
 		DestructiveBudgetScope:     destructiveBudgetDecision.Scope,
 		DestructiveBudgetKey:       destructiveBudgetDecision.Key,
 		DestructiveBudgetUsed:      destructiveBudgetDecision.Used,
 		DestructiveBudgetRemaining: destructiveBudgetDecision.Remaining,
-		CredentialIssuer:       credentialIssuer,
-		CredentialRef:          credentialRefOut,
-		CredentialEvidencePath: resolvedCredentialEvidencePath,
-		SimulateMode:           simulate,
-		WouldHaveBlocked:       wouldHaveBlocked,
-		SimulatedVerdict:       simulatedVerdict,
-		SimulatedReasonCodes:   simulatedReasonCodes,
-		Warnings:               mergeUniqueSorted(startupWarnings, signingWarnings),
+		CredentialIssuer:           credentialIssuer,
+		CredentialRef:              credentialRefOut,
+		CredentialEvidencePath:     resolvedCredentialEvidencePath,
+		SimulateMode:               simulate,
+		WouldHaveBlocked:           wouldHaveBlocked,
+		SimulatedVerdict:           simulatedVerdict,
+		SimulatedReasonCodes:       simulatedReasonCodes,
+		Warnings:                   mergeUniqueSorted(startupWarnings, signingWarnings),
 	}, exitCode)
 }
 
@@ -920,6 +954,7 @@ func buildPreApprovedOutcome(intent schemagate.IntentRequest, producerVersion st
 			ReasonCodes:     []string{match.Reason},
 			Violations:      []string{},
 		},
+		PreparedIntent: normalizedIntent,
 		PreApproved:    true,
 		PatternID:      match.PatternID,
 		RegistryReason: match.Reason,
@@ -1137,7 +1172,7 @@ func writeGateEvalOutput(jsonOutput bool, output gateEvalOutput, exitCode int) i
 
 func printGateUsage() {
 	fmt.Println("Usage:")
-	fmt.Println("  gait gate eval --policy <policy.yaml> --intent <intent.json> [--config .gait/config.yaml] [--no-config] [--profile standard|oss-prod] [--simulate] [--approval-token <token.json>] [--approval-token-chain <csv>] [--delegation-token <token.json>] [--delegation-token-chain <csv>] [--approval-audit-out audit.json] [--delegation-audit-out audit.json] [--credential-broker off|stub|env|command] [--credential-command <path>] [--wrkr-inventory <inventory.json>] [--approved-script-registry <registry.json>] [--approved-script-public-key <path>|--approved-script-public-key-env <VAR>] [--trace-out trace.json] [--key-mode dev|prod] [--private-key <path>|--private-key-env <VAR>] [--json] [--explain]")
+	fmt.Println("  gait gate eval --policy <policy.yaml> --intent <intent.json> [--context-envelope <context_envelope.json>] [--config .gait/config.yaml] [--no-config] [--profile standard|oss-prod] [--simulate] [--approval-token <token.json>] [--approval-token-chain <csv>] [--delegation-token <token.json>] [--delegation-token-chain <csv>] [--approval-audit-out audit.json] [--delegation-audit-out audit.json] [--credential-broker off|stub|env|command] [--credential-command <path>] [--wrkr-inventory <inventory.json>] [--approved-script-registry <registry.json>] [--approved-script-public-key <path>|--approved-script-public-key-env <VAR>] [--trace-out trace.json] [--key-mode dev|prod] [--private-key <path>|--private-key-env <VAR>] [--json] [--explain]")
 	fmt.Println("Rollout path:")
 	fmt.Println("  observe: gait gate eval ... --simulate --json")
 	fmt.Println("  enforce: gait gate eval ... --json")
@@ -1145,7 +1180,7 @@ func printGateUsage() {
 
 func printGateEvalUsage() {
 	fmt.Println("Usage:")
-	fmt.Println("  gait gate eval --policy <policy.yaml> --intent <intent.json> [--config .gait/config.yaml] [--no-config] [--profile standard|oss-prod] [--simulate] [--approval-token <token.json>] [--approval-token-chain <csv>] [--delegation-token <token.json>] [--delegation-token-chain <csv>] [--approval-token-ref token] [--approval-public-key <path>|--approval-public-key-env <VAR>] [--delegation-public-key <path>|--delegation-public-key-env <VAR>] [--approval-audit-out audit.json] [--delegation-audit-out audit.json] [--rate-limit-state state.json] [--credential-broker off|stub|env|command] [--credential-env-prefix GAIT_BROKER_TOKEN_] [--credential-command <path>] [--credential-command-args csv] [--credential-ref ref] [--credential-scopes csv] [--credential-evidence-out path] [--wrkr-inventory <inventory.json>] [--approved-script-registry <registry.json>] [--approved-script-public-key <path>|--approved-script-public-key-env <VAR>] [--trace-out trace.json] [--key-mode dev|prod] [--private-key <path>|--private-key-env <VAR>] [--json] [--explain]")
+	fmt.Println("  gait gate eval --policy <policy.yaml> --intent <intent.json> [--context-envelope <context_envelope.json>] [--config .gait/config.yaml] [--no-config] [--profile standard|oss-prod] [--simulate] [--approval-token <token.json>] [--approval-token-chain <csv>] [--delegation-token <token.json>] [--delegation-token-chain <csv>] [--approval-token-ref token] [--approval-public-key <path>|--approval-public-key-env <VAR>] [--delegation-public-key <path>|--delegation-public-key-env <VAR>] [--approval-audit-out audit.json] [--delegation-audit-out audit.json] [--rate-limit-state state.json] [--credential-broker off|stub|env|command] [--credential-env-prefix GAIT_BROKER_TOKEN_] [--credential-command <path>] [--credential-command-args csv] [--credential-ref ref] [--credential-scopes csv] [--credential-evidence-out path] [--wrkr-inventory <inventory.json>] [--approved-script-registry <registry.json>] [--approved-script-public-key <path>|--approved-script-public-key-env <VAR>] [--trace-out trace.json] [--key-mode dev|prod] [--private-key <path>|--private-key-env <VAR>] [--json] [--explain]")
 	fmt.Println("  observe first: add --simulate while tuning")
 	fmt.Println("  enforce later: remove --simulate once fixtures are stable")
 }

--- a/cmd/gait/main_test.go
+++ b/cmd/gait/main_test.go
@@ -12,10 +12,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Clyra-AI/gait/core/contextproof"
 	"github.com/Clyra-AI/gait/core/doctor"
 	gatecore "github.com/Clyra-AI/gait/core/gate"
 	"github.com/Clyra-AI/gait/core/projectconfig"
 	"github.com/Clyra-AI/gait/core/runpack"
+	schemacontext "github.com/Clyra-AI/gait/core/schema/v1/context"
 	schemagate "github.com/Clyra-AI/gait/core/schema/v1/gate"
 	schemarunpack "github.com/Clyra-AI/gait/core/schema/v1/runpack"
 	schemascout "github.com/Clyra-AI/gait/core/schema/v1/scout"
@@ -565,6 +567,129 @@ func TestGatePolicyTraceApproveAndDoctor(t *testing.T) {
 	}); code != exitVerifyFailed {
 		t.Fatalf("doctor production readiness failure: expected %d got %d", exitVerifyFailed, code)
 	}
+}
+
+func TestRunGateEvalRequiresVerifiedContextEnvelopeForContextPolicies(t *testing.T) {
+	workDir := t.TempDir()
+	withWorkingDir(t, workDir)
+
+	policyPath := filepath.Join(workDir, "policy.yaml")
+	mustWriteFile(t, policyPath, strings.Join([]string{
+		"default_verdict: block",
+		"rules:",
+		"  - name: allow-with-context-proof",
+		"    priority: 10",
+		"    effect: allow",
+		"    require_context_evidence: true",
+		"    max_context_age_seconds: 30",
+		"    match:",
+		"      tool_names: [tool.write]",
+	}, "\n")+"\n")
+
+	now := time.Now().UTC()
+	envelope, err := contextproof.BuildEnvelope([]schemacontext.ReferenceRecord{
+		{
+			RefID:         "ctx-1",
+			SourceType:    "doc",
+			SourceLocator: "file:///repo/context.md",
+			QueryDigest:   strings.Repeat("1", 64),
+			ContentDigest: strings.Repeat("2", 64),
+			RetrievedAt:   now.Add(-5 * time.Second),
+			RedactionMode: contextproof.PrivacyModeHashes,
+			Immutability:  "immutable",
+		},
+	}, contextproof.BuildEnvelopeOptions{
+		ContextSetID:    "ctx-set-1",
+		EvidenceMode:    contextproof.EvidenceModeRequired,
+		ProducerVersion: "test",
+		CreatedAt:       now.Add(-5 * time.Second),
+	})
+	if err != nil {
+		t.Fatalf("build context envelope: %v", err)
+	}
+	envelopePath := filepath.Join(workDir, "context_envelope.json")
+	envelopeBytes, err := json.MarshalIndent(envelope, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal context envelope: %v", err)
+	}
+	mustWriteFile(t, envelopePath, string(envelopeBytes)+"\n")
+
+	intent := schemagate.IntentRequest{
+		SchemaID:        "gait.gate.intent_request",
+		SchemaVersion:   "1.0.0",
+		CreatedAt:       time.Date(2026, time.March, 12, 12, 0, 0, 0, time.UTC),
+		ProducerVersion: "test",
+		ToolName:        "tool.write",
+		Args:            map[string]any{"path": "/tmp/context-proof.txt"},
+		Targets:         []schemagate.IntentTarget{{Kind: "path", Value: "/tmp/context-proof.txt", Operation: "write", EndpointClass: "fs.write"}},
+		Context: schemagate.IntentContext{
+			Identity:            "alice",
+			Workspace:           "/repo/gait",
+			RiskClass:           "high",
+			ContextSetDigest:    envelope.ContextSetDigest,
+			ContextEvidenceMode: envelope.EvidenceMode,
+			AuthContext:         map[string]any{"context_age_seconds": int64(1)},
+		},
+	}
+	intentPath := filepath.Join(workDir, "intent.json")
+	rawIntent, err := json.MarshalIndent(intent, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal intent: %v", err)
+	}
+	mustWriteFile(t, intentPath, string(rawIntent)+"\n")
+
+	rawBlocked := captureStdout(t, func() {
+		if code := runGateEval([]string{
+			"--policy", policyPath,
+			"--intent", intentPath,
+			"--json",
+		}); code != exitPolicyBlocked {
+			t.Fatalf("runGateEval without context envelope expected %d got %d", exitPolicyBlocked, code)
+		}
+	})
+	var blockedOut gateEvalOutput
+	if err := json.Unmarshal([]byte(rawBlocked), &blockedOut); err != nil {
+		t.Fatalf("decode blocked output: %v raw=%q", err, rawBlocked)
+	}
+	if blockedOut.ContextSetDigest != "" || blockedOut.ContextEvidenceMode != "" || blockedOut.ContextRefCount != 0 {
+		t.Fatalf("expected unverified context claims to be stripped from output, got %#v", blockedOut)
+	}
+	if !containsString(blockedOut.ReasonCodes, "context_evidence_missing") {
+		t.Fatalf("expected context_evidence_missing, got %#v", blockedOut.ReasonCodes)
+	}
+
+	rawAllowed := captureStdout(t, func() {
+		if code := runGateEval([]string{
+			"--policy", policyPath,
+			"--intent", intentPath,
+			"--context-envelope", envelopePath,
+			"--json",
+		}); code != exitOK {
+			t.Fatalf("runGateEval with context envelope expected %d got %d", exitOK, code)
+		}
+	})
+	var allowedOut gateEvalOutput
+	if err := json.Unmarshal([]byte(rawAllowed), &allowedOut); err != nil {
+		t.Fatalf("decode allowed output: %v raw=%q", err, rawAllowed)
+	}
+	if allowedOut.ContextSetDigest != envelope.ContextSetDigest {
+		t.Fatalf("expected output digest %q, got %q", envelope.ContextSetDigest, allowedOut.ContextSetDigest)
+	}
+	if allowedOut.ContextEvidenceMode != envelope.EvidenceMode {
+		t.Fatalf("expected output mode %q, got %q", envelope.EvidenceMode, allowedOut.ContextEvidenceMode)
+	}
+	if allowedOut.ContextRefCount != 1 {
+		t.Fatalf("expected context ref count 1, got %#v", allowedOut)
+	}
+}
+
+func containsString(values []string, needle string) bool {
+	for _, value := range values {
+		if value == needle {
+			return true
+		}
+	}
+	return false
 }
 
 func TestGateEvalBlockVerdictReturnsPolicyBlockedExit(t *testing.T) {

--- a/cmd/gait/mcp.go
+++ b/cmd/gait/mcp.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Clyra-AI/gait/core/contextproof"
 	"github.com/Clyra-AI/gait/core/gate"
 	"github.com/Clyra-AI/gait/core/jobruntime"
 	"github.com/Clyra-AI/gait/core/mcp"
@@ -65,19 +66,21 @@ type mcpVerifyOutput struct {
 }
 
 type mcpProxyEvalOptions struct {
-	Adapter       string
-	Profile       string
-	JobRoot       string
-	RunID         string
-	TracePath     string
-	RunpackOut    string
-	PackOut       string
-	AutoPackDir   string
-	LogExportPath string
-	OTelExport    string
-	KeyMode       string
-	PrivateKey    string // #nosec G117 -- field name is explicit config surface, not a hardcoded secret.
-	PrivateKeyEnv string
+	Adapter                    string
+	Profile                    string
+	JobRoot                    string
+	RunID                      string
+	ContextEnvelopePath        string
+	TracePath                  string
+	RunpackOut                 string
+	PackOut                    string
+	AutoPackDir                string
+	LogExportPath              string
+	OTelExport                 string
+	KeyMode                    string
+	PrivateKey                 string // #nosec G117 -- field name is explicit config surface, not a hardcoded secret.
+	PrivateKeyEnv              string
+	AllowLocalContextArtifacts bool
 }
 
 func runMCP(arguments []string) int {
@@ -108,26 +111,28 @@ func runMCPProxy(arguments []string) int {
 		return writeExplain("Decode an MCP or adapter-formatted tool call, evaluate policy deterministically, and emit a signed gate-compatible trace.")
 	}
 	arguments = reorderInterspersedFlags(arguments, map[string]bool{
-		"policy":          true,
-		"call":            true,
-		"adapter":         true,
-		"profile":         true,
-		"job-root":        true,
-		"trace-out":       true,
-		"run-id":          true,
-		"runpack-out":     true,
-		"pack-out":        true,
-		"export-log-out":  true,
-		"export-otel-out": true,
-		"key-mode":        true,
-		"private-key":     true,
-		"private-key-env": true,
+		"policy":           true,
+		"call":             true,
+		"context-envelope": true,
+		"adapter":          true,
+		"profile":          true,
+		"job-root":         true,
+		"trace-out":        true,
+		"run-id":           true,
+		"runpack-out":      true,
+		"pack-out":         true,
+		"export-log-out":   true,
+		"export-otel-out":  true,
+		"key-mode":         true,
+		"private-key":      true,
+		"private-key-env":  true,
 	})
 	flagSet := flag.NewFlagSet("mcp-proxy", flag.ContinueOnError)
 	flagSet.SetOutput(io.Discard)
 
 	var policyPath string
 	var callPath string
+	var contextEnvelopePath string
 	var adapter string
 	var profile string
 	var jobRoot string
@@ -145,6 +150,7 @@ func runMCPProxy(arguments []string) int {
 
 	flagSet.StringVar(&policyPath, "policy", "", "path to policy YAML")
 	flagSet.StringVar(&callPath, "call", "", "path to tool call JSON (use '-' for stdin)")
+	flagSet.StringVar(&contextEnvelopePath, "context-envelope", "", "path to verified context evidence envelope JSON")
 	flagSet.StringVar(&adapter, "adapter", "mcp", "adapter payload format: mcp|openai|anthropic|langchain|claude_code")
 	flagSet.StringVar(&profile, "profile", string(gateProfileStandard), "runtime profile: standard|oss-prod")
 	flagSet.StringVar(&jobRoot, "job-root", "./gait-out/jobs", "job runtime root for emergency stop preemption checks when context.job_id is present")
@@ -185,18 +191,20 @@ func runMCPProxy(arguments []string) int {
 		return writeMCPProxyOutput(jsonOutput, mcpProxyOutput{OK: false, Error: err.Error()}, exitCodeForError(err, exitInvalidInput))
 	}
 	output, exitCode, err := evaluateMCPProxyPayload(policyPath, payload, mcpProxyEvalOptions{
-		Adapter:       adapter,
-		Profile:       profile,
-		JobRoot:       jobRoot,
-		RunID:         runID,
-		TracePath:     tracePath,
-		RunpackOut:    runpackOut,
-		PackOut:       packOut,
-		LogExportPath: logExportPath,
-		OTelExport:    otelExportPath,
-		KeyMode:       keyMode,
-		PrivateKey:    privateKeyPath,
-		PrivateKeyEnv: privateKeyEnv,
+		Adapter:                    adapter,
+		Profile:                    profile,
+		JobRoot:                    jobRoot,
+		RunID:                      runID,
+		ContextEnvelopePath:        contextEnvelopePath,
+		TracePath:                  tracePath,
+		RunpackOut:                 runpackOut,
+		PackOut:                    packOut,
+		LogExportPath:              logExportPath,
+		OTelExport:                 otelExportPath,
+		KeyMode:                    keyMode,
+		PrivateKey:                 privateKeyPath,
+		PrivateKeyEnv:              privateKeyEnv,
+		AllowLocalContextArtifacts: true,
 	})
 	if err != nil {
 		return writeMCPProxyOutput(jsonOutput, mcpProxyOutput{OK: false, Error: err.Error()}, exitCodeForError(err, exitInvalidInput))
@@ -351,6 +359,30 @@ func evaluateMCPProxyPayload(policyPath string, payload []byte, options mcpProxy
 	if err != nil {
 		return mcpProxyOutput{}, exitInvalidInput, err
 	}
+	if strings.TrimSpace(call.Context.ContextEnvelopePath) != "" {
+		return mcpProxyOutput{}, exitInvalidInput, fmt.Errorf("call.context.context_envelope_path is not supported; use --context-envelope at the boundary")
+	}
+	evalOptions := gate.EvalOptions{ProducerVersion: version}
+	if envelopePath := strings.TrimSpace(options.ContextEnvelopePath); envelopePath != "" {
+		trimmedEnvelopePath := filepath.Clean(strings.TrimSpace(envelopePath))
+		if trimmedEnvelopePath == "" {
+			return mcpProxyOutput{}, exitInvalidInput, fmt.Errorf("context envelope path is required")
+		}
+		if !filepath.IsAbs(trimmedEnvelopePath) && !filepath.IsLocal(trimmedEnvelopePath) {
+			return mcpProxyOutput{}, exitInvalidInput, fmt.Errorf("context envelope path must be a local filesystem path")
+		}
+		// #nosec G304 -- context envelope path is explicit local user input.
+		rawEnvelope, loadErr := os.ReadFile(trimmedEnvelopePath)
+		if loadErr != nil {
+			return mcpProxyOutput{}, exitInvalidInput, fmt.Errorf("read context envelope: %w", loadErr)
+		}
+		envelope, parseErr := contextproof.ParseEnvelope(rawEnvelope)
+		if parseErr != nil {
+			return mcpProxyOutput{}, exitInvalidInput, parseErr
+		}
+		evalOptions.VerifiedContextEnvelope = &envelope
+		evalOptions.ContextEvidenceNow = time.Now().UTC()
+	}
 
 	resolvedProfile, err := parseGateEvalProfile(options.Profile)
 	if err != nil {
@@ -368,7 +400,7 @@ func evaluateMCPProxyPayload(policyPath string, payload []byte, options mcpProxy
 		return mcpProxyOutput{}, exitInvalidInput, err
 	}
 
-	evalResult, err := mcp.EvaluateToolCallWithIntentOptions(policy, call, gate.EvalOptions{ProducerVersion: version}, mcp.IntentOptions{
+	evalResult, err := mcp.EvaluateToolCallWithIntentOptions(policy, call, evalOptions, mcp.IntentOptions{
 		RequireExplicitContext: resolvedProfile == gateProfileOSSProd,
 	})
 	if err != nil {
@@ -966,8 +998,8 @@ func writeMCPVerifyOutput(jsonOutput bool, output mcpVerifyOutput, exitCode int)
 
 func printMCPUsage() {
 	fmt.Println("Usage:")
-	fmt.Println("  gait mcp proxy --policy <policy.yaml> --call <tool_call.json|-> [--adapter mcp|openai|anthropic|langchain|claude_code] [--profile standard|oss-prod] [--job-root ./gait-out/jobs] [--trace-out trace.json] [--run-id run_...] [--runpack-out runpack.zip] [--pack-out pack_run.zip] [--export-log-out events.jsonl] [--export-otel-out otel.jsonl] [--json] [--explain]")
-	fmt.Println("  gait mcp bridge --policy <policy.yaml> --call <tool_call.json|-> [--adapter mcp|openai|anthropic|langchain|claude_code] [--profile standard|oss-prod] [--job-root ./gait-out/jobs] [--trace-out trace.json] [--run-id run_...] [--runpack-out runpack.zip] [--pack-out pack_run.zip] [--export-log-out events.jsonl] [--export-otel-out otel.jsonl] [--json] [--explain]")
+	fmt.Println("  gait mcp proxy --policy <policy.yaml> --call <tool_call.json|-> [--context-envelope <context_envelope.json>] [--adapter mcp|openai|anthropic|langchain|claude_code] [--profile standard|oss-prod] [--job-root ./gait-out/jobs] [--trace-out trace.json] [--run-id run_...] [--runpack-out runpack.zip] [--pack-out pack_run.zip] [--export-log-out events.jsonl] [--export-otel-out otel.jsonl] [--json] [--explain]")
+	fmt.Println("  gait mcp bridge --policy <policy.yaml> --call <tool_call.json|-> [--context-envelope <context_envelope.json>] [--adapter mcp|openai|anthropic|langchain|claude_code] [--profile standard|oss-prod] [--job-root ./gait-out/jobs] [--trace-out trace.json] [--run-id run_...] [--runpack-out runpack.zip] [--pack-out pack_run.zip] [--export-log-out events.jsonl] [--export-otel-out otel.jsonl] [--json] [--explain]")
 	fmt.Println("  gait mcp verify --policy <policy.yaml> --server <server.json> [--risk-class <class>] [--json] [--explain]")
 	fmt.Println("  gait mcp serve --policy <policy.yaml> [--listen 127.0.0.1:8787] [--adapter mcp|openai|anthropic|langchain|claude_code] [--profile standard|oss-prod] [--job-root ./gait-out/jobs] [--auth-mode off|token] [--auth-token-env <VAR>] [--max-request-bytes <bytes>] [--http-verdict-status compat|strict] [--allow-client-artifact-paths] [--trace-dir <dir>] [--runpack-dir <dir>] [--pack-dir <dir>] [--trace-max-age <dur>] [--trace-max-count <n>] [--runpack-max-age <dur>] [--runpack-max-count <n>] [--pack-max-age <dur>] [--pack-max-count <n>] [--session-max-age <dur>] [--session-max-count <n>] [--json] [--explain]")
 	fmt.Println("    serve endpoints: POST /v1/evaluate, POST /v1/evaluate/sse, POST /v1/evaluate/stream")
@@ -975,7 +1007,7 @@ func printMCPUsage() {
 
 func printMCPProxyUsage() {
 	fmt.Println("Usage:")
-	fmt.Println("  gait mcp proxy --policy <policy.yaml> --call <tool_call.json|-> [--adapter mcp|openai|anthropic|langchain|claude_code] [--profile standard|oss-prod] [--job-root ./gait-out/jobs] [--trace-out trace.json] [--run-id run_...] [--runpack-out runpack.zip] [--pack-out pack_run.zip] [--export-log-out events.jsonl] [--export-otel-out otel.jsonl] [--key-mode dev|prod] [--private-key <path>|--private-key-env <VAR>] [--json] [--explain]")
+	fmt.Println("  gait mcp proxy --policy <policy.yaml> --call <tool_call.json|-> [--context-envelope <context_envelope.json>] [--adapter mcp|openai|anthropic|langchain|claude_code] [--profile standard|oss-prod] [--job-root ./gait-out/jobs] [--trace-out trace.json] [--run-id run_...] [--runpack-out runpack.zip] [--pack-out pack_run.zip] [--export-log-out events.jsonl] [--export-otel-out otel.jsonl] [--key-mode dev|prod] [--private-key <path>|--private-key-env <VAR>] [--json] [--explain]")
 }
 
 func printMCPVerifyUsage() {

--- a/cmd/gait/mcp_server.go
+++ b/cmd/gait/mcp_server.go
@@ -445,19 +445,20 @@ func evaluateMCPServeRequest(config mcpServeConfig, writer http.ResponseWriter, 
 	}
 
 	output, exitCode, evalErr := evaluateMCPProxyPayload(config.PolicyPath, callPayload, mcpProxyEvalOptions{
-		Adapter:       adapter,
-		Profile:       config.Profile,
-		JobRoot:       config.JobRoot,
-		RunID:         input.RunID,
-		TracePath:     tracePath,
-		RunpackOut:    runpackPath,
-		PackOut:       packPath,
-		AutoPackDir:   config.PackDir,
-		LogExportPath: config.LogExportPath,
-		OTelExport:    config.OTelExport,
-		KeyMode:       config.KeyMode,
-		PrivateKey:    config.PrivateKey,
-		PrivateKeyEnv: config.PrivateKeyEnv,
+		Adapter:                    adapter,
+		Profile:                    config.Profile,
+		JobRoot:                    config.JobRoot,
+		RunID:                      input.RunID,
+		TracePath:                  tracePath,
+		RunpackOut:                 runpackPath,
+		PackOut:                    packPath,
+		AutoPackDir:                config.PackDir,
+		LogExportPath:              config.LogExportPath,
+		OTelExport:                 config.OTelExport,
+		KeyMode:                    config.KeyMode,
+		PrivateKey:                 config.PrivateKey,
+		PrivateKeyEnv:              config.PrivateKeyEnv,
+		AllowLocalContextArtifacts: config.AllowClientArtifactPaths,
 	})
 	if evalErr != nil {
 		return mcpServeEvaluateResponse{}, evalErr

--- a/cmd/gait/mcp_server_test.go
+++ b/cmd/gait/mcp_server_test.go
@@ -536,6 +536,82 @@ func TestMCPServeHandlerRejectsClientArtifactPathOverridesByDefault(t *testing.T
 	}
 }
 
+func TestMCPServeHandlerRejectsContextEnvelopePathOverridesByDefault(t *testing.T) {
+	workDir := t.TempDir()
+	policyPath := filepath.Join(workDir, "policy.yaml")
+	mustWriteFile(t, policyPath, "default_verdict: allow\n")
+	handler, err := newMCPServeHandler(mcpServeConfig{
+		PolicyPath:        policyPath,
+		DefaultAdapter:    "mcp",
+		TraceDir:          filepath.Join(workDir, "traces"),
+		SessionDir:        filepath.Join(workDir, "sessions"),
+		MaxRequestBytes:   1 << 20,
+		HTTPVerdictStatus: "compat",
+		KeyMode:           "dev",
+	})
+	if err != nil {
+		t.Fatalf("newMCPServeHandler: %v", err)
+	}
+
+	requestBody := []byte(`{
+	  "call":{
+	    "name":"tool.search",
+	    "args":{"query":"gait"},
+	    "context":{"identity":"alice","workspace":"/repo/gait","session_id":"sess-1","context_envelope_path":"/tmp/ctx.json"}
+	  }
+	}`)
+	request := httptest.NewRequest(http.MethodPost, "/v1/evaluate", bytes.NewReader(requestBody))
+	request.Header.Set("content-type", "application/json")
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, request)
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("expected %d got %d body=%s", http.StatusBadRequest, recorder.Code, recorder.Body.String())
+	}
+}
+
+func TestMCPServeHandlerRejectsContextEnvelopePathEvenWhenArtifactPathsEnabled(t *testing.T) {
+	workDir := t.TempDir()
+	policyPath := filepath.Join(workDir, "policy.yaml")
+	mustWriteFile(t, policyPath, `default_verdict: block
+rules:
+  - name: allow-write-with-context
+    effect: allow
+    require_context_evidence: true
+    max_context_age_seconds: 30
+    match:
+      tool_names: [tool.write]
+`)
+	handler, err := newMCPServeHandler(mcpServeConfig{
+		PolicyPath:               policyPath,
+		DefaultAdapter:           "mcp",
+		TraceDir:                 filepath.Join(workDir, "traces"),
+		SessionDir:               filepath.Join(workDir, "sessions"),
+		AllowClientArtifactPaths: true,
+		MaxRequestBytes:          1 << 20,
+		HTTPVerdictStatus:        "compat",
+		KeyMode:                  "dev",
+	})
+	if err != nil {
+		t.Fatalf("newMCPServeHandler: %v", err)
+	}
+
+	requestBody := []byte(`{
+	  "call":{
+	    "name":"tool.write",
+	    "args":{"path":"/tmp/out.txt"},
+	    "targets":[{"kind":"path","value":"/tmp/out.txt","operation":"write"}],
+	    "context":{"identity":"alice","workspace":"/repo/gait","risk_class":"high","session_id":"sess-1","context_envelope_path":"/tmp/ctx.json"}
+	  }
+	}`)
+	request := httptest.NewRequest(http.MethodPost, "/v1/evaluate", bytes.NewReader(requestBody))
+	request.Header.Set("content-type", "application/json")
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, request)
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("expected %d got %d body=%s", http.StatusBadRequest, recorder.Code, recorder.Body.String())
+	}
+}
+
 func TestMCPServeHandlerAllowsClientArtifactPathOverridesWhenEnabled(t *testing.T) {
 	workDir := t.TempDir()
 	policyPath := filepath.Join(workDir, "policy.yaml")

--- a/cmd/gait/mcp_test.go
+++ b/cmd/gait/mcp_test.go
@@ -8,9 +8,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Clyra-AI/gait/core/contextproof"
 	"github.com/Clyra-AI/gait/core/gate"
 	"github.com/Clyra-AI/gait/core/jobruntime"
 	"github.com/Clyra-AI/gait/core/mcp"
+	schemacontext "github.com/Clyra-AI/gait/core/schema/v1/context"
 	schemagate "github.com/Clyra-AI/gait/core/schema/v1/gate"
 )
 
@@ -564,6 +566,100 @@ func TestRunMCPProxyOSSProdOAuthEvidenceValidation(t *testing.T) {
 		"--json",
 	}); code != exitOK {
 		t.Fatalf("runMCPProxy oauth valid evidence expected %d got %d", exitOK, code)
+	}
+}
+
+func TestRunMCPProxyRequiresVerifiedContextEnvelopeForContextPolicies(t *testing.T) {
+	workDir := t.TempDir()
+	withWorkingDir(t, workDir)
+
+	privateKeyPath := filepath.Join(workDir, "trace_private.key")
+	writePrivateKey(t, privateKeyPath)
+
+	policyPath := filepath.Join(workDir, "policy_context.yaml")
+	mustWriteFile(t, policyPath, `default_verdict: block
+rules:
+  - name: allow-write-with-context
+    effect: allow
+    require_context_evidence: true
+    max_context_age_seconds: 30
+    match:
+      tool_names: [tool.write]
+`)
+
+	callPath := filepath.Join(workDir, "call.json")
+	mustWriteFile(t, callPath, `{
+  "name":"tool.write",
+  "args":{"path":"/tmp/out.txt"},
+  "targets":[{"kind":"path","value":"/tmp/out.txt","operation":"write"}],
+  "context":{"identity":"alice","workspace":"/repo/gait","risk_class":"high","session_id":"sess-1"}
+}`)
+	if code := runMCPProxy([]string{
+		"--policy", policyPath,
+		"--call", callPath,
+		"--key-mode", "prod",
+		"--private-key", privateKeyPath,
+		"--json",
+	}); code != exitPolicyBlocked {
+		t.Fatalf("runMCPProxy without context envelope expected %d got %d", exitPolicyBlocked, code)
+	}
+
+	envelope, err := contextproof.BuildEnvelope([]schemacontext.ReferenceRecord{
+		{
+			RefID:         "ctx-1",
+			SourceType:    "doc",
+			SourceLocator: "file:///repo/context.md",
+			QueryDigest:   strings.Repeat("1", 64),
+			ContentDigest: strings.Repeat("2", 64),
+			RetrievedAt:   time.Now().UTC().Add(-5 * time.Second),
+			RedactionMode: contextproof.PrivacyModeHashes,
+			Immutability:  "immutable",
+		},
+	}, contextproof.BuildEnvelopeOptions{
+		ContextSetID:    "ctx-set-1",
+		EvidenceMode:    contextproof.EvidenceModeRequired,
+		ProducerVersion: "test",
+		CreatedAt:       time.Now().UTC(),
+	})
+	if err != nil {
+		t.Fatalf("build envelope: %v", err)
+	}
+	envelopePath := filepath.Join(workDir, "context_envelope.json")
+	envelopeBytes, err := json.MarshalIndent(envelope, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal envelope: %v", err)
+	}
+	mustWriteFile(t, envelopePath, string(envelopeBytes)+"\n")
+	mustWriteFile(t, callPath, `{
+  "name":"tool.write",
+  "args":{"path":"/tmp/out.txt"},
+  "targets":[{"kind":"path","value":"/tmp/out.txt","operation":"write"}],
+  "context":{
+    "identity":"alice",
+    "workspace":"/repo/gait",
+    "risk_class":"high",
+    "session_id":"sess-1"
+  }
+}`)
+
+	raw := captureStdout(t, func() {
+		if code := runMCPProxy([]string{
+			"--policy", policyPath,
+			"--call", callPath,
+			"--context-envelope", envelopePath,
+			"--key-mode", "prod",
+			"--private-key", privateKeyPath,
+			"--json",
+		}); code != exitOK {
+			t.Fatalf("runMCPProxy with context envelope expected %d got %d", exitOK, code)
+		}
+	})
+	var out mcpProxyOutput
+	if err := json.Unmarshal([]byte(raw), &out); err != nil {
+		t.Fatalf("decode mcp output: %v raw=%q", err, raw)
+	}
+	if out.Verdict != "allow" {
+		t.Fatalf("expected allow with verified context envelope, got %#v", out)
 	}
 }
 

--- a/cmd/gait/run_record.go
+++ b/cmd/gait/run_record.go
@@ -167,21 +167,37 @@ func runRecord(arguments []string) int {
 	signingKey := sign.KeyPair{}
 	signingWarnings := []string{}
 	if strings.TrimSpace(contextEnvelopePath) != "" {
-		envelope, loadErr := contextproof.LoadEnvelope(strings.TrimSpace(contextEnvelopePath))
+		trimmedEnvelopePath := filepath.Clean(strings.TrimSpace(contextEnvelopePath))
+		if trimmedEnvelopePath == "" {
+			return writeRunRecordOutput(jsonOutput, runRecordOutput{OK: false, Error: "context envelope path is required"}, exitInvalidInput)
+		}
+		if !filepath.IsAbs(trimmedEnvelopePath) && !filepath.IsLocal(trimmedEnvelopePath) {
+			return writeRunRecordOutput(jsonOutput, runRecordOutput{OK: false, Error: "context envelope path must be a local filesystem path"}, exitInvalidInput)
+		}
+		// #nosec G304 -- context envelope path is explicit local user input.
+		rawEnvelope, loadErr := os.ReadFile(trimmedEnvelopePath)
 		if loadErr != nil {
 			if normalizedContextEvidenceMode == contextproof.EvidenceModeRequired {
-				return writeRunRecordOutput(jsonOutput, runRecordOutput{OK: false, Error: loadErr.Error()}, exitInvalidInput)
+				return writeRunRecordOutput(jsonOutput, runRecordOutput{OK: false, Error: fmt.Errorf("read context envelope: %w", loadErr).Error()}, exitInvalidInput)
 			}
-			signingWarnings = append(signingWarnings, "context envelope ignored: "+loadErr.Error())
+			signingWarnings = append(signingWarnings, "context envelope ignored: "+fmt.Errorf("read context envelope: %w", loadErr).Error())
 		} else {
-			envelope.EvidenceMode = normalizedContextEvidenceMode
-			if !unsafeContextRaw && hasRawContextRecord(envelope.Records) {
-				return writeRunRecordOutput(jsonOutput, runRecordOutput{
-					OK:    false,
-					Error: "context envelope includes redaction_mode=raw; re-run with --unsafe-context-raw to allow unsafe context capture",
-				}, exitInvalidInput)
+			envelope, parseErr := contextproof.ParseEnvelope(rawEnvelope)
+			if parseErr != nil {
+				if normalizedContextEvidenceMode == contextproof.EvidenceModeRequired {
+					return writeRunRecordOutput(jsonOutput, runRecordOutput{OK: false, Error: parseErr.Error()}, exitInvalidInput)
+				}
+				signingWarnings = append(signingWarnings, "context envelope ignored: "+parseErr.Error())
+			} else {
+				envelope.EvidenceMode = normalizedContextEvidenceMode
+				if !unsafeContextRaw && hasRawContextRecord(envelope.Records) {
+					return writeRunRecordOutput(jsonOutput, runRecordOutput{
+						OK:    false,
+						Error: "context envelope includes redaction_mode=raw; re-run with --unsafe-context-raw to allow unsafe context capture",
+					}, exitInvalidInput)
+				}
+				contextproof.ApplyEnvelopeToRefs(&recordInput.Refs, envelope)
 			}
-			contextproof.ApplyEnvelopeToRefs(&recordInput.Refs, envelope)
 		}
 	}
 	if !unsafeContextRaw && hasRawContextReceipts(recordInput.Refs.Receipts) {

--- a/cmd/gait/verify.go
+++ b/cmd/gait/verify.go
@@ -648,7 +648,7 @@ func printUsage() {
 	fmt.Println("  gait doctor [--production-readiness] [--json] [--explain]")
 	fmt.Println("  gait doctor adoption --from <events.jsonl> [--json] [--explain]")
 	fmt.Println("  gait list-scripts --registry <registry.json> [--json] [--explain]")
-	fmt.Println("  gait gate eval --policy <policy.yaml> --intent <intent.json> [--profile standard|oss-prod] [--simulate] [--approval-token <token.json>] [--approval-token-chain <csv>] [--credential-broker off|stub|env|command] [--json] [--explain]")
+	fmt.Println("  gait gate eval --policy <policy.yaml> --intent <intent.json> [--context-envelope <context_envelope.json>] [--profile standard|oss-prod] [--simulate] [--approval-token <token.json>] [--approval-token-chain <csv>] [--credential-broker off|stub|env|command] [--json] [--explain]")
 	fmt.Println("  gait policy init <baseline-lowrisk|baseline-mediumrisk|baseline-highrisk> [--out gait.policy.yaml] [--force] [--json] [--explain]")
 	fmt.Println("  gait policy validate <policy.yaml> [--json] [--explain]")
 	fmt.Println("  gait policy fmt <policy.yaml> [--write] [--json] [--explain]")

--- a/core/contextproof/contextproof.go
+++ b/core/contextproof/contextproof.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"os"
 	"regexp"
 	"sort"
 	"strings"
@@ -49,6 +48,9 @@ func NormalizeEvidenceMode(mode string) (string, error) {
 }
 
 func ParseEnvelope(payload []byte) (schemacontext.Envelope, error) {
+	if int64(len(payload)) > MaxEnvelopeBytes {
+		return schemacontext.Envelope{}, fmt.Errorf("context envelope exceeds size limit (%d bytes)", MaxEnvelopeBytes)
+	}
 	var envelope schemacontext.Envelope
 	decoder := json.NewDecoder(bytes.NewReader(payload))
 	decoder.DisallowUnknownFields()
@@ -56,25 +58,6 @@ func ParseEnvelope(payload []byte) (schemacontext.Envelope, error) {
 		return schemacontext.Envelope{}, fmt.Errorf("parse context envelope: %w", err)
 	}
 	return NormalizeEnvelope(envelope)
-}
-
-func LoadEnvelope(path string) (schemacontext.Envelope, error) {
-	info, err := os.Stat(path)
-	if err != nil {
-		return schemacontext.Envelope{}, fmt.Errorf("stat context envelope: %w", err)
-	}
-	if info.Size() > MaxEnvelopeBytes {
-		return schemacontext.Envelope{}, fmt.Errorf("context envelope exceeds size limit (%d bytes)", MaxEnvelopeBytes)
-	}
-	// #nosec G304 -- path is explicit local user input.
-	payload, err := os.ReadFile(path)
-	if err != nil {
-		return schemacontext.Envelope{}, fmt.Errorf("read context envelope: %w", err)
-	}
-	if int64(len(payload)) > MaxEnvelopeBytes {
-		return schemacontext.Envelope{}, fmt.Errorf("context envelope exceeds size limit (%d bytes)", MaxEnvelopeBytes)
-	}
-	return ParseEnvelope(payload)
 }
 
 type BuildEnvelopeOptions struct {

--- a/core/contextproof/contextproof_test.go
+++ b/core/contextproof/contextproof_test.go
@@ -141,7 +141,11 @@ func TestLoadEnvelopeRejectsOversizedPayload(t *testing.T) {
 	if err := os.WriteFile(path, []byte(oversized), 0o600); err != nil {
 		t.Fatalf("write oversized payload: %v", err)
 	}
-	if _, err := LoadEnvelope(path); err == nil || !strings.Contains(err.Error(), "size limit") {
+	payload, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read oversized payload: %v", err)
+	}
+	if _, err := ParseEnvelope(payload); err == nil || !strings.Contains(err.Error(), "size limit") {
 		t.Fatalf("expected size limit error, got %v", err)
 	}
 }
@@ -317,8 +321,8 @@ func TestApplyEnvelopeToRefsAndVerify(t *testing.T) {
 }
 
 func TestLoadEnvelopePathCases(t *testing.T) {
-	if _, err := LoadEnvelope(filepath.Join(t.TempDir(), "missing.json")); err == nil {
-		t.Fatalf("expected missing envelope to fail")
+	if _, err := os.ReadFile(filepath.Join(t.TempDir(), "missing.json")); err == nil {
+		t.Fatalf("expected missing envelope read to fail")
 	}
 
 	envelope, err := BuildEnvelope([]schemacontext.ReferenceRecord{
@@ -346,9 +350,13 @@ func TestLoadEnvelopePathCases(t *testing.T) {
 	if err := os.WriteFile(path, raw, 0o600); err != nil {
 		t.Fatalf("write envelope file: %v", err)
 	}
-	loaded, err := LoadEnvelope(path)
+	payload, err := os.ReadFile(path)
 	if err != nil {
-		t.Fatalf("load envelope: %v", err)
+		t.Fatalf("read envelope file: %v", err)
+	}
+	loaded, err := ParseEnvelope(payload)
+	if err != nil {
+		t.Fatalf("parse envelope: %v", err)
 	}
 	if loaded.ContextSetDigest != envelope.ContextSetDigest {
 		t.Fatalf("loaded digest mismatch")

--- a/core/gate/context_evidence.go
+++ b/core/gate/context_evidence.go
@@ -1,0 +1,165 @@
+package gate
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/Clyra-AI/gait/core/contextproof"
+	schemacontext "github.com/Clyra-AI/gait/core/schema/v1/context"
+	schemagate "github.com/Clyra-AI/gait/core/schema/v1/gate"
+)
+
+const verifiedContextSource = "context_envelope"
+
+func prepareIntentForEvaluation(intent schemagate.IntentRequest, opts EvalOptions) (schemagate.IntentRequest, string, error) {
+	normalizedIntent, err := NormalizeIntent(intent)
+	if err != nil {
+		return schemagate.IntentRequest{}, "", err
+	}
+
+	contextSource := ""
+	if opts.VerifiedContextEnvelope != nil {
+		normalizedIntent, err = bindVerifiedContextEnvelope(normalizedIntent, *opts.VerifiedContextEnvelope, opts.ContextEvidenceNow)
+		if err != nil {
+			return schemagate.IntentRequest{}, "", err
+		}
+		contextSource = verifiedContextSource
+	} else {
+		normalizedIntent = stripContextEvidenceClaims(normalizedIntent)
+	}
+	return normalizedIntent, contextSource, nil
+}
+
+func stripContextEvidenceClaims(intent schemagate.IntentRequest) schemagate.IntentRequest {
+	output := intent
+	output.Context.ContextSetDigest = ""
+	output.Context.ContextEvidenceMode = ""
+	output.Context.ContextRefs = nil
+	if len(output.Context.AuthContext) == 0 {
+		return output
+	}
+
+	authContext := cloneAuthContext(output.Context.AuthContext)
+	delete(authContext, "context_age_seconds")
+	if len(authContext) == 0 {
+		output.Context.AuthContext = nil
+		return output
+	}
+	output.Context.AuthContext = authContext
+	return output
+}
+
+func bindVerifiedContextEnvelope(intent schemagate.IntentRequest, envelope schemacontext.Envelope, now time.Time) (schemagate.IntentRequest, error) {
+	normalizedEnvelope, err := contextproof.NormalizeEnvelope(envelope)
+	if err != nil {
+		return schemagate.IntentRequest{}, fmt.Errorf("verify context envelope: %w", err)
+	}
+	resolvedNow := now.UTC()
+	if resolvedNow.IsZero() {
+		resolvedNow = time.Now().UTC()
+	}
+
+	output := intent
+	if digestClaim := strings.TrimSpace(output.Context.ContextSetDigest); digestClaim != "" && !strings.EqualFold(digestClaim, normalizedEnvelope.ContextSetDigest) {
+		return schemagate.IntentRequest{}, fmt.Errorf("context envelope digest does not match context.context_set_digest")
+	}
+	if modeClaim := strings.TrimSpace(output.Context.ContextEvidenceMode); modeClaim != "" && !strings.EqualFold(modeClaim, normalizedEnvelope.EvidenceMode) {
+		return schemagate.IntentRequest{}, fmt.Errorf("context envelope evidence mode does not match context.context_evidence_mode")
+	}
+
+	output = stripContextEvidenceClaims(output)
+	output.Context.ContextSetDigest = normalizedEnvelope.ContextSetDigest
+	output.Context.ContextEvidenceMode = normalizedEnvelope.EvidenceMode
+	output.Context.ContextRefs = envelopeContextRefs(normalizedEnvelope)
+	authContext := cloneAuthContext(output.Context.AuthContext)
+	if authContext == nil {
+		authContext = map[string]any{}
+	}
+	authContext["context_age_seconds"] = envelopeContextAgeSeconds(normalizedEnvelope, resolvedNow)
+	output.Context.AuthContext = authContext
+	return output, nil
+}
+
+func envelopeContextRefs(envelope schemacontext.Envelope) []string {
+	if len(envelope.Records) == 0 {
+		return nil
+	}
+	refs := make([]string, 0, len(envelope.Records))
+	seen := make(map[string]struct{}, len(envelope.Records))
+	for _, record := range envelope.Records {
+		refID := strings.TrimSpace(record.RefID)
+		if refID == "" {
+			continue
+		}
+		if _, ok := seen[refID]; ok {
+			continue
+		}
+		seen[refID] = struct{}{}
+		refs = append(refs, refID)
+	}
+	sort.Strings(refs)
+	if len(refs) == 0 {
+		return nil
+	}
+	return refs
+}
+
+func envelopeContextAgeSeconds(envelope schemacontext.Envelope, now time.Time) int64 {
+	if len(envelope.Records) == 0 {
+		return contextAgeSecondsFromTime(envelope.CreatedAt.UTC(), now)
+	}
+	var maxAge int64
+	for _, record := range envelope.Records {
+		age := contextAgeSecondsFromTime(record.RetrievedAt.UTC(), now)
+		if age > maxAge {
+			maxAge = age
+		}
+	}
+	return maxAge
+}
+
+func contextAgeSecondsFromTime(value time.Time, now time.Time) int64 {
+	if value.IsZero() {
+		return 0
+	}
+	if value.After(now) {
+		return 0
+	}
+	return int64(now.Sub(value) / time.Second)
+}
+
+func mergeContextSource(current string, extra string) string {
+	parts := make([]string, 0, 2)
+	seen := map[string]struct{}{}
+	for _, value := range []string{current, extra} {
+		trimmed := strings.TrimSpace(value)
+		if trimmed == "" {
+			continue
+		}
+		if _, ok := seen[trimmed]; ok {
+			continue
+		}
+		seen[trimmed] = struct{}{}
+		parts = append(parts, trimmed)
+	}
+	sort.Strings(parts)
+	return strings.Join(parts, ",")
+}
+
+func PolicyRequiresContextEvidence(policy Policy) bool {
+	normalizedPolicy, err := normalizePolicy(policy)
+	if err != nil {
+		return false
+	}
+	if contains(normalizedPolicy.FailClosed.RequiredFields, "context_evidence") {
+		return true
+	}
+	for _, rule := range normalizedPolicy.Rules {
+		if rule.RequireContextEvidence || rule.RequiredContextEvidenceMode == "required" || rule.MaxContextAgeSeconds > 0 {
+			return true
+		}
+	}
+	return false
+}

--- a/core/gate/context_evidence_test.go
+++ b/core/gate/context_evidence_test.go
@@ -47,8 +47,17 @@ rules:
 	if !contains(outcome.Result.ReasonCodes, "context_freshness_exceeded") {
 		t.Fatalf("expected context_freshness_exceeded, got %#v", outcome.Result.ReasonCodes)
 	}
+	if outcome.PreparedIntent.ToolName != intent.ToolName {
+		t.Fatalf("expected prepared intent tool name %q, got %q", intent.ToolName, outcome.PreparedIntent.ToolName)
+	}
+	if len(outcome.PreparedIntent.Targets) != len(intent.Targets) {
+		t.Fatalf("expected prepared intent targets %#v, got %#v", intent.Targets, outcome.PreparedIntent.Targets)
+	}
 	if outcome.PreparedIntent.Context.ContextSetDigest != "" {
 		t.Fatalf("expected prepared intent to strip unverified context digest, got %q", outcome.PreparedIntent.Context.ContextSetDigest)
+	}
+	if outcome.PreparedIntent.Context.ContextEvidenceMode != "" {
+		t.Fatalf("expected prepared intent to strip unverified context evidence mode, got %q", outcome.PreparedIntent.Context.ContextEvidenceMode)
 	}
 }
 

--- a/core/gate/context_evidence_test.go
+++ b/core/gate/context_evidence_test.go
@@ -1,0 +1,141 @@
+package gate
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Clyra-AI/gait/core/contextproof"
+	schemacontext "github.com/Clyra-AI/gait/core/schema/v1/context"
+	schemagate "github.com/Clyra-AI/gait/core/schema/v1/gate"
+)
+
+func TestEvaluatePolicyDetailedIgnoresUnverifiedContextEvidenceClaims(t *testing.T) {
+	policy, err := ParsePolicyYAML([]byte(`
+default_verdict: block
+rules:
+  - name: allow-with-context-proof
+    priority: 10
+    effect: allow
+    require_context_evidence: true
+    max_context_age_seconds: 30
+    match:
+      tool_names: [tool.write]
+`))
+	if err != nil {
+		t.Fatalf("parse policy: %v", err)
+	}
+
+	intent := baseIntent()
+	intent.ToolName = "tool.write"
+	intent.Args = map[string]any{"path": "/tmp/out.txt"}
+	intent.Targets = []schemagate.IntentTarget{{Kind: "path", Value: "/tmp/out.txt", Operation: "write", EndpointClass: "fs.write"}}
+	intent.Context.ContextSetDigest = strings.Repeat("a", 64)
+	intent.Context.ContextEvidenceMode = contextproof.EvidenceModeRequired
+	intent.Context.AuthContext = map[string]any{"context_age_seconds": int64(1)}
+
+	outcome, err := EvaluatePolicyDetailed(policy, intent, EvalOptions{})
+	if err != nil {
+		t.Fatalf("evaluate policy detailed: %v", err)
+	}
+	if outcome.Result.Verdict != "block" {
+		t.Fatalf("expected unverified context evidence claims to fail closed, got %#v", outcome.Result)
+	}
+	if !contains(outcome.Result.ReasonCodes, "context_evidence_missing") {
+		t.Fatalf("expected context_evidence_missing, got %#v", outcome.Result.ReasonCodes)
+	}
+	if !contains(outcome.Result.ReasonCodes, "context_freshness_exceeded") {
+		t.Fatalf("expected context_freshness_exceeded, got %#v", outcome.Result.ReasonCodes)
+	}
+	if outcome.PreparedIntent.Context.ContextSetDigest != "" {
+		t.Fatalf("expected prepared intent to strip unverified context digest, got %q", outcome.PreparedIntent.Context.ContextSetDigest)
+	}
+}
+
+func TestEvaluatePolicyDetailedAcceptsVerifiedContextEnvelope(t *testing.T) {
+	policy, err := ParsePolicyYAML([]byte(`
+default_verdict: block
+rules:
+  - name: allow-with-context-proof
+    priority: 10
+    effect: allow
+    require_context_evidence: true
+    max_context_age_seconds: 30
+    match:
+      tool_names: [tool.write]
+`))
+	if err != nil {
+		t.Fatalf("parse policy: %v", err)
+	}
+
+	now := time.Date(2026, time.March, 12, 12, 0, 0, 0, time.UTC)
+	envelope := mustBuildTestContextEnvelope(t, now.Add(-5*time.Second))
+	intent := baseIntent()
+	intent.ToolName = "tool.write"
+	intent.Args = map[string]any{"path": "/tmp/out.txt"}
+	intent.Targets = []schemagate.IntentTarget{{Kind: "path", Value: "/tmp/out.txt", Operation: "write", EndpointClass: "fs.write"}}
+
+	outcome, err := EvaluatePolicyDetailed(policy, intent, EvalOptions{
+		VerifiedContextEnvelope: &envelope,
+		ContextEvidenceNow:      now,
+	})
+	if err != nil {
+		t.Fatalf("evaluate policy detailed: %v", err)
+	}
+	if outcome.Result.Verdict != "allow" {
+		t.Fatalf("expected verified context envelope to satisfy policy, got %#v", outcome.Result)
+	}
+	if outcome.PreparedIntent.Context.ContextSetDigest != envelope.ContextSetDigest {
+		t.Fatalf("expected prepared intent digest %q, got %q", envelope.ContextSetDigest, outcome.PreparedIntent.Context.ContextSetDigest)
+	}
+	if outcome.PreparedIntent.Context.ContextEvidenceMode != envelope.EvidenceMode {
+		t.Fatalf("expected prepared intent mode %q, got %q", envelope.EvidenceMode, outcome.PreparedIntent.Context.ContextEvidenceMode)
+	}
+	if len(outcome.PreparedIntent.Context.ContextRefs) != len(envelope.Records) {
+		t.Fatalf("expected context refs to reflect envelope records, got %#v", outcome.PreparedIntent.Context.ContextRefs)
+	}
+	if outcome.ContextSource != verifiedContextSource {
+		t.Fatalf("expected verified context source %q, got %q", verifiedContextSource, outcome.ContextSource)
+	}
+}
+
+func TestEvaluatePolicyDetailedRejectsConflictingVerifiedContextEnvelope(t *testing.T) {
+	now := time.Date(2026, time.March, 12, 12, 0, 0, 0, time.UTC)
+	envelope := mustBuildTestContextEnvelope(t, now.Add(-5*time.Second))
+	intent := baseIntent()
+	intent.ToolName = "tool.write"
+	intent.Context.ContextSetDigest = strings.Repeat("b", 64)
+
+	_, err := EvaluatePolicyDetailed(Policy{DefaultVerdict: "allow"}, intent, EvalOptions{
+		VerifiedContextEnvelope: &envelope,
+		ContextEvidenceNow:      now,
+	})
+	if err == nil || !strings.Contains(err.Error(), "context envelope digest does not match") {
+		t.Fatalf("expected digest conflict error, got %v", err)
+	}
+}
+
+func mustBuildTestContextEnvelope(t *testing.T, retrievedAt time.Time) schemacontext.Envelope {
+	t.Helper()
+	envelope, err := contextproof.BuildEnvelope([]schemacontext.ReferenceRecord{
+		{
+			RefID:         "ctx-1",
+			SourceType:    "doc",
+			SourceLocator: "file:///repo/context.md",
+			QueryDigest:   strings.Repeat("1", 64),
+			ContentDigest: strings.Repeat("2", 64),
+			RetrievedAt:   retrievedAt,
+			RedactionMode: contextproof.PrivacyModeHashes,
+			Immutability:  "immutable",
+		},
+	}, contextproof.BuildEnvelopeOptions{
+		ContextSetID:    "ctx-set-1",
+		EvidenceMode:    contextproof.EvidenceModeRequired,
+		ProducerVersion: "test",
+		CreatedAt:       retrievedAt,
+	})
+	if err != nil {
+		t.Fatalf("build envelope: %v", err)
+	}
+	return envelope
+}

--- a/core/gate/policy.go
+++ b/core/gate/policy.go
@@ -300,7 +300,8 @@ func EvaluatePolicyDetailed(policy Policy, intent schemagate.IntentRequest, opts
 		violations = mergeUniqueSorted(violations, endpointViolations)
 		if len(reasons) > 0 {
 			return EvalOutcome{
-				Result: buildGateResult(normalizedPolicy, normalizedIntent, opts, "block", reasons, violations),
+				Result:         buildGateResult(normalizedPolicy, normalizedIntent, opts, "block", reasons, violations),
+				PreparedIntent: normalizedIntent,
 			}, nil
 		}
 	}

--- a/core/gate/policy.go
+++ b/core/gate/policy.go
@@ -13,6 +13,7 @@ import (
 	gaitjcs "github.com/Clyra-AI/proof/canon"
 	"github.com/goccy/go-yaml"
 
+	schemacontext "github.com/Clyra-AI/gait/core/schema/v1/context"
 	schemagate "github.com/Clyra-AI/gait/core/schema/v1/gate"
 )
 
@@ -183,13 +184,16 @@ type ToolAnnotationMatch struct {
 }
 
 type EvalOptions struct {
-	ProducerVersion string
-	WrkrInventory   map[string]WrkrToolMetadata
-	WrkrSource      string
+	ProducerVersion         string
+	WrkrInventory           map[string]WrkrToolMetadata
+	WrkrSource              string
+	VerifiedContextEnvelope *schemacontext.Envelope
+	ContextEvidenceNow      time.Time
 }
 
 type EvalOutcome struct {
 	Result                   schemagate.GateResult
+	PreparedIntent           schemagate.IntentRequest
 	MatchedRule              string
 	MinApprovals             int
 	RequireDistinctApprovers bool
@@ -279,7 +283,7 @@ func EvaluatePolicyDetailed(policy Policy, intent schemagate.IntentRequest, opts
 		return EvalOutcome{}, err
 	}
 
-	normalizedIntent, err := NormalizeIntent(intent)
+	normalizedIntent, verifiedContextSource, err := prepareIntentForEvaluation(intent, opts)
 	if err != nil {
 		if shouldFailClosed(normalizedPolicy.FailClosed, strings.ToLower(strings.TrimSpace(intent.Context.RiskClass))) {
 			return EvalOutcome{
@@ -310,8 +314,12 @@ func EvaluatePolicyDetailed(policy Policy, intent schemagate.IntentRequest, opts
 	if err != nil {
 		return EvalOutcome{}, err
 	}
+	outcome.PreparedIntent = enrichedIntent
+	if verifiedContextSource != "" {
+		outcome.ContextSource = mergeContextSource(outcome.ContextSource, verifiedContextSource)
+	}
 	if contextApplied {
-		outcome.ContextSource = resolveWrkrSource(opts.WrkrSource)
+		outcome.ContextSource = mergeContextSource(outcome.ContextSource, resolveWrkrSource(opts.WrkrSource))
 	}
 	return outcome, nil
 }
@@ -364,6 +372,7 @@ func evaluateSingleIntent(policy Policy, intent schemagate.IntentRequest, opts E
 		}
 		return EvalOutcome{
 			Result:                   buildGateResult(policy, intent, opts, effect, reasons, violations),
+			PreparedIntent:           intent,
 			MatchedRule:              rule.Name,
 			MinApprovals:             minApprovals,
 			RequireDistinctApprovers: rule.RequireDistinctApprovers,
@@ -390,7 +399,8 @@ func evaluateSingleIntent(policy Policy, intent schemagate.IntentRequest, opts E
 			[]string{"default_" + policy.DefaultVerdict},
 			[]string{},
 		),
-		MinApprovals: minApprovals,
+		PreparedIntent: intent,
+		MinApprovals:   minApprovals,
 	}, nil
 }
 
@@ -414,6 +424,9 @@ func evaluateScriptPolicyDetailed(policy Policy, intent schemagate.IntentRequest
 	aggregatedRateLimit := RateLimitPolicy{}
 	aggregatedDestructiveBudget := RateLimitPolicy{}
 	contextSource := ""
+	if opts.VerifiedContextEnvelope != nil {
+		contextSource = mergeContextSource(contextSource, verifiedContextSource)
+	}
 
 	for index, step := range intent.Script.Steps {
 		stepIntent := intent
@@ -469,7 +482,7 @@ func evaluateScriptPolicyDetailed(policy Policy, intent schemagate.IntentRequest
 		}
 		riskClasses = mergeUniqueSorted(riskClasses, []string{classifyScriptStepRisk(step.Targets)})
 		if contextApplied {
-			contextSource = resolveWrkrSource(opts.WrkrSource)
+			contextSource = mergeContextSource(contextSource, resolveWrkrSource(opts.WrkrSource))
 		}
 	}
 
@@ -514,6 +527,7 @@ func evaluateScriptPolicyDetailed(policy Policy, intent schemagate.IntentRequest
 		RateLimit:                aggregatedRateLimit,
 		DestructiveBudget:        aggregatedDestructiveBudget,
 		DataflowTriggered:        dataflowTriggered,
+		PreparedIntent:           intent,
 		Script:                   true,
 		StepCount:                len(intent.Script.Steps),
 		ScriptHash:               intent.ScriptHash,

--- a/core/mcp/interfaces.go
+++ b/core/mcp/interfaces.go
@@ -76,6 +76,7 @@ type CallContext struct {
 	AuthContext            map[string]any `json:"auth_context,omitempty"`
 	CredentialScopes       []string       `json:"credential_scopes,omitempty"`
 	EnvironmentFingerprint string         `json:"environment_fingerprint,omitempty"`
+	ContextEnvelopePath    string         `json:"context_envelope_path,omitempty"`
 }
 
 type OAuthEvidence struct {

--- a/core/mcp/proxy.go
+++ b/core/mcp/proxy.go
@@ -36,13 +36,16 @@ func EvaluateToolCallWithIntentOptions(policy gate.Policy, call ToolCall, opts g
 	if err != nil {
 		return EvalResult{}, err
 	}
-	normalizedIntent, err := gate.NormalizeIntent(intent)
+	outcome, err := gate.EvaluatePolicyDetailed(policy, intent, opts)
 	if err != nil {
 		return EvalResult{}, err
 	}
-	outcome, err := gate.EvaluatePolicyDetailed(policy, normalizedIntent, opts)
-	if err != nil {
-		return EvalResult{}, err
+	normalizedIntent := outcome.PreparedIntent
+	if normalizedIntent.SchemaID == "" {
+		normalizedIntent, err = gate.NormalizeIntent(intent)
+		if err != nil {
+			return EvalResult{}, err
+		}
 	}
 	outcome = ApplyTrustPolicy(policy.MCPTrust, call, outcome, time.Now().UTC())
 	return EvalResult{

--- a/docs-site/public/llm/contracts.md
+++ b/docs-site/public/llm/contracts.md
@@ -4,7 +4,7 @@ Stable OSS contracts include:
 
 - **PackSpec v1**: Unified portable artifact envelope for run, job, and call evidence with Ed25519 signatures and SHA-256 manifest. Schema: `schemas/v1/pack/manifest.schema.json`.
   - includes first-class export surfaces: `gait pack export --otel-out ...` and `--postgres-sql-out ...` for observability and metadata indexing.
-- **ContextSpec v1**: Deterministic context evidence envelopes with privacy-aware modes and fail-closed enforcement.
+- **ContextSpec v1**: Deterministic context evidence envelopes with privacy-aware modes and fail-closed enforcement. For `gait gate eval`, required context-proof checks are satisfied through a verified `--context-envelope` input rather than raw intent claims.
 - **Primitive Contract**: Four deterministic primitives — capture, enforce, regress, diagnose.
 - **Repo Policy Contract**: `gait init` writes `.gait.yaml`; `gait check` reports the live contract (`default_verdict`, `rule_count`, `gap_warnings`).
 - **MCP Trust + Trace Onboarding**: local MCP trust snapshots and observe-only `gait trace` are additive onboarding contracts over the same signed trace and policy surfaces.

--- a/docs-site/public/llm/security.md
+++ b/docs-site/public/llm/security.md
@@ -10,7 +10,7 @@
 - Approval tokens can carry bounded destructive scope (`max_targets`, `max_ops`); overruns fail closed.
 - Approved-script registry entries are signature-verified and policy-digest bound; tampered or missing state fails closed in high-risk enforcement.
 - SayToken capability tokens for voice agent commitment gating — gated speech cannot execute without a valid token.
-- Context evidence envelopes with fail-closed enforcement when evidence is missing for high-risk actions.
+- Context evidence envelopes with fail-closed enforcement when evidence is missing for high-risk actions; `gait gate eval` requires a verified `--context-envelope` input for context-required policies.
 - Durable jobs with deterministic stop reasons and checkpoint integrity.
 - No hosted service dependency required for core operation.
 - MCP trust inputs remain local-file based and complementary to external scanners or registries; Gait enforces, it does not become the scanner.

--- a/docs-site/public/llms.txt
+++ b/docs-site/public/llms.txt
@@ -9,7 +9,7 @@
 ## Core Commands
 - gait init --json
 - gait check --json
-- gait gate eval --policy <policy.yaml> --intent <intent.json>
+- gait gate eval --policy <policy.yaml> --intent <intent.json> [--context-envelope <context_envelope.json>]
 - gait demo
 - gait verify <run_id|path>
 - gait test -- <child command...>
@@ -52,7 +52,7 @@
 - Offline verification for packs, runpacks, and traces.
 - Structured intent model for policy decisions, not free-form prompt filtering.
 - SayToken capability tokens for voice agent commitment gating.
-- Context evidence envelopes with fail-closed enforcement when evidence is missing.
+- Context evidence envelopes with fail-closed enforcement when evidence is missing, stale, or not supplied through a verified `--context-envelope` gate input.
 - MCP trust stays file-based and offline-first: external tool finds, Gait enforces.
 
 ## Canonical Docs

--- a/docs/agent_integration_boundary.md
+++ b/docs/agent_integration_boundary.md
@@ -28,6 +28,7 @@ What Gait can do:
 
 - full policy enforcement (`allow` only executes)
 - approval/delegation token checks
+- verified context-evidence enforcement when the wrapper or sidecar passes `--context-envelope` for context-required policies
 - signed trace emission
 - runpack/pack capture and regress loop
 
@@ -47,6 +48,7 @@ What Gait can do:
 - enforce decisions at middleware boundary
 - emit signed traces and artifacts
 - provide deterministic CI regression loop
+- enforce authenticated context-proof checks when middleware can supply the local context envelope artifact alongside the gate call
 
 Constraints:
 

--- a/docs/contracts/contextspec_v1.md
+++ b/docs/contracts/contextspec_v1.md
@@ -60,6 +60,8 @@ Optional record fields:
 ## Safety and Enforcement Rules
 
 - `evidence_mode=required` means missing/invalid context evidence blocks high-risk execution paths.
+- For `gait gate eval`, raw `intent.context_set_digest`, `intent.context_evidence_mode`, and `context.auth_context.context_age_seconds` claims are non-authoritative on their own.
+- Required context-proof enforcement at the gate boundary must be satisfied with `--context-envelope <context_envelope.json>` so Gait can verify the envelope and derive digest, mode, and freshness from it.
 - Raw context evidence requires explicit unsafe operator intent:
   - `gait run record --unsafe-context-raw`
 - Gate policies may enforce:
@@ -125,7 +127,11 @@ gait run record \
 Fail-closed context policy evaluation:
 
 ```bash
-gait gate eval --policy ./policy.yaml --intent ./intent.json --json
+gait gate eval \
+  --policy ./policy.yaml \
+  --intent ./intent.json \
+  --context-envelope ./context_envelope.json \
+  --json
 ```
 
 Pack inspect context summary:
@@ -160,7 +166,7 @@ A context envelope is a deterministic JSON artifact that captures what context m
 
 ### When does context evidence fail-closed?
 
-When policy requires context evidence for a high-risk action class and the evidence is missing or stale, the gate blocks execution with an explicit reason code.
+When policy requires context evidence for a high-risk action class and the evidence is missing, stale, or not supplied through a verified context envelope, the gate blocks execution with an explicit reason code.
 
 ### What privacy modes are available?
 

--- a/docs/integration_checklist.md
+++ b/docs/integration_checklist.md
@@ -128,6 +128,8 @@ gait run record \
 - include `require_context_evidence: true`
 - include `required_context_evidence_mode: required`
 - optional `max_context_age_seconds`
+- pass `--context-envelope <context_envelope.json>` on `gait gate eval` whenever those constraints are expected to hold at enforcement time
+- do not rely on raw `intent.context_set_digest` or `context.auth_context.context_age_seconds` claims to satisfy fail-closed gate checks
 - verify deterministic reason codes:
 - `context_evidence_missing`
 - `context_set_digest_missing`

--- a/internal/e2e/v25_context_cli_test.go
+++ b/internal/e2e/v25_context_cli_test.go
@@ -165,7 +165,8 @@ rules:
 	}
 
 	intentPresentPath := filepath.Join(workDir, "intent_present.json")
-	// Fill context digest from inspected pack output for deterministic allow result.
+	// Preserve the recorded digest in the intent payload, but require the verified
+	// context envelope at the gate boundary for the allow path.
 	var intentPresent map[string]any
 	if err := json.Unmarshal([]byte(`{
   "schema_id": "gait.gate.intent_request",
@@ -196,7 +197,7 @@ rules:
 		t.Fatalf("write intent present payload: %v", err)
 	}
 
-	presentGateOut := runJSONCommand(t, workDir, binPath, "gate", "eval", "--policy", policyPath, "--intent", intentPresentPath, "--json")
+	presentGateOut := runJSONCommand(t, workDir, binPath, "gate", "eval", "--policy", policyPath, "--intent", intentPresentPath, "--context-envelope", contextEnvelopePath, "--json")
 	var presentGate struct {
 		OK      bool   `json:"ok"`
 		Verdict string `json:"verdict"`

--- a/internal/integration/contextproof_test.go
+++ b/internal/integration/contextproof_test.go
@@ -180,12 +180,16 @@ rules:
 		},
 	}
 
-	allowResult, err := gate.EvaluatePolicy(policy, intent, gate.EvalOptions{ProducerVersion: "0.0.0-test"})
+	allowOutcome, err := gate.EvaluatePolicyDetailed(policy, intent, gate.EvalOptions{
+		ProducerVersion:         "0.0.0-test",
+		VerifiedContextEnvelope: &envelopeA,
+		ContextEvidenceNow:      createdAt.Add(60 * time.Second),
+	})
 	if err != nil {
 		t.Fatalf("evaluate context-ready intent: %v", err)
 	}
-	if allowResult.Verdict != "allow" {
-		t.Fatalf("expected allow verdict, got %s (%v)", allowResult.Verdict, allowResult.ReasonCodes)
+	if allowOutcome.Result.Verdict != "allow" {
+		t.Fatalf("expected allow verdict, got %s (%v)", allowOutcome.Result.Verdict, allowOutcome.Result.ReasonCodes)
 	}
 
 	intentMissing := intent
@@ -206,7 +210,7 @@ rules:
 		t.Fatalf("generate keypair: %v", err)
 	}
 	tracePath := filepath.Join(workDir, "trace_context.json")
-	traceResult, err := gate.EmitSignedTrace(policy, intent, allowResult, gate.EmitTraceOptions{
+	traceResult, err := gate.EmitSignedTrace(policy, allowOutcome.PreparedIntent, allowOutcome.Result, gate.EmitTraceOptions{
 		ProducerVersion:   "0.0.0-test",
 		SigningPrivateKey: keyPair.Private,
 		TracePath:         tracePath,


### PR DESCRIPTION
## Problem
High-risk tool calls could proceed without deterministic context evidence enforcement across the CLI and MCP boundaries, which weakens the fail-closed contract for context-aware policy evaluation.

## Changes
- add shared gate context-evidence enforcement and tests in `core/gate`
- thread context evidence requirements through CLI, MCP proxy/server, and related integration paths
- update docs and contract references to keep the CLI/docs surface aligned

## Validation
- `./gait doctor --json`
- `make prepush-full`
