### PR TITLE
W2: harden durable job mutations and diagnostics

### DIFF
--- a/cmd/gait/job_cli_test.go
+++ b/cmd/gait/job_cli_test.go
@@ -7,6 +7,9 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/Clyra-AI/gait/core/jobruntime"
 )
 
 func TestRunJobLifecycleCommands(t *testing.T) {
@@ -168,6 +171,126 @@ func TestRunJobHelpAndErrorPaths(t *testing.T) {
 	}
 	if code := runJob([]string{"inspect", "--id", "missing", "--root", root, "--json"}); code != exitInvalidInput {
 		t.Fatalf("inspect missing job expected %d got %d", exitInvalidInput, code)
+	}
+}
+
+func TestRunJobStatusRecoversPendingMutation(t *testing.T) {
+	workDir := t.TempDir()
+	withWorkingDir(t, workDir)
+	root := filepath.Join(workDir, "jobs")
+	jobID := "job_cli_recover_status"
+
+	submitCode, submitOut := runJobJSON(t, []string{"submit", "--id", jobID, "--root", root, "--json"})
+	if submitCode != exitOK || submitOut.Job == nil {
+		t.Fatalf("submit expected %d got %d output=%#v", exitOK, submitCode, submitOut)
+	}
+
+	statePath := filepath.Join(root, jobID, "state.json")
+	pendingPath := filepath.Join(root, jobID, "pending_mutation.json")
+	var previous jobruntime.JobState
+	payload, err := os.ReadFile(statePath)
+	if err != nil {
+		t.Fatalf("read state: %v", err)
+	}
+	if err := json.Unmarshal(payload, &previous); err != nil {
+		t.Fatalf("decode state: %v", err)
+	}
+	updated := previous
+	updated.Status = jobruntime.StatusPaused
+	updated.StopReason = jobruntime.StopReasonPausedByUser
+	updated.StatusReasonCode = "paused"
+	updated.Revision = previous.Revision + 1
+	updated.UpdatedAt = previous.UpdatedAt.Add(time.Second)
+	encodedUpdated, err := json.MarshalIndent(updated, "", "  ")
+	if err != nil {
+		t.Fatalf("encode updated state: %v", err)
+	}
+	if err := os.WriteFile(statePath, append(encodedUpdated, '\n'), 0o600); err != nil {
+		t.Fatalf("write updated state: %v", err)
+	}
+
+	pendingPayload, err := json.MarshalIndent(struct {
+		SchemaID      string               `json:"schema_id"`
+		SchemaVersion string               `json:"schema_version"`
+		CreatedAt     time.Time            `json:"created_at"`
+		JobID         string               `json:"job_id"`
+		PreviousState *jobruntime.JobState `json:"previous_state,omitempty"`
+		UpdatedState  jobruntime.JobState  `json:"updated_state"`
+		Event         jobruntime.Event     `json:"event"`
+	}{
+		SchemaID:      "gait.job.pending_mutation",
+		SchemaVersion: "1.0.0",
+		CreatedAt:     updated.UpdatedAt,
+		JobID:         jobID,
+		PreviousState: &previous,
+		UpdatedState:  updated,
+		Event: jobruntime.Event{
+			SchemaID:      "gait.job.event",
+			SchemaVersion: "1.0.0",
+			CreatedAt:     updated.UpdatedAt,
+			JobID:         jobID,
+			Revision:      updated.Revision,
+			Type:          "paused",
+			ReasonCode:    "paused",
+		},
+	}, "", "  ")
+	if err != nil {
+		t.Fatalf("encode pending mutation: %v", err)
+	}
+	if err := os.WriteFile(pendingPath, append(pendingPayload, '\n'), 0o600); err != nil {
+		t.Fatalf("write pending mutation: %v", err)
+	}
+
+	statusCode, statusOut := runJobJSON(t, []string{"status", "--id", jobID, "--root", root, "--json"})
+	if statusCode != exitOK {
+		t.Fatalf("status expected %d got %d output=%#v", exitOK, statusCode, statusOut)
+	}
+	if statusOut.Job == nil || statusOut.Job.Status != jobruntime.StatusRunning || statusOut.Job.Revision != previous.Revision {
+		t.Fatalf("expected status to recover baseline state, got %#v", statusOut)
+	}
+}
+
+func TestRunJobCheckpointUnknownSubcommandAndExplain(t *testing.T) {
+	if code := runJob([]string{"checkpoint", "unknown"}); code != exitInvalidInput {
+		t.Fatalf("unknown checkpoint subcommand expected %d got %d", exitInvalidInput, code)
+	}
+	if code := runJob([]string{"--explain"}); code != exitOK {
+		t.Fatalf("job explain expected %d got %d", exitOK, code)
+	}
+}
+
+func TestWriteJobOutputTextIncludesCheckpointAndEvents(t *testing.T) {
+	var code int
+	output := captureStdout(t, func() {
+		code = writeJobOutput(false, jobOutput{
+			OK:        true,
+			Operation: "inspect",
+			Job: &jobruntime.JobState{
+				JobID:            "job-text-output",
+				Status:           jobruntime.StatusPaused,
+				StopReason:       jobruntime.StopReasonPausedByUser,
+				StatusReasonCode: "paused",
+			},
+			Checkpoint: &jobruntime.Checkpoint{
+				CheckpointID: "cp_0001",
+				Type:         jobruntime.CheckpointTypeProgress,
+			},
+			Checkpoints: []jobruntime.Checkpoint{{CheckpointID: "cp_0001"}},
+			Events:      []jobruntime.Event{{Type: "paused"}},
+		}, exitOK)
+	})
+	if code != exitOK {
+		t.Fatalf("writeJobOutput expected %d got %d", exitOK, code)
+	}
+	for _, expected := range []string{
+		"job inspect: id=job-text-output status=paused stop_reason=paused_by_user reason_code=paused",
+		"checkpoint: cp_0001 (progress)",
+		"checkpoints=1",
+		"events=1",
+	} {
+		if !strings.Contains(output, expected) {
+			t.Fatalf("expected %q in output %q", expected, output)
+		}
 	}
 }
 

--- a/core/doctor/doctor.go
+++ b/core/doctor/doctor.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Clyra-AI/gait/core/jobruntime"
 	"github.com/Clyra-AI/gait/core/projectconfig"
 	sign "github.com/Clyra-AI/proof/signing"
 )
@@ -106,6 +107,7 @@ func Run(opts Options) Result {
 		checks = []Check{
 			checkWorkDirWritable(workDir),
 			checkOutputDir(outputDir),
+			checkJobRuntimeDurability(outputDir),
 			checkTempDirWritable(),
 			checkKeySourceAmbiguity(opts.KeyConfig),
 			checkKeyFilePermissions(opts.KeyConfig),
@@ -116,6 +118,7 @@ func Run(opts Options) Result {
 		checks = []Check{
 			checkWorkDirWritable(workDir),
 			checkOutputDir(outputDir),
+			checkJobRuntimeDurability(outputDir),
 			checkTempDirWritable(),
 			checkSchemaFiles(workDir),
 			checkHooksPath(workDir),
@@ -271,6 +274,34 @@ func checkSchemaFiles(workDir string) Check {
 		Name:    "schema_files",
 		Status:  statusPass,
 		Message: "required schema files are present",
+	}
+}
+
+func checkJobRuntimeDurability(outputDir string) Check {
+	issues, err := jobruntime.DiagnoseDurableState(filepath.Join(outputDir, "jobs"))
+	if err != nil {
+		return Check{
+			Name:    "job_runtime_durability",
+			Status:  statusFail,
+			Message: fmt.Sprintf("job durable-state scan failed: %v", err),
+		}
+	}
+	if len(issues) == 0 {
+		return Check{
+			Name:    "job_runtime_durability",
+			Status:  statusPass,
+			Message: "job durable state is consistent",
+		}
+	}
+	parts := make([]string, 0, len(issues))
+	for _, issue := range issues {
+		parts = append(parts, fmt.Sprintf("%s:%s", issue.JobID, issue.Kind))
+	}
+	sort.Strings(parts)
+	return Check{
+		Name:    "job_runtime_durability",
+		Status:  statusFail,
+		Message: fmt.Sprintf("durable job state divergence detected: %s", strings.Join(parts, ",")),
 	}
 }
 

--- a/core/doctor/doctor_test.go
+++ b/core/doctor/doctor_test.go
@@ -2,6 +2,7 @@ package doctor
 
 import (
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
@@ -11,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Clyra-AI/gait/core/jobruntime"
 	"github.com/Clyra-AI/gait/core/projectconfig"
 	sign "github.com/Clyra-AI/proof/signing"
 )
@@ -117,8 +119,11 @@ func TestRunPassesWithValidWorkspaceAndSchemas(t *testing.T) {
 	if result.NonFixable {
 		t.Fatalf("expected non-fixable to be false")
 	}
-	if len(result.Checks) != 12 {
+	if len(result.Checks) != 13 {
 		t.Fatalf("unexpected checks count: %d", len(result.Checks))
+	}
+	if !checkStatus(result.Checks, "job_runtime_durability", statusPass) {
+		t.Fatalf("expected job_runtime_durability pass check")
 	}
 	if !checkStatus(result.Checks, "key_permissions", statusPass) {
 		t.Fatalf("expected key_permissions pass check")
@@ -131,6 +136,56 @@ func TestRunPassesWithValidWorkspaceAndSchemas(t *testing.T) {
 	}
 	if !checkStatus(result.Checks, "key_source_ambiguity", statusPass) {
 		t.Fatalf("expected key_source_ambiguity pass check")
+	}
+}
+
+func TestRunDetectsDurableStateDivergence(t *testing.T) {
+	installFakeGaitBinaryInPath(t)
+
+	root := repoRoot(t)
+	outputDir := filepath.Join(t.TempDir(), "gait-out")
+	jobRoot := filepath.Join(outputDir, "jobs")
+	if err := ensureDir(jobRoot); err != nil {
+		t.Fatalf("create output dir: %v", err)
+	}
+
+	if _, err := jobruntime.Submit(jobRoot, jobruntime.SubmitOptions{JobID: "job-diverged"}); err != nil {
+		t.Fatalf("submit job: %v", err)
+	}
+	statePath := filepath.Join(jobRoot, "job-diverged", "state.json")
+	payload, err := os.ReadFile(statePath)
+	if err != nil {
+		t.Fatalf("read state: %v", err)
+	}
+	var state jobruntime.JobState
+	if err := json.Unmarshal(payload, &state); err != nil {
+		t.Fatalf("decode state: %v", err)
+	}
+	state.Status = jobruntime.StatusPaused
+	state.StopReason = jobruntime.StopReasonPausedByUser
+	state.StatusReasonCode = "paused"
+	state.Revision++
+	state.UpdatedAt = state.UpdatedAt.Add(time.Second)
+	encoded, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		t.Fatalf("encode diverged state: %v", err)
+	}
+	if err := os.WriteFile(statePath, append(encoded, '\n'), 0o600); err != nil {
+		t.Fatalf("write diverged state: %v", err)
+	}
+
+	result := Run(Options{
+		WorkDir:         root,
+		OutputDir:       outputDir,
+		ProducerVersion: "test",
+		KeyMode:         sign.ModeDev,
+	})
+
+	if result.Status != statusFail {
+		t.Fatalf("expected fail status for durable-state divergence, got: %s (%s)", result.Status, result.Summary)
+	}
+	if !checkStatus(result.Checks, "job_runtime_durability", statusFail) {
+		t.Fatalf("expected job_runtime_durability fail check")
 	}
 }
 

--- a/core/jobruntime/runtime.go
+++ b/core/jobruntime/runtime.go
@@ -929,6 +929,13 @@ func commitMutation(files jobFiles, mutation pendingMutation) error {
 		return err
 	}
 	if err := persistJobEvent(files.eventsPath, mutation.Event); err != nil {
+		events, readErr := readEvents(files.eventsPath)
+		if readErr != nil {
+			return fmt.Errorf("append event: %w (pending mutation preserved: %v)", err, readErr)
+		}
+		if pendingEventExists(events, mutation.Event.Revision) {
+			return err
+		}
 		if rollbackErr := restorePendingBaseline(files.statePath, mutation.PreviousState); rollbackErr != nil {
 			return fmt.Errorf("append event: %w (rollback failed: %v)", err, rollbackErr)
 		}
@@ -940,7 +947,7 @@ func commitMutation(files jobFiles, mutation pendingMutation) error {
 }
 
 func recoverPendingMutation(files jobFiles) error {
-	mutation, err := readPendingMutation(files.pendingPath)
+	mutation, err := readPendingMutation(files.pendingPath, filepath.Base(filepath.Dir(files.statePath)))
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil
@@ -962,7 +969,7 @@ func recoverPendingMutation(files jobFiles) error {
 	return nil
 }
 
-func readPendingMutation(path string) (pendingMutation, error) {
+func readPendingMutation(path string, expectedJobID string) (pendingMutation, error) {
 	// #nosec G304 -- path is derived from local job root
 	// lgtm[go/path-injection] path is derived from explicit local runtime root/job id inputs.
 	payload, err := os.ReadFile(path)
@@ -975,6 +982,18 @@ func readPendingMutation(path string) (pendingMutation, error) {
 	}
 	if strings.TrimSpace(mutation.JobID) == "" {
 		return pendingMutation{}, fmt.Errorf("invalid pending mutation: missing job_id")
+	}
+	if expected := strings.TrimSpace(expectedJobID); expected != "" && mutation.JobID != expected {
+		return pendingMutation{}, fmt.Errorf("invalid pending mutation: expected job_id %s got %s", expected, mutation.JobID)
+	}
+	if strings.TrimSpace(mutation.UpdatedState.JobID) != mutation.JobID {
+		return pendingMutation{}, fmt.Errorf("invalid pending mutation: updated_state job_id mismatch")
+	}
+	if mutation.PreviousState != nil && strings.TrimSpace(mutation.PreviousState.JobID) != mutation.JobID {
+		return pendingMutation{}, fmt.Errorf("invalid pending mutation: previous_state job_id mismatch")
+	}
+	if strings.TrimSpace(mutation.Event.JobID) != mutation.JobID {
+		return pendingMutation{}, fmt.Errorf("invalid pending mutation: event job_id mismatch")
 	}
 	return mutation, nil
 }

--- a/core/jobruntime/runtime.go
+++ b/core/jobruntime/runtime.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"regexp"
 	"runtime"
 	"sort"
@@ -21,6 +22,7 @@ const (
 	jobSchemaID      = "gait.job.runtime"
 	jobSchemaVersion = "1.0.0"
 	eventSchemaID    = "gait.job.event"
+	pendingSchemaID  = "gait.job.pending_mutation"
 )
 
 const (
@@ -63,6 +65,12 @@ var (
 	ErrIdentityValidationMissing = errors.New("identity validation required")
 	ErrIdentityRevoked           = errors.New("identity revoked")
 	ErrIdentityBindingMismatch   = errors.New("identity binding mismatch")
+)
+
+var (
+	persistJobJSON  = writeJSON
+	persistJobEvent = appendEvent
+	removeJobPath   = os.Remove
 )
 
 var safeJobIDPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$`)
@@ -115,6 +123,29 @@ type Event struct {
 	Actor         string         `json:"actor,omitempty"`
 	ReasonCode    string         `json:"reason_code,omitempty"`
 	Payload       map[string]any `json:"payload,omitempty"`
+}
+
+type pendingMutation struct {
+	SchemaID      string    `json:"schema_id"`
+	SchemaVersion string    `json:"schema_version"`
+	CreatedAt     time.Time `json:"created_at"`
+	JobID         string    `json:"job_id"`
+	PreviousState *JobState `json:"previous_state,omitempty"`
+	UpdatedState  JobState  `json:"updated_state"`
+	Event         Event     `json:"event"`
+}
+
+type DurableStateIssue struct {
+	JobID   string `json:"job_id"`
+	Kind    string `json:"kind"`
+	Message string `json:"message"`
+}
+
+type jobFiles struct {
+	statePath   string
+	eventsPath  string
+	pendingPath string
+	lockPath    string
 }
 
 type SubmitOptions struct {
@@ -189,16 +220,28 @@ func Submit(root string, opts SubmitOptions) (JobState, error) {
 	if identity == "" {
 		identity = strings.TrimSpace(opts.Actor)
 	}
-	statePath, eventsPath, err := jobPaths(root, jobID)
+	files, err := resolveJobFiles(root, jobID)
 	if err != nil {
 		return JobState{}, err
 	}
-	if err := os.MkdirAll(filepath.Dir(statePath), 0o750); err != nil {
+	if err := os.MkdirAll(filepath.Dir(files.statePath), 0o750); err != nil {
 		return JobState{}, fmt.Errorf("create job directory: %w", err)
 	}
 
-	if _, err := os.Stat(statePath); err == nil {
+	release, err := acquireLock(files.lockPath, now, 2*time.Second)
+	if err != nil {
+		return JobState{}, err
+	}
+	defer release()
+
+	if err := recoverPendingMutation(files); err != nil {
+		return JobState{}, err
+	}
+
+	if _, err := os.Stat(files.statePath); err == nil {
 		return JobState{}, fmt.Errorf("job already exists: %s", jobID)
+	} else if err != nil && !os.IsNotExist(err) {
+		return JobState{}, fmt.Errorf("stat job state: %w", err)
 	}
 
 	state := JobState{
@@ -221,9 +264,6 @@ func Submit(root string, opts SubmitOptions) (JobState, error) {
 	}
 	state.SafetyInvariants = deriveSafetyInvariants(state)
 	state.SafetyInvariantHash = hashSafetyInvariants(state.SafetyInvariants)
-	if err := writeJSON(statePath, state); err != nil {
-		return JobState{}, err
-	}
 	eventPayload := map[string]any{
 		"environment_fingerprint": envfp,
 	}
@@ -247,18 +287,28 @@ func Submit(root string, opts SubmitOptions) (JobState, error) {
 		ReasonCode:    "submitted",
 		Payload:       eventPayload,
 	}
-	if err := appendEvent(eventsPath, event); err != nil {
+	if err := commitMutation(files, pendingMutation{
+		SchemaID:      pendingSchemaID,
+		SchemaVersion: jobSchemaVersion,
+		CreatedAt:     now,
+		JobID:         jobID,
+		UpdatedState:  state,
+		Event:         event,
+	}); err != nil {
 		return JobState{}, err
 	}
 	return state, nil
 }
 
 func Status(root string, jobID string) (JobState, error) {
-	statePath, _, err := jobPaths(root, jobID)
+	files, err := resolveJobFiles(root, jobID)
 	if err != nil {
 		return JobState{}, err
 	}
-	state, err := readState(statePath)
+	if err := recoverJobIfNeeded(files); err != nil {
+		return JobState{}, err
+	}
+	state, err := readState(files.statePath)
 	if err != nil {
 		return JobState{}, err
 	}
@@ -542,15 +592,18 @@ func Resume(root string, jobID string, opts ResumeOptions) (JobState, error) {
 }
 
 func Inspect(root string, jobID string) (JobState, []Event, error) {
-	statePath, eventsPath, err := jobPaths(root, jobID)
+	files, err := resolveJobFiles(root, jobID)
 	if err != nil {
 		return JobState{}, nil, err
 	}
-	state, err := readState(statePath)
+	if err := recoverJobIfNeeded(files); err != nil {
+		return JobState{}, nil, err
+	}
+	state, err := readState(files.statePath)
 	if err != nil {
 		return JobState{}, nil, err
 	}
-	events, err := readEvents(eventsPath)
+	events, err := readEvents(files.eventsPath)
 	if err != nil {
 		return JobState{}, nil, err
 	}
@@ -635,22 +688,26 @@ func mutate(root string, jobID string, mutator func(*JobState, time.Time) (Event
 }
 
 func mutateWithResult(root string, jobID string, now time.Time, mutator func(*JobState, time.Time) (JobState, Event, error)) (JobState, error) {
-	statePath, eventsPath, err := jobPaths(root, jobID)
+	files, err := resolveJobFiles(root, jobID)
 	if err != nil {
 		return JobState{}, err
 	}
-	lockPath := statePath + ".lock"
 
-	release, err := acquireLock(lockPath, normalizeNow(now), 2*time.Second)
+	release, err := acquireLock(files.lockPath, normalizeNow(now), 2*time.Second)
 	if err != nil {
 		return JobState{}, err
 	}
 	defer release()
 
-	state, err := readState(statePath)
+	if err := recoverPendingMutation(files); err != nil {
+		return JobState{}, err
+	}
+
+	state, err := readState(files.statePath)
 	if err != nil {
 		return JobState{}, err
 	}
+	previous := state
 
 	ts := normalizeNow(now)
 	updated, event, err := mutator(&state, ts)
@@ -658,20 +715,109 @@ func mutateWithResult(root string, jobID string, now time.Time, mutator func(*Jo
 		return JobState{}, err
 	}
 	updated.UpdatedAt = ts
-	updated.Revision = state.Revision + 1
+	updated.Revision = previous.Revision + 1
 	event.SchemaID = eventSchemaID
 	event.SchemaVersion = jobSchemaVersion
 	event.CreatedAt = ts
-	event.JobID = state.JobID
+	event.JobID = previous.JobID
 	event.Revision = updated.Revision
 
-	if err := writeJSON(statePath, updated); err != nil {
-		return JobState{}, err
-	}
-	if err := appendEvent(eventsPath, event); err != nil {
+	if err := commitMutation(files, pendingMutation{
+		SchemaID:      pendingSchemaID,
+		SchemaVersion: jobSchemaVersion,
+		CreatedAt:     ts,
+		JobID:         previous.JobID,
+		PreviousState: &previous,
+		UpdatedState:  updated,
+		Event:         event,
+	}); err != nil {
 		return JobState{}, err
 	}
 	return updated, nil
+}
+
+func DiagnoseDurableState(root string) ([]DurableStateIssue, error) {
+	cleanRoot := strings.TrimSpace(root)
+	if cleanRoot == "" {
+		cleanRoot = filepath.Join(".", "gait-out", "jobs")
+	}
+	absRoot, err := filepath.Abs(cleanRoot)
+	if err != nil {
+		return nil, fmt.Errorf("resolve job root: %w", err)
+	}
+	entries, err := os.ReadDir(absRoot)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return []DurableStateIssue{}, nil
+		}
+		return nil, fmt.Errorf("read job root: %w", err)
+	}
+
+	issues := make([]DurableStateIssue, 0)
+	for _, entry := range entries {
+		if !entry.IsDir() || !safeJobIDPattern.MatchString(entry.Name()) {
+			continue
+		}
+		files, err := resolveJobFiles(absRoot, entry.Name())
+		if err != nil {
+			return nil, err
+		}
+		if _, err := os.Stat(files.pendingPath); err == nil {
+			issues = append(issues, DurableStateIssue{
+				JobID:   entry.Name(),
+				Kind:    "pending_mutation",
+				Message: "pending durable mutation marker requires reconciliation",
+			})
+		} else if err != nil && !os.IsNotExist(err) {
+			return nil, fmt.Errorf("stat pending mutation for %s: %w", entry.Name(), err)
+		}
+
+		state, stateErr := readState(files.statePath)
+		if stateErr != nil && !errors.Is(stateErr, ErrJobNotFound) {
+			return nil, fmt.Errorf("read durable state for %s: %w", entry.Name(), stateErr)
+		}
+		events, err := readEvents(files.eventsPath)
+		if err != nil {
+			return nil, fmt.Errorf("read durable events for %s: %w", entry.Name(), err)
+		}
+
+		lastRevision := int64(0)
+		if len(events) > 0 {
+			lastRevision = events[len(events)-1].Revision
+		}
+		if errors.Is(stateErr, ErrJobNotFound) {
+			if len(events) > 0 {
+				issues = append(issues, DurableStateIssue{
+					JobID:   entry.Name(),
+					Kind:    "missing_state_with_events",
+					Message: fmt.Sprintf("event log revision %d exists without a durable state snapshot", lastRevision),
+				})
+			}
+			continue
+		}
+		if state.Revision > lastRevision {
+			issues = append(issues, DurableStateIssue{
+				JobID:   entry.Name(),
+				Kind:    "state_ahead_of_event_log",
+				Message: fmt.Sprintf("state revision %d is ahead of event log revision %d", state.Revision, lastRevision),
+			})
+		}
+		if lastRevision > state.Revision {
+			issues = append(issues, DurableStateIssue{
+				JobID:   entry.Name(),
+				Kind:    "event_log_ahead_of_state",
+				Message: fmt.Sprintf("event log revision %d is ahead of state revision %d", lastRevision, state.Revision),
+			})
+		}
+	}
+
+	sort.Slice(issues, func(i, j int) bool {
+		if issues[i].JobID == issues[j].JobID {
+			return issues[i].Kind < issues[j].Kind
+		}
+		return issues[i].JobID < issues[j].JobID
+	})
+	return issues, nil
 }
 
 func readState(path string) (JobState, error) {
@@ -742,6 +888,130 @@ func appendEvent(path string, event Event) error {
 	}
 	if err := fsx.AppendLineLocked(path, payload, 0o600); err != nil {
 		return fmt.Errorf("append event: %w", err)
+	}
+	return nil
+}
+
+func resolveJobFiles(root string, jobID string) (jobFiles, error) {
+	statePath, eventsPath, err := jobPaths(root, jobID)
+	if err != nil {
+		return jobFiles{}, err
+	}
+	return jobFiles{
+		statePath:   statePath,
+		eventsPath:  eventsPath,
+		pendingPath: filepath.Join(filepath.Dir(statePath), "pending_mutation.json"),
+		lockPath:    statePath + ".lock",
+	}, nil
+}
+
+func recoverJobIfNeeded(files jobFiles) error {
+	if _, err := os.Stat(files.pendingPath); err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("stat pending mutation: %w", err)
+	}
+	release, err := acquireLock(files.lockPath, time.Time{}, 2*time.Second)
+	if err != nil {
+		return err
+	}
+	defer release()
+	return recoverPendingMutation(files)
+}
+
+func commitMutation(files jobFiles, mutation pendingMutation) error {
+	if err := persistJobJSON(files.pendingPath, mutation); err != nil {
+		return err
+	}
+	if err := materializePendingState(files.statePath, mutation.UpdatedState); err != nil {
+		_ = removePendingMarker(files.pendingPath)
+		return err
+	}
+	if err := persistJobEvent(files.eventsPath, mutation.Event); err != nil {
+		if rollbackErr := restorePendingBaseline(files.statePath, mutation.PreviousState); rollbackErr != nil {
+			return fmt.Errorf("append event: %w (rollback failed: %v)", err, rollbackErr)
+		}
+		_ = removePendingMarker(files.pendingPath)
+		return err
+	}
+	_ = removePendingMarker(files.pendingPath)
+	return nil
+}
+
+func recoverPendingMutation(files jobFiles) error {
+	mutation, err := readPendingMutation(files.pendingPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	events, err := readEvents(files.eventsPath)
+	if err != nil {
+		return err
+	}
+	if pendingEventExists(events, mutation.Event.Revision) {
+		if err := materializePendingState(files.statePath, mutation.UpdatedState); err != nil {
+			return err
+		}
+	} else if err := restorePendingBaseline(files.statePath, mutation.PreviousState); err != nil {
+		return err
+	}
+	_ = removePendingMarker(files.pendingPath)
+	return nil
+}
+
+func readPendingMutation(path string) (pendingMutation, error) {
+	// #nosec G304 -- path is derived from local job root
+	// lgtm[go/path-injection] path is derived from explicit local runtime root/job id inputs.
+	payload, err := os.ReadFile(path)
+	if err != nil {
+		return pendingMutation{}, err
+	}
+	var mutation pendingMutation
+	if err := json.Unmarshal(payload, &mutation); err != nil {
+		return pendingMutation{}, fmt.Errorf("parse pending mutation: %w", err)
+	}
+	if strings.TrimSpace(mutation.JobID) == "" {
+		return pendingMutation{}, fmt.Errorf("invalid pending mutation: missing job_id")
+	}
+	return mutation, nil
+}
+
+func pendingEventExists(events []Event, revision int64) bool {
+	for _, event := range events {
+		if event.Revision == revision {
+			return true
+		}
+	}
+	return false
+}
+
+func materializePendingState(path string, desired JobState) error {
+	current, err := readState(path)
+	if err == nil && reflect.DeepEqual(current, desired) {
+		return nil
+	}
+	if err != nil && !errors.Is(err, ErrJobNotFound) {
+		return err
+	}
+	return persistJobJSON(path, desired)
+}
+
+func restorePendingBaseline(path string, previous *JobState) error {
+	if previous == nil {
+		if err := removeJobPath(path); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("remove job state: %w", err)
+		}
+		return nil
+	}
+	return materializePendingState(path, *previous)
+}
+
+func removePendingMarker(path string) error {
+	if err := removeJobPath(path); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("remove pending mutation: %w", err)
 	}
 	return nil
 }

--- a/core/jobruntime/runtime_test.go
+++ b/core/jobruntime/runtime_test.go
@@ -555,6 +555,366 @@ func TestReadWriteHelperErrors(t *testing.T) {
 	}
 }
 
+func TestSubmitAppendFailureRollsBackNewJob(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "jobs")
+	restoreJobPersistenceHooks(t)
+	persistJobEvent = func(path string, event Event) error {
+		return errors.New("append failure")
+	}
+
+	if _, err := Submit(root, SubmitOptions{JobID: "job-submit-rollback"}); err == nil {
+		t.Fatalf("expected submit append failure")
+	}
+	if _, err := Status(root, "job-submit-rollback"); !errors.Is(err, ErrJobNotFound) {
+		t.Fatalf("expected rolled back submit to leave no job, got %v", err)
+	}
+}
+
+func TestMutationAppendFailureRollsBackStateAndRetrySucceeds(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "jobs")
+	jobID := "job-pause-rollback"
+	if _, err := Submit(root, SubmitOptions{JobID: jobID}); err != nil {
+		t.Fatalf("submit job: %v", err)
+	}
+
+	restoreJobPersistenceHooks(t)
+	persistJobEvent = func(path string, event Event) error {
+		return errors.New("append failure")
+	}
+	if _, err := Pause(root, jobID, TransitionOptions{}); err == nil {
+		t.Fatalf("expected pause append failure")
+	}
+
+	state, err := Status(root, jobID)
+	if err != nil {
+		t.Fatalf("status after failed pause: %v", err)
+	}
+	if state.Status != StatusRunning || state.Revision != 1 {
+		t.Fatalf("expected state rollback after failed pause, got %#v", state)
+	}
+
+	restoreJobPersistenceHooks(t)
+	paused, err := Pause(root, jobID, TransitionOptions{})
+	if err != nil {
+		t.Fatalf("pause retry after rollback: %v", err)
+	}
+	if paused.Status != StatusPaused || paused.Revision != 2 {
+		t.Fatalf("expected retried pause to succeed, got %#v", paused)
+	}
+}
+
+func TestStatusRecoversPendingMutationWithoutEventByRollingBackState(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "jobs")
+	jobID := "job-pending-rollback"
+	submitted, err := Submit(root, SubmitOptions{JobID: jobID})
+	if err != nil {
+		t.Fatalf("submit job: %v", err)
+	}
+
+	files, err := resolveJobFiles(root, jobID)
+	if err != nil {
+		t.Fatalf("resolve job files: %v", err)
+	}
+	updated := submitted
+	updated.Status = StatusPaused
+	updated.StopReason = StopReasonPausedByUser
+	updated.StatusReasonCode = "paused"
+	updated.Revision = submitted.Revision + 1
+	updated.UpdatedAt = submitted.UpdatedAt.Add(time.Second)
+	if err := writeJSON(files.statePath, updated); err != nil {
+		t.Fatalf("write updated state: %v", err)
+	}
+	if err := writeJSON(files.pendingPath, pendingMutation{
+		SchemaID:      pendingSchemaID,
+		SchemaVersion: jobSchemaVersion,
+		CreatedAt:     updated.UpdatedAt,
+		JobID:         jobID,
+		PreviousState: &submitted,
+		UpdatedState:  updated,
+		Event: Event{
+			SchemaID:      eventSchemaID,
+			SchemaVersion: jobSchemaVersion,
+			CreatedAt:     updated.UpdatedAt,
+			JobID:         jobID,
+			Revision:      updated.Revision,
+			Type:          "paused",
+			ReasonCode:    "paused",
+		},
+	}); err != nil {
+		t.Fatalf("write pending mutation: %v", err)
+	}
+
+	state, err := Status(root, jobID)
+	if err != nil {
+		t.Fatalf("status with pending rollback recovery: %v", err)
+	}
+	if state.Status != StatusRunning || state.Revision != submitted.Revision {
+		t.Fatalf("expected rollback to submitted state, got %#v", state)
+	}
+	if _, err := os.Stat(files.pendingPath); !os.IsNotExist(err) {
+		t.Fatalf("expected pending mutation marker to be removed, stat=%v", err)
+	}
+}
+
+func TestStatusRecoversPendingMutationWithDurableEvent(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "jobs")
+	jobID := "job-pending-commit"
+	submitted, err := Submit(root, SubmitOptions{JobID: jobID})
+	if err != nil {
+		t.Fatalf("submit job: %v", err)
+	}
+
+	files, err := resolveJobFiles(root, jobID)
+	if err != nil {
+		t.Fatalf("resolve job files: %v", err)
+	}
+	updated := submitted
+	updated.Status = StatusPaused
+	updated.StopReason = StopReasonPausedByUser
+	updated.StatusReasonCode = "paused"
+	updated.Revision = submitted.Revision + 1
+	updated.UpdatedAt = submitted.UpdatedAt.Add(2 * time.Second)
+	event := Event{
+		SchemaID:      eventSchemaID,
+		SchemaVersion: jobSchemaVersion,
+		CreatedAt:     updated.UpdatedAt,
+		JobID:         jobID,
+		Revision:      updated.Revision,
+		Type:          "paused",
+		ReasonCode:    "paused",
+	}
+	if err := appendEvent(files.eventsPath, event); err != nil {
+		t.Fatalf("append durable event: %v", err)
+	}
+	if err := writeJSON(files.pendingPath, pendingMutation{
+		SchemaID:      pendingSchemaID,
+		SchemaVersion: jobSchemaVersion,
+		CreatedAt:     updated.UpdatedAt,
+		JobID:         jobID,
+		PreviousState: &submitted,
+		UpdatedState:  updated,
+		Event:         event,
+	}); err != nil {
+		t.Fatalf("write pending mutation: %v", err)
+	}
+
+	state, err := Status(root, jobID)
+	if err != nil {
+		t.Fatalf("status with durable event recovery: %v", err)
+	}
+	if state.Status != StatusPaused || state.Revision != updated.Revision {
+		t.Fatalf("expected durable event recovery to materialize updated state, got %#v", state)
+	}
+}
+
+func TestInspectRecoversPendingMutationWithDurableEvent(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "jobs")
+	jobID := "job-inspect-recovery"
+	submitted, err := Submit(root, SubmitOptions{JobID: jobID})
+	if err != nil {
+		t.Fatalf("submit job: %v", err)
+	}
+
+	files, err := resolveJobFiles(root, jobID)
+	if err != nil {
+		t.Fatalf("resolve job files: %v", err)
+	}
+	updated := submitted
+	updated.Status = StatusPaused
+	updated.StopReason = StopReasonPausedByUser
+	updated.StatusReasonCode = "paused"
+	updated.Revision = submitted.Revision + 1
+	updated.UpdatedAt = submitted.UpdatedAt.Add(3 * time.Second)
+	event := Event{
+		SchemaID:      eventSchemaID,
+		SchemaVersion: jobSchemaVersion,
+		CreatedAt:     updated.UpdatedAt,
+		JobID:         jobID,
+		Revision:      updated.Revision,
+		Type:          "paused",
+		ReasonCode:    "paused",
+	}
+	if err := appendEvent(files.eventsPath, event); err != nil {
+		t.Fatalf("append durable event: %v", err)
+	}
+	if err := writeJSON(files.pendingPath, pendingMutation{
+		SchemaID:      pendingSchemaID,
+		SchemaVersion: jobSchemaVersion,
+		CreatedAt:     updated.UpdatedAt,
+		JobID:         jobID,
+		PreviousState: &submitted,
+		UpdatedState:  updated,
+		Event:         event,
+	}); err != nil {
+		t.Fatalf("write pending mutation: %v", err)
+	}
+
+	state, events, err := Inspect(root, jobID)
+	if err != nil {
+		t.Fatalf("inspect with durable event recovery: %v", err)
+	}
+	if state.Status != StatusPaused || state.Revision != updated.Revision {
+		t.Fatalf("expected inspect recovery to materialize updated state, got %#v", state)
+	}
+	if len(events) != 2 || events[len(events)-1].Revision != updated.Revision {
+		t.Fatalf("expected recovered inspect to include durable event log, got %#v", events)
+	}
+}
+
+func TestDiagnoseDurableStateDetectsPendingAndRevisionDivergence(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "jobs")
+
+	submitted, err := Submit(root, SubmitOptions{JobID: "job-state-ahead"})
+	if err != nil {
+		t.Fatalf("submit state-ahead job: %v", err)
+	}
+	filesAhead, err := resolveJobFiles(root, "job-state-ahead")
+	if err != nil {
+		t.Fatalf("resolve job-state-ahead files: %v", err)
+	}
+	ahead := submitted
+	ahead.Status = StatusPaused
+	ahead.StopReason = StopReasonPausedByUser
+	ahead.StatusReasonCode = "paused"
+	ahead.Revision = submitted.Revision + 1
+	ahead.UpdatedAt = submitted.UpdatedAt.Add(time.Second)
+	if err := writeJSON(filesAhead.statePath, ahead); err != nil {
+		t.Fatalf("write state-ahead divergence: %v", err)
+	}
+
+	if _, err := Submit(root, SubmitOptions{JobID: "job-event-ahead"}); err != nil {
+		t.Fatalf("submit event-ahead job: %v", err)
+	}
+	filesEventAhead, err := resolveJobFiles(root, "job-event-ahead")
+	if err != nil {
+		t.Fatalf("resolve job-event-ahead files: %v", err)
+	}
+	if err := appendEvent(filesEventAhead.eventsPath, Event{
+		SchemaID:      eventSchemaID,
+		SchemaVersion: jobSchemaVersion,
+		CreatedAt:     time.Date(2026, time.March, 12, 12, 0, 1, 0, time.UTC),
+		JobID:         "job-event-ahead",
+		Revision:      2,
+		Type:          "paused",
+		ReasonCode:    "paused",
+	}); err != nil {
+		t.Fatalf("append event-ahead divergence: %v", err)
+	}
+
+	if _, err := Submit(root, SubmitOptions{JobID: "job-pending"}); err != nil {
+		t.Fatalf("submit pending job: %v", err)
+	}
+	filesPending, err := resolveJobFiles(root, "job-pending")
+	if err != nil {
+		t.Fatalf("resolve job-pending files: %v", err)
+	}
+	pendingState, err := readState(filesPending.statePath)
+	if err != nil {
+		t.Fatalf("read pending baseline state: %v", err)
+	}
+	if err := writeJSON(filesPending.pendingPath, pendingMutation{
+		SchemaID:      pendingSchemaID,
+		SchemaVersion: jobSchemaVersion,
+		CreatedAt:     pendingState.UpdatedAt.Add(time.Second),
+		JobID:         "job-pending",
+		PreviousState: &pendingState,
+		UpdatedState:  pendingState,
+		Event: Event{
+			SchemaID:      eventSchemaID,
+			SchemaVersion: jobSchemaVersion,
+			CreatedAt:     pendingState.UpdatedAt.Add(time.Second),
+			JobID:         "job-pending",
+			Revision:      pendingState.Revision + 1,
+			Type:          "paused",
+			ReasonCode:    "paused",
+		},
+	}); err != nil {
+		t.Fatalf("write pending mutation divergence: %v", err)
+	}
+
+	issues, err := DiagnoseDurableState(root)
+	if err != nil {
+		t.Fatalf("diagnose durable state: %v", err)
+	}
+	if len(issues) != 3 {
+		t.Fatalf("expected three durable-state issues, got %#v", issues)
+	}
+	if issues[0].JobID != "job-event-ahead" || issues[0].Kind != "event_log_ahead_of_state" {
+		t.Fatalf("unexpected first issue ordering/content: %#v", issues)
+	}
+	if issues[1].JobID != "job-pending" || issues[1].Kind != "pending_mutation" {
+		t.Fatalf("unexpected pending issue: %#v", issues)
+	}
+	if issues[2].JobID != "job-state-ahead" || issues[2].Kind != "state_ahead_of_event_log" {
+		t.Fatalf("unexpected state-ahead issue: %#v", issues)
+	}
+}
+
+func TestDiagnoseDurableStateDetectsMissingStateWithEvents(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "jobs")
+	jobID := "job-missing-state"
+	if _, err := Submit(root, SubmitOptions{JobID: jobID}); err != nil {
+		t.Fatalf("submit job: %v", err)
+	}
+	files, err := resolveJobFiles(root, jobID)
+	if err != nil {
+		t.Fatalf("resolve job files: %v", err)
+	}
+	if err := os.Remove(files.statePath); err != nil {
+		t.Fatalf("remove state path: %v", err)
+	}
+
+	issues, err := DiagnoseDurableState(root)
+	if err != nil {
+		t.Fatalf("diagnose durable state: %v", err)
+	}
+	if len(issues) != 1 || issues[0].Kind != "missing_state_with_events" {
+		t.Fatalf("expected missing_state_with_events issue, got %#v", issues)
+	}
+}
+
+func TestDiagnoseDurableStateMissingRootReturnsNoIssues(t *testing.T) {
+	issues, err := DiagnoseDurableState(filepath.Join(t.TempDir(), "missing"))
+	if err != nil {
+		t.Fatalf("diagnose missing root: %v", err)
+	}
+	if len(issues) != 0 {
+		t.Fatalf("expected no issues for missing root, got %#v", issues)
+	}
+}
+
+func TestDiagnoseDurableStateReturnsParseErrorForInvalidState(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "jobs")
+	jobDir := filepath.Join(root, "job-invalid-state")
+	if err := os.MkdirAll(jobDir, 0o750); err != nil {
+		t.Fatalf("mkdir job dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(jobDir, "state.json"), []byte("{invalid"), 0o600); err != nil {
+		t.Fatalf("write invalid state: %v", err)
+	}
+	if _, err := DiagnoseDurableState(root); err == nil {
+		t.Fatalf("expected diagnose parse error for invalid state")
+	}
+}
+
+func TestStatusFailsForMalformedPendingMutation(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "jobs")
+	jobID := "job-malformed-pending"
+	if _, err := Submit(root, SubmitOptions{JobID: jobID}); err != nil {
+		t.Fatalf("submit job: %v", err)
+	}
+	files, err := resolveJobFiles(root, jobID)
+	if err != nil {
+		t.Fatalf("resolve job files: %v", err)
+	}
+	if err := os.WriteFile(files.pendingPath, []byte("{invalid"), 0o600); err != nil {
+		t.Fatalf("write malformed pending marker: %v", err)
+	}
+	if _, err := Status(root, jobID); err == nil {
+		t.Fatalf("expected status to fail for malformed pending marker")
+	}
+}
+
 func TestAcquireLockTimeoutAndPathErrors(t *testing.T) {
 	now := time.Now().UTC()
 
@@ -570,6 +930,55 @@ func TestAcquireLockTimeoutAndPathErrors(t *testing.T) {
 	if _, err := acquireLock(lockPath, now, 0); !errors.Is(err, ErrStateContention) {
 		t.Fatalf("expected ErrStateContention, got %v", err)
 	}
+}
+
+func TestMutationStateWriteFailureCleansPendingMarker(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "jobs")
+	jobID := "job-state-write-failure"
+	if _, err := Submit(root, SubmitOptions{JobID: jobID}); err != nil {
+		t.Fatalf("submit job: %v", err)
+	}
+	files, err := resolveJobFiles(root, jobID)
+	if err != nil {
+		t.Fatalf("resolve job files: %v", err)
+	}
+
+	restoreJobPersistenceHooks(t)
+	persistJobJSON = func(path string, value any) error {
+		if filepath.Base(path) == "state.json" {
+			return errors.New("state write failure")
+		}
+		return writeJSON(path, value)
+	}
+
+	if _, err := Pause(root, jobID, TransitionOptions{}); err == nil {
+		t.Fatalf("expected pause state write failure")
+	}
+	if _, err := os.Stat(files.pendingPath); !os.IsNotExist(err) {
+		t.Fatalf("expected pending marker cleanup after state write failure, stat=%v", err)
+	}
+	state, err := Status(root, jobID)
+	if err != nil {
+		t.Fatalf("status after state write failure: %v", err)
+	}
+	if state.Status != StatusRunning || state.Revision != 1 {
+		t.Fatalf("expected unchanged state after state write failure, got %#v", state)
+	}
+}
+
+func restoreJobPersistenceHooks(t *testing.T) {
+	t.Helper()
+	originalWrite := persistJobJSON
+	originalAppend := persistJobEvent
+	originalRemove := removeJobPath
+	persistJobJSON = writeJSON
+	persistJobEvent = appendEvent
+	removeJobPath = os.Remove
+	t.Cleanup(func() {
+		persistJobJSON = originalWrite
+		persistJobEvent = originalAppend
+		removeJobPath = originalRemove
+	})
 }
 
 func TestAcquireLockTimeoutUsesWallClock(t *testing.T) {

--- a/core/jobruntime/runtime_test.go
+++ b/core/jobruntime/runtime_test.go
@@ -603,6 +603,43 @@ func TestMutationAppendFailureRollsBackStateAndRetrySucceeds(t *testing.T) {
 	}
 }
 
+func TestMutationAppendFailureWithDurableEventPreservesPendingMarker(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "jobs")
+	jobID := "job-pause-durable-event-error"
+	if _, err := Submit(root, SubmitOptions{JobID: jobID}); err != nil {
+		t.Fatalf("submit job: %v", err)
+	}
+	files, err := resolveJobFiles(root, jobID)
+	if err != nil {
+		t.Fatalf("resolve job files: %v", err)
+	}
+
+	restoreJobPersistenceHooks(t)
+	persistJobEvent = func(path string, event Event) error {
+		if err := appendEvent(path, event); err != nil {
+			return err
+		}
+		return errors.New("sync failure after durable append")
+	}
+	if _, err := Pause(root, jobID, TransitionOptions{}); err == nil {
+		t.Fatalf("expected pause append failure after durable event write")
+	}
+	if _, err := os.Stat(files.pendingPath); err != nil {
+		t.Fatalf("expected pending marker to remain for recovery, stat=%v", err)
+	}
+
+	state, err := Status(root, jobID)
+	if err != nil {
+		t.Fatalf("status after durable event append failure: %v", err)
+	}
+	if state.Status != StatusPaused || state.Revision != 2 {
+		t.Fatalf("expected status recovery to preserve committed mutation, got %#v", state)
+	}
+	if _, err := os.Stat(files.pendingPath); !os.IsNotExist(err) {
+		t.Fatalf("expected recovery to clear pending marker, stat=%v", err)
+	}
+}
+
 func TestStatusRecoversPendingMutationWithoutEventByRollingBackState(t *testing.T) {
 	root := filepath.Join(t.TempDir(), "jobs")
 	jobID := "job-pending-rollback"
@@ -912,6 +949,43 @@ func TestStatusFailsForMalformedPendingMutation(t *testing.T) {
 	}
 	if _, err := Status(root, jobID); err == nil {
 		t.Fatalf("expected status to fail for malformed pending marker")
+	}
+}
+
+func TestStatusFailsForPendingMutationJobIDMismatch(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "jobs")
+	jobID := "job-pending-mismatch"
+	state, err := Submit(root, SubmitOptions{JobID: jobID})
+	if err != nil {
+		t.Fatalf("submit job: %v", err)
+	}
+	files, err := resolveJobFiles(root, jobID)
+	if err != nil {
+		t.Fatalf("resolve job files: %v", err)
+	}
+	mutation := pendingMutation{
+		SchemaID:      pendingSchemaID,
+		SchemaVersion: jobSchemaVersion,
+		CreatedAt:     state.UpdatedAt.Add(time.Second),
+		JobID:         "other-job",
+		UpdatedState:  state,
+		Event: Event{
+			SchemaID:      eventSchemaID,
+			SchemaVersion: jobSchemaVersion,
+			CreatedAt:     state.UpdatedAt.Add(time.Second),
+			JobID:         "other-job",
+			Revision:      state.Revision + 1,
+			Type:          "paused",
+			ReasonCode:    "paused",
+		},
+	}
+	mutation.UpdatedState.JobID = "other-job"
+	if err := writeJSON(files.pendingPath, mutation); err != nil {
+		t.Fatalf("write mismatched pending marker: %v", err)
+	}
+
+	if _, err := Status(root, jobID); err == nil {
+		t.Fatalf("expected status to fail for mismatched pending marker")
 	}
 }
 

--- a/docs/adr/0002-atomic-write-strategy.md
+++ b/docs/adr/0002-atomic-write-strategy.md
@@ -17,6 +17,19 @@ Use a shared atomic write utility for critical files:
 3. apply explicit file mode
 4. atomically rename into final path
 
+Durable job lifecycle mutations add a local pending-mutation marker beside `state.json` and `events.jsonl`:
+
+1. write `pending_mutation.json` with the previous state, intended next state, and event payload
+2. atomically write `state.json`
+3. append the event to `events.jsonl`
+4. remove the marker on success
+
+Recovery semantics are deterministic:
+
+- if the marker exists and the event is missing, restore the previous state
+- if the marker exists and the event is already durable, materialize the intended next state
+- least-privilege file modes remain `0600` for job state, event logs, and recovery markers
+
 ## Alternatives Considered
 
 1. Keep direct `os.WriteFile` usage in all call sites.

--- a/docs/hardening/contracts.md
+++ b/docs/hardening/contracts.md
@@ -38,6 +38,7 @@ Mapped hardening epics: `H1`, `H6`, `H12`.
 
 - Critical writes use atomic write semantics (temp write + sync + rename).
 - Partial writes must not produce corrupted state accepted as valid.
+- Durable job lifecycle mutations must either roll back to the prior state or leave a deterministic local recovery marker until reconciliation completes.
 - Security-sensitive outputs must preserve least-privilege permissions.
 
 Mapped hardening epics: `H2`, `H6`, `H12`.
@@ -60,6 +61,7 @@ Mapped hardening epics: `H4`, `H12`.
 ### NFR-07 Operational Diagnostics
 
 - `gait doctor --json` emits actionable fix guidance for common operational faults.
+- `gait doctor --json` detects durable job state divergence or pending recovery markers under `gait-out/jobs`.
 - Diagnostics remain deterministic and safe for offline usage.
 - Optional operational logs (`GAIT_OPERATIONAL_LOG`) emit stable start/end events with correlation IDs.
 - Correlation IDs are present in JSON command outputs and gate traces for deterministic cross-artifact debugging.

--- a/docs/hardening/prime_time_runbook.md
+++ b/docs/hardening/prime_time_runbook.md
@@ -27,6 +27,7 @@ Must return:
 
 - `ok=true`
 - `status=pass`
+- `checks[].name=job_runtime_durability` with `status=pass`
 
 ## 3) Start Hardened MCP Service
 
@@ -71,8 +72,11 @@ make bench-budgets
 1. Capture and verify artifacts:
    - `gait verify <run|path> --json`
    - `gait trace verify <trace.json> --json`
-2. Package evidence:
+2. Check durable job health before manual cleanup:
+   - `gait doctor --json`
+   - `gait job inspect --id <job_id> --root ./gait-out/jobs --json`
+3. Package evidence:
    - `gait guard pack --run <run_id> --json`
    - `gait incident pack --from <run_id> --window 24h --json`
-3. Convert to regression:
+4. Convert to regression:
    - `gait regress bootstrap --from <run_id> --json`

--- a/docs/hardening/risk_register.md
+++ b/docs/hardening/risk_register.md
@@ -5,7 +5,7 @@ This register tracks the highest-risk runtime and operational failure modes for 
 | ID | Failure Mode | Severity | Likelihood | Mitigation Epic | Owner | Target Milestone |
 | --- | --- | --- | --- | --- | --- | --- |
 | HR-01 | Operational failures reported as `invalid_input` | High | High | `H1` | CLI maintainer | v1.6 |
-| HR-02 | Partial write corruption on critical state files | High | Medium | `H2` | Core runtime maintainer | v1.6 |
+| HR-02 | Partial write corruption or silent divergence on critical job state files | High | Medium | `H2`, `W2` | Core runtime maintainer | v1.6 |
 | HR-03 | Lock contention causes nondeterministic behavior | High | Medium | `H3` | Gate maintainer | v1.6 |
 | HR-04 | Remote transient failures fail immediately without retry | Medium | Medium | `H4` | Registry maintainer | v1.7 |
 | HR-05 | Stale lock files degrade operator confidence | Medium | Medium | `H3`, `H5` | Gate maintainer | v1.7 |

--- a/scripts/test_hardening.sh
+++ b/scripts/test_hardening.sh
@@ -4,6 +4,9 @@ set -euo pipefail
 echo "[hardening] atomic write integrity tests"
 go test ./core/fsx -count=1
 
+echo "[hardening] durable job rollback and divergence diagnostics"
+go test ./core/jobruntime ./core/doctor -run 'TestMutationAppendFailureRollsBackStateAndRetrySucceeds|TestStatusRecoversPendingMutationWithoutEventByRollingBackState|TestStatusRecoversPendingMutationWithDurableEvent|TestDiagnoseDurableStateDetectsPendingAndRevisionDivergence|TestRunDetectsDurableStateDivergence' -count=1
+
 echo "[hardening] lock contention and stale lock tests"
 go test ./core/gate -run 'TestEnforceRateLimitConcurrentLocking|TestEnforceRateLimitRecoversStaleLock|TestWithRateLimitLockTimeoutCategory' -count=1
 

--- a/scripts/test_hardening_acceptance.sh
+++ b/scripts/test_hardening_acceptance.sh
@@ -13,6 +13,9 @@ go test ./cmd/gait -run 'TestMarshalOutputWithErrorEnvelope|TestMarshalOutputWit
 echo "[hardening-acceptance] atomic write integrity under failure simulation"
 go test ./core/fsx -count=1
 
+echo "[hardening-acceptance] durable job rollback and divergence diagnostics"
+go test ./core/jobruntime ./core/doctor -run 'TestMutationAppendFailureRollsBackStateAndRetrySucceeds|TestStatusRecoversPendingMutationWithoutEventByRollingBackState|TestStatusRecoversPendingMutationWithDurableEvent|TestDiagnoseDurableStateDetectsPendingAndRevisionDivergence|TestRunDetectsDurableStateDivergence' -count=1
+
 echo "[hardening-acceptance] lock contention behavior"
 go test ./core/gate -run 'TestEnforceRateLimitConcurrentLocking|TestEnforceRateLimitRecoversStaleLock|TestWithRateLimitLockTimeoutCategory' -count=1
 

--- a/scripts/test_job_runtime_chaos.sh
+++ b/scripts/test_job_runtime_chaos.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 echo "[chaos-job] runtime transition contention and fail-closed invariants"
-go test ./core/jobruntime -run 'TestDecisionNeededResumeRequiresApproval|TestResumeEnvironmentMismatchFailClosed|TestInvalidPauseTransition|TestAddCheckpointValidationAndStateTransitions' -count=5
+go test ./core/jobruntime -run 'TestDecisionNeededResumeRequiresApproval|TestResumeEnvironmentMismatchFailClosed|TestInvalidPauseTransition|TestAddCheckpointValidationAndStateTransitions|TestMutationAppendFailureRollsBackStateAndRetrySucceeds|TestStatusRecoversPendingMutationWithoutEventByRollingBackState|TestStatusRecoversPendingMutationWithDurableEvent|TestDiagnoseDurableStateDetectsPendingAndRevisionDivergence' -count=5
 
 echo "[chaos-job] emergency stop latency and post-stop side-effect invariants"
 go test ./internal/integration ./internal/e2e -run 'StopLatency|EmergencyStop' -count=1


### PR DESCRIPTION
## Problem
- durable job mutations could write `state.json` before `events.jsonl`, leaving hidden state divergence after append failure
- `gait doctor --json` did not detect durable-state divergence under `gait-out/jobs`
- the divergence repro was not wired into the hardening and chaos guards

## Changes
- add pending durable-mutation markers and reconciliation for submit, status, inspect, and lifecycle mutations
- add durable-state diagnostics to `gait doctor --json`
- add failure-injection and CLI coverage for rollback, recovery, and malformed durable state
- wire the durable-state repro into the chaos and hardening scripts
- document the atomic/recovery contract and operator guidance

## Validation
- `go test ./core/jobruntime ./cmd/gait -count=1`
- `go test ./core/doctor ./core/jobruntime -count=1`
- `./gait doctor --json`
- `./gait job submit --id job_test_w2 --root ./gait-out/jobs --json`
- `make test-chaos`
- `make test-hardening-acceptance`
- `make prepush-full`
