### PR TITLE
feat(policy): stabilize equal-priority evaluation and demo json

### DIFF
--- a/.agents/skills/commit-push/SKILL.md
+++ b/.agents/skills/commit-push/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: commit-push
-description: Commit and push all unstaged changes on the current branch, open/update PR, monitor CI to green, merge to main, monitor post-merge CI, and run up to 2 hotfix PR loops for actionable failures.
+description: Commit and push all unstaged changes on the current branch, open/update PR, fix actionable blockers through CI and review loops, merge to main, and keep driving post-merge CI to green until only a hard blocker remains.
 disable-model-invocation: true
 ---
 
@@ -14,6 +14,7 @@ Execute this workflow for: "commit/push/open PR", "ship this branch", "merge aft
 - Works on current local branch, then merges into `main`.
 - No GitHub issue creation.
 - PR text must use heredoc EOF bodies (no inline `--body` strings).
+- Default posture: when a blocker is actionable from the repo, branch, or CI logs, fix it in-loop and continue instead of stopping at first failure.
 
 ## Preconditions
 
@@ -35,9 +36,11 @@ If preconditions fail, stop and report.
 - `git fetch origin main`
 - Ensure current branch is rebased/merged with latest `origin/main` using non-interactive commands.
 
-3. Local validation before commit:
+3. Local validation and remediation before commit:
 - `make prepush-full`
-- If it fails, stop and report; do not push.
+- If it fails for actionable repo/test/lint/config issues, inspect the failures, implement the minimal fix set, and rerun until green.
+- In each remediation pass, fix all currently-known actionable failures before rerunning, not just the first one encountered.
+- Stop only for non-actionable external blockers, unsafe repo state, or 2 consecutive no-progress remediation passes.
 
 4. Stage and commit all unstaged files on this branch:
 - `git add -A`
@@ -62,6 +65,9 @@ If preconditions fail, stop and report.
 - actionable product/test failure
 - flaky/infra/transient
 - permission/workflow policy failure
+- For actionable product/test/workflow failures that can be fixed on the branch, enter remediation immediately, fix the full actionable set from the failing run, push, and continue the PR loop.
+- For flaky/infra/transient failures, retry or rerun non-interactively when appropriate and continue; stop only if the failure persists and is not repo-fixable.
+- For permission/workflow policy failures, fix them when the remedy is in-repo or branch-scoped; otherwise stop and report the external blocker.
 
 8. Codex review settle gate (mandatory, passive, latest-head preferred):
 - After PR creation/update and green CI, inspect Codex review output before merge.
@@ -89,7 +95,7 @@ If preconditions fail, stop and report.
 - if Codex explicitly reports service/quota failure for automatic review, stop and report blocker
 - Do not create a new GitHub comment to force or retry review.
 
-9. Pre-merge unresolved comment triage and fix loop (max 2 loops):
+9. Pre-merge unresolved comment triage and fix loop:
 - Fetch unresolved PR review threads/comments, preferring latest-head Codex items first, then any GitHub Advanced Security inline comments on the latest head, and then any still-open carry-forward `P0/P1` items from earlier heads.
 - Triage each unresolved item as `implement`, `blocked`, `defer`, `reject`, or `already_satisfied`.
 - Resolve the corresponding GitHub review thread for `implement` or `already_satisfied` items once they are satisfied on the current head.
@@ -99,6 +105,7 @@ If preconditions fail, stop and report.
 - `P0/P1`, or
 - high-confidence `P2` with concrete repro or break path
 - For each fix loop:
+- batch all compatible `implement` items for the current head into the smallest coherent fix set; do not stop after addressing a single comment if more actionable blockers are known
 - apply the minimal scoped fix on the same PR branch
 - run `make prepush-full`
 - `git add -A`
@@ -108,7 +115,8 @@ If preconditions fail, stop and report.
 - resolve satisfied GitHub review threads/comments
 - re-run the passive Codex review settle gate on the new latest PR head SHA
 - re-fetch unresolved threads/comments
-- If unresolved `P0/P1` items remain after loop cap, stop and report blocker.
+- Continue looping while unresolved actionable items remain and each cycle makes progress.
+- Stop only if remaining blockers are external/non-actionable/safety-blocked, or if 2 consecutive cycles fail to reduce the actionable blocker set.
 
 10. Merge PR after green and review gate satisfied:
 - Merge only when all are true on the latest PR head SHA:
@@ -125,29 +133,30 @@ If preconditions fail, stop and report.
 12. Monitor post-merge CI on `main`:
 - Watch the latest `main` CI run with timeout `25 minutes`.
 
-13. Hotfix loop on post-merge red (max 2 loops):
-- Run only for actionable failures.
-- Loop cap: `2`.
+13. Hotfix loop on post-merge red:
+- Run only for actionable or repo-fixable failures.
 - For each loop:
-- Create branch from updated `main`: `codex/hotfix-<topic>-r<1|2>`
-- Implement minimal fix.
+- Create branch from updated `main`: `codex/hotfix-<topic>-r<n>`
+- Implement the minimal fix set that clears all actionable blockers visible in the failing run.
 - Run `make prepush-full`.
 - `git add -A`
-- `git commit -m "hotfix: <summary> (r<1|2>)"`
+- `git commit -m "hotfix: <summary> (r<n>)"`
 - `git push -u origin <hotfix-branch>`
 - Open PR with heredoc EOF body.
 - Monitor PR CI to green (25 min timeout).
 - Merge PR.
 - `git checkout main && git pull --ff-only origin main`
 - Monitor post-merge CI again (25 min timeout).
+- Continue hotfixing while failures remain actionable and each cycle makes progress.
+- Stop only for external/non-actionable blockers, safety blockers, or 2 consecutive no-progress hotfix cycles.
 
 14. Stop conditions:
 - CI green on main: success.
 - Codex gate unresolved after passive latest-head poll plus PR-wide carry-forward triage, without any Codex `eyes` in-progress signal: stop and report blocker.
 - Codex gate remains pending with Codex `eyes` in-progress signal: continue waiting up to the `15 minute` Stage B window; only then stop and report blocker if no terminal signal appears.
-- Unresolved pre-merge `P0/P1` comments after 2 fix loops: stop and report blocker.
-- Non-actionable failure class: stop and report.
-- Loop count exceeded (`>2`): stop and report blocker.
+- Unresolved pre-merge actionable comments after 2 consecutive no-progress cycles: stop and report blocker.
+- Non-actionable or external failure class: stop and report.
+- Safety blocker or unexpected repo state that cannot be reconciled safely: stop and report blocker.
 
 ## Command Anchors
 
@@ -185,9 +194,8 @@ Never use inline `--body "..."` for multi-line PR text.
 - Codex review settle polling interval: `15 seconds`.
 - Codex review settle initial window: `15 minutes` to find latest-head terminal signals or an `eyes` in-progress signal.
 - Codex review settle after `eyes`: poll every `30 seconds` for up to `15 minutes` before blocking if no terminal signal appears.
-- Pre-merge comment-fix loop cap: `2`.
+- Local/PR/hotfix remediation policy: continue while failures are actionable and each cycle makes progress; stop after `2` consecutive no-progress cycles or when the blocker is external or safety-critical.
 - Post-merge main CI watch timeout: `25 minutes`.
-- Retry/hotfix loop cap: `2`.
 
 ## Expected Output
 

--- a/.agents/skills/commit-push/agents/openai.yaml
+++ b/.agents/skills/commit-push/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Commit Push"
-  short_description: "Ship branch, PR, and CI to green"
-  default_prompt: "Use $commit-push to commit changes, open or update a PR, and drive checks to green."
+  short_description: "Ship branch, fix blockers, land green"
+  default_prompt: "Use $commit-push to commit changes, open or update a PR, fix actionable blockers through CI and review loops, and land the branch on green main."

--- a/README.md
+++ b/README.md
@@ -125,6 +125,8 @@ verify=ok
 next=gait verify run_demo --json,gait regress bootstrap --from run_demo --json --junit ./gait-out/junit.xml,...
 ```
 
+For wrappers and SDKs, use `gait demo --json`; machine-readable clients should not scrape the human text form.
+
 No account. No API key. No hosted dependency.
 
 ## Simple End-To-End Scenario
@@ -133,7 +135,7 @@ See [`docs/scenarios/simple_agent_tool_boundary.md`](docs/scenarios/simple_agent
 
 ## What Ships In OSS
 
-**Gate** — evaluate structured tool-call intent against YAML policy with fail-closed enforcement. Non-allow means non-execute.
+**Gate** — evaluate structured tool-call intent against YAML policy with fail-closed enforcement. Non-allow means non-execute. When multiple rules at the same priority match, Gait resolves that priority tier to the most restrictive verdict instead of depending on rule names.
 
 **Evidence** — signed traces, runpacks, packs, and callpacks you can verify, diff, and attach to tickets, PRs, audits, and incidents.
 

--- a/cmd/gait/main_test.go
+++ b/cmd/gait/main_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"reflect"
 	"runtime"
 	"strings"
 	"testing"
@@ -2157,6 +2158,81 @@ func TestPolicyValidateFmtAndMatchedRuleOutput(t *testing.T) {
 	}
 }
 
+func TestPolicyTestEqualPriorityRenamesDoNotChangeVerdict(t *testing.T) {
+	workDir := t.TempDir()
+	withWorkingDir(t, workDir)
+
+	intentPath := filepath.Join(workDir, "intent.json")
+	writeIntentFixture(t, intentPath, "tool.write")
+
+	policyAPath := filepath.Join(workDir, "policy_a.yaml")
+	mustWriteFile(t, policyAPath, strings.Join([]string{
+		"default_verdict: allow",
+		"rules:",
+		"  - name: alpha-allow",
+		"    priority: 1",
+		"    effect: allow",
+		"    match:",
+		"      tool_names: [tool.write]",
+		"    reason_codes: [allow_write]",
+		"  - name: zeta-block",
+		"    priority: 1",
+		"    effect: block",
+		"    match:",
+		"      tool_names: [tool.write]",
+		"    reason_codes: [block_write]",
+	}, "\n")+"\n")
+
+	policyBPath := filepath.Join(workDir, "policy_b.yaml")
+	mustWriteFile(t, policyBPath, strings.Join([]string{
+		"default_verdict: allow",
+		"rules:",
+		"  - name: zeta-allow",
+		"    priority: 1",
+		"    effect: allow",
+		"    match:",
+		"      tool_names: [tool.write]",
+		"    reason_codes: [allow_write]",
+		"  - name: alpha-block",
+		"    priority: 1",
+		"    effect: block",
+		"    match:",
+		"      tool_names: [tool.write]",
+		"    reason_codes: [block_write]",
+	}, "\n")+"\n")
+
+	var codeA int
+	rawA := captureStdout(t, func() {
+		codeA = runPolicyTest([]string{policyAPath, intentPath, "--json"})
+	})
+	if codeA != exitPolicyBlocked {
+		t.Fatalf("expected policy A to block with exit %d, got %d", exitPolicyBlocked, codeA)
+	}
+	var outputA policyTestOutput
+	if err := json.Unmarshal([]byte(rawA), &outputA); err != nil {
+		t.Fatalf("decode policy A output: %v", err)
+	}
+
+	var codeB int
+	rawB := captureStdout(t, func() {
+		codeB = runPolicyTest([]string{policyBPath, intentPath, "--json"})
+	})
+	if codeB != exitPolicyBlocked {
+		t.Fatalf("expected policy B to block with exit %d, got %d", exitPolicyBlocked, codeB)
+	}
+	var outputB policyTestOutput
+	if err := json.Unmarshal([]byte(rawB), &outputB); err != nil {
+		t.Fatalf("decode policy B output: %v", err)
+	}
+
+	if outputA.Verdict != "block" || outputB.Verdict != "block" {
+		t.Fatalf("expected both policy tests to block, got %q and %q", outputA.Verdict, outputB.Verdict)
+	}
+	if !reflect.DeepEqual(outputA.ReasonCodes, outputB.ReasonCodes) {
+		t.Fatalf("expected stable reason codes across renamed rules, got %#v vs %#v", outputA.ReasonCodes, outputB.ReasonCodes)
+	}
+}
+
 func TestDemoJSONOutput(t *testing.T) {
 	workDir := t.TempDir()
 	withWorkingDir(t, workDir)
@@ -2914,18 +2990,11 @@ func TestGateEvalCredentialCommandBrokerAndRateLimit(t *testing.T) {
 		"      tool_names: [tool.write]",
 	}, "\n")+"\n")
 
-	brokerPath := filepath.Join(workDir, "broker.sh")
-	brokerScript := "#!/bin/sh\necho '{\"issued_by\":\"command\",\"credential_ref\":\"cmd:token\"}'\n"
-	if runtime.GOOS == "windows" {
-		brokerPath = filepath.Join(workDir, "broker.cmd")
-		brokerScript = "@echo {\"issued_by\":\"command\",\"credential_ref\":\"cmd:token\"}\r\n"
+	brokerPath, err := os.Executable()
+	if err != nil {
+		t.Fatalf("resolve test executable: %v", err)
 	}
-	mustWriteFile(t, brokerPath, brokerScript)
-	if runtime.GOOS != "windows" {
-		if err := os.Chmod(brokerPath, 0o700); err != nil {
-			t.Fatalf("chmod broker script: %v", err)
-		}
-	}
+	t.Setenv("GAIT_TEST_GATE_CREDENTIAL_BROKER_HELPER", "1")
 
 	rateStatePath := filepath.Join(workDir, "rate_state.json")
 	if code := runGateEval([]string{
@@ -2933,6 +3002,7 @@ func TestGateEvalCredentialCommandBrokerAndRateLimit(t *testing.T) {
 		"--intent", intentPath,
 		"--credential-broker", "command",
 		"--credential-command", brokerPath,
+		"--credential-command-args", "-test.run,TestGateEvalCredentialBrokerHelperProcess,--",
 		"--rate-limit-state", rateStatePath,
 		"--json",
 	}); code != exitOK {
@@ -2951,6 +3021,7 @@ func TestGateEvalCredentialCommandBrokerAndRateLimit(t *testing.T) {
 		"--intent", intentPath,
 		"--credential-broker", "command",
 		"--credential-command", brokerPath,
+		"--credential-command-args", "-test.run,TestGateEvalCredentialBrokerHelperProcess,--",
 		"--rate-limit-state", rateStatePath,
 		"--json",
 	}); code != exitPolicyBlocked {
@@ -2980,6 +3051,14 @@ func TestGateEvalCredentialCommandBrokerAndRateLimit(t *testing.T) {
 	}); code != exitInvalidInput {
 		t.Fatalf("runGateEval command broker missing command: expected %d got %d", exitInvalidInput, code)
 	}
+}
+
+func TestGateEvalCredentialBrokerHelperProcess(t *testing.T) {
+	if os.Getenv("GAIT_TEST_GATE_CREDENTIAL_BROKER_HELPER") != "1" {
+		t.Skip("helper process")
+	}
+	fmt.Print(`{"issued_by":"command","credential_ref":"cmd:token"}`)
+	os.Exit(0)
 }
 
 func TestGateEvalDestructiveBudgetAppliesToScriptTargets(t *testing.T) {

--- a/core/gate/policy.go
+++ b/core/gate/policy.go
@@ -216,6 +216,22 @@ type EvalOutcome struct {
 	MCPTrust                 *schemagate.MCPTrustDecision
 }
 
+type matchedRuleEvaluation struct {
+	RuleName                 string
+	Effect                   string
+	Reasons                  []string
+	Violations               []string
+	MinApprovals             int
+	RequireDistinctApprovers bool
+	RequireBrokerCredential  bool
+	RequireDelegation        bool
+	BrokerReference          string
+	BrokerScopes             []string
+	RateLimit                RateLimitPolicy
+	DestructiveBudget        RateLimitPolicy
+	DataflowTriggered        bool
+}
+
 func LoadPolicyFile(path string) (Policy, error) {
 	// #nosec G304 -- policy path is explicit local user input.
 	content, err := os.ReadFile(path)
@@ -326,63 +342,77 @@ func EvaluatePolicyDetailed(policy Policy, intent schemagate.IntentRequest, opts
 }
 
 func evaluateSingleIntent(policy Policy, intent schemagate.IntentRequest, opts EvalOptions) (EvalOutcome, error) {
+	matchedRules := make([]PolicyRule, 0, 1)
+	matchedPriority := 0
 	for _, rule := range policy.Rules {
 		if !ruleMatches(rule.Match, intent) {
 			continue
 		}
-		effect := rule.Effect
-		reasons := uniqueSorted(rule.ReasonCodes)
-		violations := uniqueSorted(rule.Violations)
-		if len(reasons) == 0 {
-			reasons = []string{"matched_rule_" + sanitizeName(rule.Name)}
+		if len(matchedRules) == 0 {
+			matchedPriority = rule.Priority
 		}
-		dataflowTriggered, dataflowEffect, dataflowReasons, dataflowViolations := evaluateDataflowConstraint(rule.Dataflow, intent)
-		if dataflowTriggered {
-			effect = dataflowEffect
-			reasons = mergeUniqueSorted(reasons, dataflowReasons)
-			violations = mergeUniqueSorted(violations, dataflowViolations)
+		if rule.Priority != matchedPriority {
+			break
 		}
-		endpointTriggered, endpointEffect, endpointReasons, endpointViolations := evaluateEndpointConstraint(rule.Endpoint, intent)
-		if endpointTriggered {
-			effect = mostRestrictiveVerdict(effect, endpointEffect)
-			reasons = mergeUniqueSorted(reasons, endpointReasons)
-			violations = mergeUniqueSorted(violations, endpointViolations)
+		matchedRules = append(matchedRules, rule)
+	}
+
+	if len(matchedRules) > 0 {
+		evaluations := make([]matchedRuleEvaluation, 0, len(matchedRules))
+		verdict := "allow"
+		matchedRuleNames := make([]string, 0, len(matchedRules))
+		for _, rule := range matchedRules {
+			evaluation := evaluateMatchedRule(rule, intent)
+			evaluations = append(evaluations, evaluation)
+			matchedRuleNames = append(matchedRuleNames, evaluation.RuleName)
+			verdict = mostRestrictiveVerdict(verdict, evaluation.Effect)
 		}
-		contextTriggered, contextEffect, contextReasons, contextViolations := evaluateContextConstraint(rule, intent)
-		if contextTriggered {
-			effect = mostRestrictiveVerdict(effect, contextEffect)
-			reasons = mergeUniqueSorted(reasons, contextReasons)
-			violations = mergeUniqueSorted(violations, contextViolations)
-		}
-		destructiveTarget := intentContainsDestructiveTarget(intent.Targets)
-		switch strings.ToLower(strings.TrimSpace(intent.Context.Phase)) {
-		case "plan":
-			if destructiveTarget {
-				effect = mostRestrictiveVerdict(effect, "dry_run")
-				reasons = mergeUniqueSorted(reasons, []string{"plan_phase_non_destructive"})
+
+		reasons := []string{}
+		violations := []string{}
+		minApprovals := 0
+		requireDistinctApprovers := false
+		requireBrokerCredential := false
+		requireDelegation := false
+		brokerReferences := []string{}
+		brokerScopes := []string{}
+		rateLimit := RateLimitPolicy{}
+		destructiveBudget := RateLimitPolicy{}
+		dataflowTriggered := false
+		for _, evaluation := range evaluations {
+			if evaluation.Effect != verdict {
+				continue
 			}
-		case "", "apply":
-			if destructiveTarget {
-				effect = mostRestrictiveVerdict(effect, "require_approval")
-				reasons = mergeUniqueSorted(reasons, []string{"destructive_apply_requires_approval"})
+			reasons = mergeUniqueSorted(reasons, evaluation.Reasons)
+			violations = mergeUniqueSorted(violations, evaluation.Violations)
+			if evaluation.MinApprovals > minApprovals {
+				minApprovals = evaluation.MinApprovals
 			}
+			requireDistinctApprovers = requireDistinctApprovers || evaluation.RequireDistinctApprovers
+			requireBrokerCredential = requireBrokerCredential || evaluation.RequireBrokerCredential
+			requireDelegation = requireDelegation || evaluation.RequireDelegation
+			brokerReferences = mergeUniqueSorted(brokerReferences, []string{evaluation.BrokerReference})
+			brokerScopes = mergeUniqueSorted(brokerScopes, evaluation.BrokerScopes)
+			rateLimit = mostRestrictiveRateLimitPolicy(rateLimit, evaluation.RateLimit)
+			destructiveBudget = mostRestrictiveRateLimitPolicy(destructiveBudget, evaluation.DestructiveBudget)
+			dataflowTriggered = dataflowTriggered || evaluation.DataflowTriggered
 		}
-		minApprovals := rule.MinApprovals
-		if effect == "require_approval" && minApprovals == 0 {
-			minApprovals = 1
+		if verdict != "require_approval" {
+			minApprovals = 0
+			requireDistinctApprovers = false
 		}
 		return EvalOutcome{
-			Result:                   buildGateResult(policy, intent, opts, effect, reasons, violations),
+			Result:                   buildGateResult(policy, intent, opts, verdict, reasons, violations),
 			PreparedIntent:           intent,
-			MatchedRule:              rule.Name,
+			MatchedRule:              strings.Join(uniqueSorted(matchedRuleNames), ","),
 			MinApprovals:             minApprovals,
-			RequireDistinctApprovers: rule.RequireDistinctApprovers,
-			RequireBrokerCredential:  rule.RequireBrokerCredential,
-			RequireDelegation:        rule.Match.RequireDelegation,
-			BrokerReference:          rule.BrokerReference,
-			BrokerScopes:             uniqueSorted(rule.BrokerScopes),
-			RateLimit:                rule.RateLimit,
-			DestructiveBudget:        rule.DestructiveBudget,
+			RequireDistinctApprovers: requireDistinctApprovers,
+			RequireBrokerCredential:  requireBrokerCredential,
+			RequireDelegation:        requireDelegation,
+			BrokerReference:          strings.Join(uniqueSorted(brokerReferences), ","),
+			BrokerScopes:             uniqueSorted(brokerScopes),
+			RateLimit:                rateLimit,
+			DestructiveBudget:        destructiveBudget,
 			DataflowTriggered:        dataflowTriggered,
 		}, nil
 	}
@@ -403,6 +433,66 @@ func evaluateSingleIntent(policy Policy, intent schemagate.IntentRequest, opts E
 		PreparedIntent: intent,
 		MinApprovals:   minApprovals,
 	}, nil
+}
+
+func evaluateMatchedRule(rule PolicyRule, intent schemagate.IntentRequest) matchedRuleEvaluation {
+	effect := rule.Effect
+	reasons := uniqueSorted(rule.ReasonCodes)
+	violations := uniqueSorted(rule.Violations)
+	if len(reasons) == 0 {
+		reasons = []string{"matched_rule_" + sanitizeName(rule.Name)}
+	}
+	dataflowTriggered, dataflowEffect, dataflowReasons, dataflowViolations := evaluateDataflowConstraint(rule.Dataflow, intent)
+	if dataflowTriggered {
+		effect = dataflowEffect
+		reasons = mergeUniqueSorted(reasons, dataflowReasons)
+		violations = mergeUniqueSorted(violations, dataflowViolations)
+	}
+	endpointTriggered, endpointEffect, endpointReasons, endpointViolations := evaluateEndpointConstraint(rule.Endpoint, intent)
+	if endpointTriggered {
+		effect = mostRestrictiveVerdict(effect, endpointEffect)
+		reasons = mergeUniqueSorted(reasons, endpointReasons)
+		violations = mergeUniqueSorted(violations, endpointViolations)
+	}
+	contextTriggered, contextEffect, contextReasons, contextViolations := evaluateContextConstraint(rule, intent)
+	if contextTriggered {
+		effect = mostRestrictiveVerdict(effect, contextEffect)
+		reasons = mergeUniqueSorted(reasons, contextReasons)
+		violations = mergeUniqueSorted(violations, contextViolations)
+	}
+	destructiveTarget := intentContainsDestructiveTarget(intent.Targets)
+	switch strings.ToLower(strings.TrimSpace(intent.Context.Phase)) {
+	case "plan":
+		if destructiveTarget {
+			effect = mostRestrictiveVerdict(effect, "dry_run")
+			reasons = mergeUniqueSorted(reasons, []string{"plan_phase_non_destructive"})
+		}
+	case "", "apply":
+		if destructiveTarget {
+			effect = mostRestrictiveVerdict(effect, "require_approval")
+			reasons = mergeUniqueSorted(reasons, []string{"destructive_apply_requires_approval"})
+		}
+	}
+	minApprovals := rule.MinApprovals
+	if effect == "require_approval" && minApprovals == 0 {
+		minApprovals = 1
+	}
+
+	return matchedRuleEvaluation{
+		RuleName:                 rule.Name,
+		Effect:                   effect,
+		Reasons:                  reasons,
+		Violations:               violations,
+		MinApprovals:             minApprovals,
+		RequireDistinctApprovers: rule.RequireDistinctApprovers,
+		RequireBrokerCredential:  rule.RequireBrokerCredential,
+		RequireDelegation:        rule.Match.RequireDelegation,
+		BrokerReference:          rule.BrokerReference,
+		BrokerScopes:             uniqueSorted(rule.BrokerScopes),
+		RateLimit:                rule.RateLimit,
+		DestructiveBudget:        rule.DestructiveBudget,
+		DataflowTriggered:        dataflowTriggered,
+	}
 }
 
 func evaluateScriptPolicyDetailed(policy Policy, intent schemagate.IntentRequest, opts EvalOptions) (EvalOutcome, error) {
@@ -1793,6 +1883,42 @@ func mostRestrictiveVerdict(current string, candidate string) string {
 		return candidate
 	}
 	return current
+}
+
+func mostRestrictiveRateLimitPolicy(current RateLimitPolicy, candidate RateLimitPolicy) RateLimitPolicy {
+	if candidate.Requests <= 0 {
+		return current
+	}
+	if current.Requests <= 0 {
+		return candidate
+	}
+	if candidate.Requests < current.Requests {
+		return candidate
+	}
+	if candidate.Requests > current.Requests {
+		return current
+	}
+	if rateLimitWindowRank(candidate.Window) < rateLimitWindowRank(current.Window) {
+		return candidate
+	}
+	if rateLimitWindowRank(candidate.Window) > rateLimitWindowRank(current.Window) {
+		return current
+	}
+	if candidate.Scope < current.Scope {
+		return candidate
+	}
+	return current
+}
+
+func rateLimitWindowRank(window string) int {
+	switch strings.ToLower(strings.TrimSpace(window)) {
+	case "minute":
+		return 0
+	case "hour":
+		return 1
+	default:
+		return 2
+	}
 }
 
 func buildGateResult(

--- a/core/gate/policy_test.go
+++ b/core/gate/policy_test.go
@@ -722,6 +722,180 @@ rules:
 	}
 }
 
+func TestEvaluatePolicyDetailedEqualPriorityUsesMostRestrictiveVerdict(t *testing.T) {
+	policy, err := ParsePolicyYAML([]byte(`
+default_verdict: allow
+rules:
+  - name: allow-write
+    priority: 1
+    effect: allow
+    match:
+      tool_names: [tool.write]
+    reason_codes: [allow_write]
+  - name: block-write
+    priority: 1
+    effect: block
+    match:
+      tool_names: [tool.write]
+    reason_codes: [block_write]
+    violations: [blocked_write]
+`))
+	if err != nil {
+		t.Fatalf("parse policy: %v", err)
+	}
+
+	intent := baseIntent()
+	intent.ToolName = "tool.write"
+
+	outcome, err := EvaluatePolicyDetailed(policy, intent, EvalOptions{})
+	if err != nil {
+		t.Fatalf("evaluate policy detailed: %v", err)
+	}
+	if outcome.Result.Verdict != "block" {
+		t.Fatalf("expected block verdict, got %#v", outcome.Result)
+	}
+	if !reflect.DeepEqual(outcome.Result.ReasonCodes, []string{"block_write"}) {
+		t.Fatalf("unexpected reason codes: %#v", outcome.Result.ReasonCodes)
+	}
+	if !reflect.DeepEqual(outcome.Result.Violations, []string{"blocked_write"}) {
+		t.Fatalf("unexpected violations: %#v", outcome.Result.Violations)
+	}
+	if outcome.MatchedRule != "allow-write,block-write" {
+		t.Fatalf("unexpected matched rule set: %q", outcome.MatchedRule)
+	}
+}
+
+func TestEvaluatePolicyDetailedEqualPriorityRenameDoesNotChangeVerdict(t *testing.T) {
+	intent := baseIntent()
+	intent.ToolName = "tool.write"
+
+	policyA, err := ParsePolicyYAML([]byte(`
+default_verdict: allow
+rules:
+  - name: alpha-allow
+    priority: 1
+    effect: allow
+    match:
+      tool_names: [tool.write]
+    reason_codes: [allow_write]
+  - name: zeta-block
+    priority: 1
+    effect: block
+    match:
+      tool_names: [tool.write]
+    reason_codes: [block_write]
+`))
+	if err != nil {
+		t.Fatalf("parse policy A: %v", err)
+	}
+	policyB, err := ParsePolicyYAML([]byte(`
+default_verdict: allow
+rules:
+  - name: zeta-allow
+    priority: 1
+    effect: allow
+    match:
+      tool_names: [tool.write]
+    reason_codes: [allow_write]
+  - name: alpha-block
+    priority: 1
+    effect: block
+    match:
+      tool_names: [tool.write]
+    reason_codes: [block_write]
+`))
+	if err != nil {
+		t.Fatalf("parse policy B: %v", err)
+	}
+
+	outcomeA, err := EvaluatePolicyDetailed(policyA, intent, EvalOptions{})
+	if err != nil {
+		t.Fatalf("evaluate policy A: %v", err)
+	}
+	outcomeB, err := EvaluatePolicyDetailed(policyB, intent, EvalOptions{})
+	if err != nil {
+		t.Fatalf("evaluate policy B: %v", err)
+	}
+	if outcomeA.Result.Verdict != outcomeB.Result.Verdict {
+		t.Fatalf("expected stable verdict across renamed rules, got %q vs %q", outcomeA.Result.Verdict, outcomeB.Result.Verdict)
+	}
+	if !reflect.DeepEqual(outcomeA.Result.ReasonCodes, outcomeB.Result.ReasonCodes) {
+		t.Fatalf("expected stable reason codes across renamed rules, got %#v vs %#v", outcomeA.Result.ReasonCodes, outcomeB.Result.ReasonCodes)
+	}
+}
+
+func TestMostRestrictiveRateLimitPolicy(t *testing.T) {
+	tests := []struct {
+		name      string
+		current   RateLimitPolicy
+		candidate RateLimitPolicy
+		want      RateLimitPolicy
+	}{
+		{
+			name:      "ignore empty candidate",
+			current:   RateLimitPolicy{Requests: 5, Window: "day", Scope: "workspace"},
+			candidate: RateLimitPolicy{},
+			want:      RateLimitPolicy{Requests: 5, Window: "day", Scope: "workspace"},
+		},
+		{
+			name:      "use candidate when current unset",
+			current:   RateLimitPolicy{},
+			candidate: RateLimitPolicy{Requests: 4, Window: "day", Scope: "workspace"},
+			want:      RateLimitPolicy{Requests: 4, Window: "day", Scope: "workspace"},
+		},
+		{
+			name:      "prefer lower request count",
+			current:   RateLimitPolicy{Requests: 6, Window: "day", Scope: "workspace"},
+			candidate: RateLimitPolicy{Requests: 3, Window: "hour", Scope: "workspace"},
+			want:      RateLimitPolicy{Requests: 3, Window: "hour", Scope: "workspace"},
+		},
+		{
+			name:      "prefer shorter window on tied requests",
+			current:   RateLimitPolicy{Requests: 3, Window: "day", Scope: "workspace"},
+			candidate: RateLimitPolicy{Requests: 3, Window: "hour", Scope: "workspace"},
+			want:      RateLimitPolicy{Requests: 3, Window: "hour", Scope: "workspace"},
+		},
+		{
+			name:      "prefer smaller scope on tied requests and window",
+			current:   RateLimitPolicy{Requests: 3, Window: "hour", Scope: "workspace"},
+			candidate: RateLimitPolicy{Requests: 3, Window: "hour", Scope: "org"},
+			want:      RateLimitPolicy{Requests: 3, Window: "hour", Scope: "org"},
+		},
+		{
+			name:      "keep current when candidate is less restrictive",
+			current:   RateLimitPolicy{Requests: 3, Window: "hour", Scope: "org"},
+			candidate: RateLimitPolicy{Requests: 3, Window: "day", Scope: "workspace"},
+			want:      RateLimitPolicy{Requests: 3, Window: "hour", Scope: "org"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := mostRestrictiveRateLimitPolicy(tc.current, tc.candidate)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("mostRestrictiveRateLimitPolicy(%#v, %#v) = %#v, want %#v", tc.current, tc.candidate, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRateLimitWindowRank(t *testing.T) {
+	tests := []struct {
+		window string
+		want   int
+	}{
+		{window: "minute", want: 0},
+		{window: " HOUR ", want: 1},
+		{window: "day", want: 2},
+	}
+
+	for _, tc := range tests {
+		if got := rateLimitWindowRank(tc.window); got != tc.want {
+			t.Fatalf("rateLimitWindowRank(%q) = %d, want %d", tc.window, got, tc.want)
+		}
+	}
+}
+
 func TestPolicyHighRiskBrokerRequirements(t *testing.T) {
 	withoutBroker, err := ParsePolicyYAML([]byte(`
 default_verdict: allow

--- a/core/gate/trace.go
+++ b/core/gate/trace.go
@@ -278,8 +278,10 @@ func matchedRuleIDsFromStepVerdicts(stepVerdicts []schemagate.TraceStepVerdict) 
 	}
 	matched := make([]string, 0, len(stepVerdicts))
 	for _, step := range stepVerdicts {
-		if ruleID := strings.TrimSpace(step.MatchedRule); ruleID != "" {
-			matched = append(matched, ruleID)
+		for _, ruleID := range strings.Split(step.MatchedRule, ",") {
+			if trimmed := strings.TrimSpace(ruleID); trimmed != "" {
+				matched = append(matched, trimmed)
+			}
 		}
 	}
 	return uniqueSorted(matched)

--- a/core/gate/trace_test.go
+++ b/core/gate/trace_test.go
@@ -419,7 +419,7 @@ func TestEmitSignedTraceRelationshipEnvelope(t *testing.T) {
 		TracePath:         filepath.Join(t.TempDir(), "trace_relationship_1.json"),
 		StepVerdicts: []schemagate.TraceStepVerdict{
 			{Index: 0, ToolName: "tool.write", Verdict: "allow", MatchedRule: "rule-z"},
-			{Index: 1, ToolName: "tool.write", Verdict: "allow", MatchedRule: "rule-a"},
+			{Index: 1, ToolName: "tool.write", Verdict: "allow", MatchedRule: "rule-b, rule-a"},
 			{Index: 2, ToolName: "tool.write", Verdict: "allow", MatchedRule: "rule-a"},
 		},
 	})
@@ -432,16 +432,16 @@ func TestEmitSignedTraceRelationshipEnvelope(t *testing.T) {
 	if first.Trace.Relationship.ParentRef == nil || first.Trace.Relationship.ParentRef.Kind != "session" || first.Trace.Relationship.ParentRef.ID != "sess_demo" {
 		t.Fatalf("unexpected parent_ref: %#v", first.Trace.Relationship.ParentRef)
 	}
-	if first.Trace.Relationship.PolicyRef == nil || len(first.Trace.Relationship.PolicyRef.MatchedRuleIDs) != 2 {
+	if first.Trace.Relationship.PolicyRef == nil || len(first.Trace.Relationship.PolicyRef.MatchedRuleIDs) != 3 {
 		t.Fatalf("expected matched rule ids in relationship policy_ref: %#v", first.Trace.Relationship.PolicyRef)
 	}
 	if first.Trace.PolicyID != policy.SchemaID || first.Trace.PolicyVersion != policy.SchemaVersion {
 		t.Fatalf("expected policy lineage fields in trace: id=%q version=%q", first.Trace.PolicyID, first.Trace.PolicyVersion)
 	}
-	if len(first.Trace.MatchedRuleIDs) != 2 {
+	if len(first.Trace.MatchedRuleIDs) != 3 {
 		t.Fatalf("expected matched_rule_ids in trace: %#v", first.Trace.MatchedRuleIDs)
 	}
-	if first.Trace.Relationship.PolicyRef.MatchedRuleIDs[0] != "rule-a" || first.Trace.Relationship.PolicyRef.MatchedRuleIDs[1] != "rule-z" {
+	if first.Trace.Relationship.PolicyRef.MatchedRuleIDs[0] != "rule-a" || first.Trace.Relationship.PolicyRef.MatchedRuleIDs[1] != "rule-b" || first.Trace.Relationship.PolicyRef.MatchedRuleIDs[2] != "rule-z" {
 		t.Fatalf("expected deterministic matched rule ordering, got %#v", first.Trace.Relationship.PolicyRef.MatchedRuleIDs)
 	}
 	if len(first.Trace.Relationship.EntityRefs) == 0 || len(first.Trace.Relationship.Edges) == 0 {

--- a/docs-site/public/llm/contracts.md
+++ b/docs-site/public/llm/contracts.md
@@ -7,6 +7,7 @@ Stable OSS contracts include:
 - **ContextSpec v1**: Deterministic context evidence envelopes with privacy-aware modes and fail-closed enforcement. For `gait gate eval`, required context-proof checks are satisfied through a verified `--context-envelope` input rather than raw intent claims.
 - **Primitive Contract**: Four deterministic primitives — capture, enforce, regress, diagnose.
 - **Repo Policy Contract**: `gait init` writes `.gait.yaml`; `gait check` reports the live contract (`default_verdict`, `rule_count`, `gap_warnings`).
+- **Equal-Priority Policy Semantics**: when multiple rules at the same priority match one intent, Gait evaluates that priority tier and applies the most restrictive verdict rather than depending on rule names.
 - **MCP Trust + Trace Onboarding**: local MCP trust snapshots and observe-only `gait trace` are additive onboarding contracts over the same signed trace and policy surfaces.
   - `mcp_trust.snapshot` must point at a local file; scanners and registries remain complementary inputs.
 - **Script Governance Contract**: Script intent steps, deterministic `script_hash`, Wrkr-derived context matching fields, and signed approved-script registry entries.

--- a/docs-site/public/llm/quickstart.md
+++ b/docs-site/public/llm/quickstart.md
@@ -13,6 +13,9 @@ gait check --json
 # Create a signed pack from a synthetic agent run
 gait demo
 
+# Machine-readable wrapper/SDK path
+gait demo --json
+
 # Prove it's intact
 gait verify run_demo --json
 
@@ -34,6 +37,8 @@ run_id=run_demo
 ticket_footer=GAIT run_id=run_demo ...
 verify=ok
 ```
+
+For SDKs and wrappers, prefer the JSON form and treat the text form as human-facing output only.
 
 Then continue with one integration seam:
 

--- a/docs-site/public/llms.txt
+++ b/docs-site/public/llms.txt
@@ -11,6 +11,7 @@
 - gait check --json
 - gait gate eval --policy <policy.yaml> --intent <intent.json> [--context-envelope <context_envelope.json>]
 - gait demo
+- gait demo --json
 - gait verify <run_id|path>
 - gait test -- <child command...>
 - gait enforce -- <child command...>
@@ -48,6 +49,7 @@
 
 ## Safety Model
 - Fail-closed by default for ambiguous high-risk policy outcomes.
+- Equal-priority rule overlaps resolve to the most restrictive verdict for that priority tier, not by rule name ordering.
 - `gait init` writes `.gait.yaml`; `gait check` reports the live policy contract and gap warnings.
 - Offline verification for packs, runpacks, and traces.
 - Structured intent model for policy decisions, not free-form prompt filtering.

--- a/docs/policy_authoring.md
+++ b/docs/policy_authoring.md
@@ -34,6 +34,16 @@ Interpretation:
 - `policy test` evaluates one intent fixture and returns verdict, reason codes, and `matched_rule`.
 - `policy simulate` compares baseline vs candidate verdicts over fixture corpora and recommends rollout stage (`observe`, `require_approval`, `enforce`).
 
+## Equal-Priority Contract
+
+When multiple rules at the same priority match one intent, Gait evaluates the entire matching priority tier and applies the most restrictive verdict from that tier.
+
+- verdict precedence is `allow < dry_run < require_approval < block`
+- renaming same-priority rules must not change the verdict
+- `matched_rule` remains deterministic and may include a comma-separated set of same-priority matches when more than one rule is visible
+
+If you need one rule to win unconditionally, give it a strictly lower numeric `priority` instead of relying on rule names.
+
 ## Repo-Root Policy Contract
 
 The default onboarding contract is the repo-root file `.gait.yaml`.
@@ -145,6 +155,7 @@ This gives fast feedback for enum values and unknown keys before runtime.
 - Run `policy simulate` against representative fixture sets before changing rollout stage.
 - Keep policy files formatted by `policy fmt --write` before review.
 - Review policy changes with fixture deltas and matched-rule evidence, not raw YAML diff alone.
+- Include equal-priority overlap fixtures in CI when multiple rules intentionally target the same tool surface.
 - Keep the repo-default contract truthful: if docs say `.gait.yaml`, examples should use `.gait.yaml` unless a custom path is the point of the example.
 
 ## Signing Key Lifecycle (Local)

--- a/docs/sdk/python.md
+++ b/docs/sdk/python.md
@@ -18,7 +18,7 @@ Supported primitives:
 
 - intent capture (`capture_intent`)
 - gate evaluation (`evaluate_gate`)
-- demo capture (`capture_demo_runpack`)
+- demo capture (`capture_demo_runpack`, via `gait demo --json`)
 - regress fixture init (`create_regress_fixture`)
 - run capture (`record_runpack`)
 - trace copy/validation (`write_trace`)
@@ -36,6 +36,7 @@ The SDK executes commands via `subprocess.run(...)` with a bounded timeout.
 
 - default timeout: `30s`
 - JSON-decoding is strict for command responses expected to be JSON
+- demo capture consumes machine-readable `gait demo --json` output only
 - non-zero exits raise `GaitCommandError` with command, exit code, stdout, and stderr
 
 ## Binary Resolution And Errors

--- a/sdk/python/gait/client.py
+++ b/sdk/python/gait/client.py
@@ -183,37 +183,38 @@ def write_trace(*, trace_path: str | Path, destination_path: str | Path) -> Path
 def capture_demo_runpack(
     *, gait_bin: str | Sequence[str] = "gait", cwd: str | Path | None = None
 ) -> DemoCapture:
-    result = _run_command(_command_prefix(gait_bin) + ["demo"], cwd=cwd)
-    if result.exit_code != 0:
+    result = _run_command(_command_prefix(gait_bin) + ["demo", "--json"], cwd=cwd)
+    payload = _parse_json_stdout(result.stdout)
+    if payload is None:
         raise GaitCommandError(
-            "gait demo failed",
+            "failed to parse JSON from gait demo",
+            command=result.command,
+            exit_code=result.exit_code,
+            stdout=result.stdout,
+            stderr=result.stderr,
+        )
+    if result.exit_code != 0:
+        message = str(payload.get("error") or "gait demo failed")
+        raise GaitCommandError(
+            message,
             command=result.command,
             exit_code=result.exit_code,
             stdout=result.stdout,
             stderr=result.stderr,
         )
 
-    run_id = ""
-    bundle_path = ""
-    ticket_footer = ""
-    verified = False
-    for line in result.stdout.splitlines():
-        if line.startswith("run_id="):
-            run_id = line.removeprefix("run_id=").strip()
-        elif line.startswith("bundle="):
-            bundle_path = line.removeprefix("bundle=").strip()
-        elif line.startswith("ticket_footer="):
-            ticket_footer = line.removeprefix("ticket_footer=").strip()
-        elif line.strip() == "verify=ok":
-            verified = True
+    if not bool(payload.get("ok", False)):
+        raise GaitError("gait demo returned ok=false")
 
+    run_id = str(payload.get("run_id", ""))
+    bundle_path = str(payload.get("bundle", ""))
     if not run_id or not bundle_path:
-        raise GaitError("unable to parse gait demo output")
+        raise GaitError("gait demo JSON response is missing run_id or bundle")
     return DemoCapture(
         run_id=run_id,
         bundle_path=bundle_path,
-        ticket_footer=ticket_footer,
-        verified=verified,
+        ticket_footer=str(payload.get("ticket_footer", "")),
+        verified=str(payload.get("verify", "")).strip().lower() == "ok",
         raw_output=result.stdout,
     )
 

--- a/sdk/python/tests/helpers.py
+++ b/sdk/python/tests/helpers.py
@@ -98,11 +98,26 @@ def run_regress_init():
     return 0
 
 
-def run_demo():
-    print("run_id=run_demo")
-    print("bundle=./gait-out/runpack_run_demo.zip")
-    print("ticket_footer=GAIT run_id=run_demo manifest=sha256:abc verify=\\"gait verify run_demo\\"")
-    print("verify=ok")
+def run_demo(args):
+    if "--json" in args:
+        print(
+            json.dumps(
+                {
+                    "ok": True,
+                    "mode": "standard",
+                    "run_id": "run_demo",
+                    "bundle": "./gait-out/runpack_run_demo.zip",
+                    "ticket_footer": 'GAIT run_id=run_demo manifest=sha256:abc verify="gait verify run_demo"',
+                    "verify": "ok",
+                }
+            )
+        )
+        return 0
+
+    print("demo_run=run_demo")
+    print("artifact=./gait-out/runpack_run_demo.zip")
+    print('receipt=GAIT run_id=run_demo manifest=sha256:abc verify="gait verify run_demo"')
+    print("verification_status=ok")
     return 0
 
 
@@ -149,7 +164,7 @@ def main():
     if args[:2] == ["run", "record"]:
         return run_record(args[2:])
     if args[:1] == ["demo"]:
-        return run_demo()
+        return run_demo(args[1:])
     print(json.dumps({"ok": False, "error": "unsupported command", "argv": args}))
     return 6
 

--- a/sdk/python/tests/test_client.py
+++ b/sdk/python/tests/test_client.py
@@ -4,6 +4,7 @@ import json
 import subprocess
 import sys
 from pathlib import Path
+from typing import Sequence
 
 import pytest
 
@@ -153,6 +154,34 @@ def test_capture_demo_and_create_regress_fixture(tmp_path: Path) -> None:
     assert fixture.run_id == "run_demo"
     assert fixture.fixture_name == "run_demo"
     assert fixture.runpack_path == "fixtures/run_demo/runpack.zip"
+
+
+def test_capture_demo_runpack_uses_json_cli_contract(tmp_path: Path) -> None:
+    observed_commands: list[list[str]] = []
+
+    def fake_run(command: Sequence[str], cwd: object = None) -> client_module._CommandResult:
+        observed_commands.append(list(command))
+        return client_module._CommandResult(
+            command=list(command),
+            exit_code=0,
+            stdout=json.dumps(
+                {
+                    "ok": True,
+                    "run_id": "run_demo",
+                    "bundle": "./gait-out/runpack_run_demo.zip",
+                    "ticket_footer": "GAIT run_id=run_demo manifest=sha256:abc",
+                    "verify": "ok",
+                }
+            ),
+            stderr="",
+        )
+
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setattr(client_module, "_run_command", fake_run)
+        demo = capture_demo_runpack(gait_bin="gait", cwd=tmp_path)
+
+    assert demo.run_id == "run_demo"
+    assert observed_commands == [["gait", "demo", "--json"]]
 
 
 def test_record_runpack_round_trip(tmp_path: Path) -> None:
@@ -345,6 +374,25 @@ def test_create_regress_fixture_malformed_json_raises_command_error(
 
     with pytest.raises(client_module.GaitCommandError) as raised:
         create_regress_fixture(from_run="run_demo", gait_bin="gait", cwd=tmp_path)
+    assert "failed to parse JSON" in str(raised.value)
+
+
+def test_capture_demo_runpack_malformed_json_raises_command_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        client_module,
+        "_run_command",
+        lambda command, cwd=None: client_module._CommandResult(
+            command=list(command),
+            exit_code=0,
+            stdout="run_id=run_demo\nbundle=./gait-out/runpack_run_demo.zip\n",
+            stderr="",
+        ),
+    )
+
+    with pytest.raises(client_module.GaitCommandError) as raised:
+        capture_demo_runpack(gait_bin="gait", cwd=tmp_path)
     assert "failed to parse JSON" in str(raised.value)
 
 


### PR DESCRIPTION
## Problem
- same-priority policy rule overlaps could depend on rule naming rather than the most restrictive outcome
- the Python SDK demo helper scraped human text output instead of consuming the machine-readable CLI contract
- the repo ship-loop skill still stopped on several actionable blockers instead of fixing them in-loop

## Changes
- evaluate all matching rules in the highest-priority tier and apply the most restrictive verdict with deterministic matched-rule metadata
- add Go regression coverage for equal-priority verdict stability and rate-limit policy selection
- switch Python demo capture to `gait demo --json` and add JSON-contract tests and helper fixtures
- sync README/docs/llm docs with the equal-priority policy contract and JSON demo guidance
- update the `commit-push` skill to keep fixing actionable blockers through local, PR, and hotfix loops

## Validation
- `go run ./cmd/gait doctor --json`
- `make prepush-full`
- push hook `make prepush`
