### PR TITLE
hotfix: align context acceptance harnesses

### DIFF
--- a/scripts/check_context_budgets.py
+++ b/scripts/check_context_budgets.py
@@ -209,9 +209,6 @@ def operation_gate_eval_context_required(gait: Path, work_dir: Path, _: int) -> 
                     "identity": "alice",
                     "workspace": "/repo/gait",
                     "risk_class": "high",
-                    "context_set_digest": "a" * 64,
-                    "context_evidence_mode": "required",
-                    "context_refs": ["ctx_001"],
                 },
             },
             indent=2,
@@ -219,8 +216,28 @@ def operation_gate_eval_context_required(gait: Path, work_dir: Path, _: int) -> 
         + "\n",
         encoding="utf-8",
     )
+    envelope_path = work_dir / "context_envelope_gate_required.json"
+    envelope_path.write_text(
+        json.dumps(
+            build_envelope("a" * 64, "2026-02-14T00:00:00Z"),
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
     decision = run_json(
-        [str(gait), "gate", "eval", "--policy", str(policy_path), "--intent", str(intent_path), "--json"],
+        [
+            str(gait),
+            "gate",
+            "eval",
+            "--policy",
+            str(policy_path),
+            "--intent",
+            str(intent_path),
+            "--context-envelope",
+            str(envelope_path),
+            "--json",
+        ],
         work_dir,
     )
     if decision.get("verdict") != "allow":

--- a/scripts/test_v2_5_acceptance.sh
+++ b/scripts/test_v2_5_acceptance.sh
@@ -303,7 +303,11 @@ cat >"${TMP_DIR}/intent_present.json" <<JSON
 }
 JSON
 
-"${BIN_PATH}" gate eval --policy "${TMP_DIR}/policy.yaml" --intent "${TMP_DIR}/intent_present.json" --json >"${TMP_DIR}/gate_present.json"
+"${BIN_PATH}" gate eval \
+  --policy "${TMP_DIR}/policy.yaml" \
+  --intent "${TMP_DIR}/intent_present.json" \
+  --context-envelope "${TMP_DIR}/context_envelope.json" \
+  --json >"${TMP_DIR}/gate_present.json"
 python3 - <<'PY' "${TMP_DIR}/gate_present.json"
 import json, sys
 payload = json.load(open(sys.argv[1], encoding="utf-8"))


### PR DESCRIPTION
## Problem
Post-merge `main` CI for PR #78 failed in `v2-5-acceptance` and `runtime-slo` because those harnesses still expected raw `context_*` intent claims to satisfy context-evidence enforcement without a verified envelope.

## Changes
- update the v2.5 acceptance allow-path to pass the verified context envelope to `gait gate eval`
- update the context budget benchmark to measure the verified-envelope path and remove stale synthetic context claims that now conflict with envelope binding

## Validation
- `make test-v2-5-acceptance`
- `make test-runtime-slo`
- `make prepush-full`
