### PR TITLE
docs: sync W4 release-trust and CI guards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,6 +212,30 @@ jobs:
         run: |
           make test-scenarios
 
+  boundary-repro-guards:
+    needs: changes
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+      - name: Run boundary contract repro guards
+        env:
+          PYTHONPATH: .
+        shell: bash
+        run: |
+          go test ./cmd/gait -count=1 -run 'TestRunGateEvalRequiresVerifiedContextEnvelopeForContextPolicies|TestPolicyTestEqualPriorityRenamesDoNotChangeVerdict'
+          go test ./core/gate -count=1 -run 'TestEvaluatePolicyDetailedEqualPriorityRenameDoesNotChangeVerdict'
+          go test ./core/jobruntime -count=1 -run 'TestSubmitAppendFailureRollsBackNewJob|TestMutationAppendFailureRollsBackStateAndRetrySucceeds|TestMutationAppendFailureWithDurableEventPreservesPendingMarker'
+          cd sdk/python
+          uv run --python 3.13 --extra dev pytest tests/test_client.py -q -k 'capture_demo_runpack_uses_json_cli_contract or capture_demo_runpack_malformed_json_raises_command_error'
+
   e2e:
     needs: changes
     runs-on: ${{ matrix.os }}
@@ -464,6 +488,22 @@ jobs:
         shell: bash
         run: |
           make test-v2-5-acceptance
+
+  v2-6-acceptance:
+    needs: changes
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - name: Run v2.6 acceptance gate
+        shell: bash
+        run: |
+          make test-v2-6-acceptance
 
   voice-acceptance:
     needs: changes

--- a/.github/workflows/pr-fast.yml
+++ b/.github/workflows/pr-fast.yml
@@ -58,6 +58,31 @@ jobs:
         run: |
           bash scripts/validate_scenarios.sh
 
+  repro-guards:
+    name: pr-fast-repro-guards
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - name: Install uv
+        run: |
+          python -m pip install --upgrade pip uv
+      - name: Run boundary contract repro guards
+        env:
+          PYTHONPATH: .
+        shell: bash
+        run: |
+          go test ./cmd/gait -count=1 -run 'TestRunGateEvalRequiresVerifiedContextEnvelopeForContextPolicies|TestPolicyTestEqualPriorityRenamesDoNotChangeVerdict'
+          go test ./core/gate -count=1 -run 'TestEvaluatePolicyDetailedEqualPriorityRenameDoesNotChangeVerdict'
+          go test ./core/jobruntime -count=1 -run 'TestSubmitAppendFailureRollsBackNewJob|TestMutationAppendFailureRollsBackStateAndRetrySucceeds|TestMutationAppendFailureWithDurableEventPreservesPendingMarker'
+          cd sdk/python
+          uv run --python 3.13 --extra dev pytest tests/test_client.py -q -k 'capture_demo_runpack_uses_json_cli_contract or capture_demo_runpack_malformed_json_raises_command_error'
+
   windows-fast:
     name: pr-fast-windows
     runs-on: windows-latest
@@ -67,8 +92,22 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - name: Install uv
+        shell: bash
+        run: |
+          python -m pip install --upgrade pip uv
       - name: Windows Go smoke suite
         shell: bash
         run: |
           go test -json ./...
           go build ./cmd/gait
+      - name: Windows Python SDK repro guard
+        shell: bash
+        env:
+          PYTHONPATH: .
+        run: |
+          cd sdk/python
+          uv run --python 3.13 --extra dev pytest tests/test_client.py -q -k 'capture_demo_runpack_uses_json_cli_contract or capture_demo_runpack_malformed_json_raises_command_error'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,8 +81,62 @@ jobs:
           make test-runtime-slo
           make bench-check
 
+  v2_6_gate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - name: Run v2.6 release contract gate
+        run: |
+          make test-v2-6-acceptance
+
+  boundary_repro_gate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+      - name: Run boundary contract repro guards
+        env:
+          PYTHONPATH: .
+        shell: bash
+        run: |
+          go test ./cmd/gait -count=1 -run 'TestRunGateEvalRequiresVerifiedContextEnvelopeForContextPolicies|TestPolicyTestEqualPriorityRenamesDoNotChangeVerdict'
+          go test ./core/gate -count=1 -run 'TestEvaluatePolicyDetailedEqualPriorityRenameDoesNotChangeVerdict'
+          go test ./core/jobruntime -count=1 -run 'TestSubmitAppendFailureRollsBackNewJob|TestMutationAppendFailureRollsBackStateAndRetrySucceeds|TestMutationAppendFailureWithDurableEventPreservesPendingMarker'
+          cd sdk/python
+          uv run --python 3.13 --extra dev pytest tests/test_client.py -q -k 'capture_demo_runpack_uses_json_cli_contract or capture_demo_runpack_malformed_json_raises_command_error'
+
+  hardening_gate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - name: Run release hardening gate
+        run: |
+          make test-hardening-acceptance
+
   release:
-    needs: [v2_3_gate, v2_4_gate, v2_5_gate]
+    needs: [v2_3_gate, v2_4_gate, v2_5_gate, v2_6_gate, boundary_repro_gate, hardening_gate]
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/README.md
+++ b/README.md
@@ -127,6 +127,18 @@ next=gait verify run_demo --json,gait regress bootstrap --from run_demo --json -
 
 For wrappers and SDKs, use `gait demo --json`; machine-readable clients should not scrape the human text form.
 
+Integration touchpoints:
+
+- Wrapper or sidecar: call `gait gate eval` at the exact tool-dispatch site before side effects execute.
+- Context-required policies: pass `--context-envelope <context_envelope.json>` at that boundary; raw `intent.context_set_digest`, `intent.context_evidence_mode`, or `context.auth_context.context_age_seconds` claims are treated as non-authoritative until the envelope is verified.
+- SDKs and automation: use `gait demo --json` for smoke checks and handoffs; the text form is human-facing only.
+- Policy authors: when same-priority rules overlap, Gait applies the most restrictive verdict for that priority tier. Use a strictly lower numeric `priority` when one rule must win.
+
+Migration notes:
+
+- If an older integration relied on raw intent context fields to satisfy `require_context_evidence`, move that proof to a verified `--context-envelope` input.
+- If tooling parsed `gait demo` text output, switch it to `gait demo --json` or the Python SDK helper surface.
+
 No account. No API key. No hosted dependency.
 
 ## Simple End-To-End Scenario

--- a/docs-site/public/llm/contracts.md
+++ b/docs-site/public/llm/contracts.md
@@ -6,6 +6,7 @@ Stable OSS contracts include:
   - includes first-class export surfaces: `gait pack export --otel-out ...` and `--postgres-sql-out ...` for observability and metadata indexing.
 - **ContextSpec v1**: Deterministic context evidence envelopes with privacy-aware modes and fail-closed enforcement. For `gait gate eval`, required context-proof checks are satisfied through a verified `--context-envelope` input rather than raw intent claims.
 - **Primitive Contract**: Four deterministic primitives — capture, enforce, regress, diagnose.
+- **Python SDK Demo Contract**: machine-readable SDK/demo capture consumes `gait demo --json` output only; the human text form is non-contractual.
 - **Repo Policy Contract**: `gait init` writes `.gait.yaml`; `gait check` reports the live contract (`default_verdict`, `rule_count`, `gap_warnings`).
 - **Equal-Priority Policy Semantics**: when multiple rules at the same priority match one intent, Gait evaluates that priority tier and applies the most restrictive verdict rather than depending on rule names.
 - **MCP Trust + Trace Onboarding**: local MCP trust snapshots and observe-only `gait trace` are additive onboarding contracts over the same signed trace and policy surfaces.

--- a/docs-site/public/llm/faq.md
+++ b/docs-site/public/llm/faq.md
@@ -6,7 +6,7 @@ Gait enforces fail-closed policy before agent tool side effects execute and keep
 
 ## What should teams run first?
 
-Run `gait init --json`, `gait check --json`, `gait demo`, `gait verify run_demo --json`, and `gait regress bootstrap --from run_demo --json --junit ./gait-out/junit.xml`.
+Run `gait init --json`, `gait check --json`, `gait demo` for the operator path, `gait demo --json` for wrappers/SDKs, then `gait verify run_demo --json` and `gait regress bootstrap --from run_demo --json --junit ./gait-out/junit.xml`.
 
 ## What problem does Gait solve for long-running agent work?
 
@@ -36,6 +36,8 @@ Yes. Voice mode gates high-stakes spoken commitments before they are uttered. A 
 
 Context evidence is deterministic proof of what context material the model was working from at decision time. Gait captures privacy-aware context envelopes and enforces fail-closed policy when evidence is missing for high-risk actions.
 
+For context-required policies, the gate only trusts a verified `--context-envelope` input; raw context digest, mode, or age claims inside the intent are not sufficient on their own.
+
 ## Can I replay an agent run without re-executing real API calls?
 
 Yes. `gait run replay` uses recorded results as deterministic stubs so you can debug safely. `gait pack diff` then shows exactly what changed between two runs, including context drift classification.
@@ -50,4 +52,4 @@ Yes. Use `gait approve-script` to mint signed registry entries bound to policy d
 
 ## How should teams start?
 
-Bootstrap `.gait.yaml` with `gait init` and `gait check`, then run `gait demo` and wire one integration seam from the integration checklist.
+Bootstrap `.gait.yaml` with `gait init` and `gait check`, run `gait demo --json` for automation, then wire one integration seam from the integration checklist at the real tool-dispatch boundary.

--- a/docs-site/public/llm/product.md
+++ b/docs-site/public/llm/product.md
@@ -9,14 +9,14 @@ It provides seven OSS primitives:
 3. **Regress**: Convert incidents into deterministic CI regression fixtures with JUnit output and stable exit codes through `gait capture`, `gait regress add`, and `gait regress bootstrap`.
 4. **Jobs**: Dispatch multi-step, multi-hour agent work with checkpoints, pause/resume/stop/cancel, approval gates, deterministic stop reasons, and emergency-stop preemption evidence.
 5. **Voice**: Gate high-stakes spoken commitments before they are uttered with SayToken capability tokens and callpack artifacts.
-6. **Context Evidence**: Deterministic proof of what context the model was working from at decision time. Privacy-aware envelopes with fail-closed enforcement when evidence is missing.
+6. **Context Evidence**: Deterministic proof of what context the model was working from at decision time. Privacy-aware envelopes with fail-closed enforcement when evidence is missing, and context-required gate checks bind digest/mode/freshness from a verified `--context-envelope`.
 7. **Doctor**: Diagnose first-run environment issues with stable JSON output.
 
 Secondary boundary surfaces:
 
 - **MCP Trust**: evaluate local trust snapshots for MCP server admission with `gait mcp verify`, `gait mcp proxy`, and `gait mcp serve`.
 - **Trace**: observe-only wrapper mode with `gait trace` for integrations that already emit Gait trace references.
-- **LangChain Middleware**: official Python middleware with optional callback correlation; callbacks never decide allow or block behavior.
+- **LangChain Middleware**: official Python middleware with optional callback correlation; callbacks never decide allow or block behavior, and demo capture stays bound to `gait demo --json`.
 
 Gait is vendor-neutral and offline-first for core workflows: capture, verify, diff, policy evaluation, regressions, and voice/context verification all run without network dependencies.
 

--- a/docs-site/public/llm/quickstart.md
+++ b/docs-site/public/llm/quickstart.md
@@ -40,12 +40,20 @@ verify=ok
 
 For SDKs and wrappers, prefer the JSON form and treat the text form as human-facing output only.
 
+Context-required policies must pass `--context-envelope <context_envelope.json>` on `gait gate eval`; raw intent context claims are not authoritative by themselves.
+
 Then continue with one integration seam:
 
 - one-PR CI adoption: `/docs/adopt_in_one_pr/`
 - durable jobs lifecycle: `/docs/durable_jobs/`
 - production integration checklist: `/docs/integration_checklist/`
 - LangChain middleware contract: `/docs/sdk/python/`
+
+Boundary touchpoints:
+
+- wrapper or sidecar dispatch site: `gait gate eval`
+- context-required boundary: `gait gate eval --context-envelope ...`
+- machine-readable smoke path: `gait demo --json`
 
 Use `gait policy test` and `gait gate eval --simulate` before enforce rollout on high-risk tool-call boundaries. `gait enforce` is a bounded wrapper for integrations that already emit Gait trace references.
 

--- a/docs-site/public/llm/security.md
+++ b/docs-site/public/llm/security.md
@@ -10,7 +10,7 @@
 - Approval tokens can carry bounded destructive scope (`max_targets`, `max_ops`); overruns fail closed.
 - Approved-script registry entries are signature-verified and policy-digest bound; tampered or missing state fails closed in high-risk enforcement.
 - SayToken capability tokens for voice agent commitment gating — gated speech cannot execute without a valid token.
-- Context evidence envelopes with fail-closed enforcement when evidence is missing for high-risk actions; `gait gate eval` requires a verified `--context-envelope` input for context-required policies.
+- Context evidence envelopes with fail-closed enforcement when evidence is missing for high-risk actions; `gait gate eval` requires a verified `--context-envelope` input for context-required policies, and raw intent digest/mode/age claims are not sufficient on their own.
 - Durable jobs with deterministic stop reasons and checkpoint integrity.
 - No hosted service dependency required for core operation.
 - MCP trust inputs remain local-file based and complementary to external scanners or registries; Gait enforces, it does not become the scanner.

--- a/docs-site/public/llms.txt
+++ b/docs-site/public/llms.txt
@@ -35,6 +35,7 @@
 - Boundary location: the exact adapter call site before real tool side effects execute.
 - Input: structured intent payload.
 - Rule: `verdict != allow` means no tool execution.
+- Context-required policies must receive `--context-envelope <context_envelope.json>` at that boundary; raw context digest/mode/age claims are not authoritative alone.
 - Official LangChain lane: middleware with optional callback correlation, not a separate policy engine.
 
 ## When To Use
@@ -50,6 +51,7 @@
 ## Safety Model
 - Fail-closed by default for ambiguous high-risk policy outcomes.
 - Equal-priority rule overlaps resolve to the most restrictive verdict for that priority tier, not by rule name ordering.
+- Machine-readable wrappers and SDKs use `gait demo --json`; the text form is human-facing only.
 - `gait init` writes `.gait.yaml`; `gait check` reports the live policy contract and gap warnings.
 - Offline verification for packs, runpacks, and traces.
 - Structured intent model for policy decisions, not free-form prompt filtering.

--- a/docs/agent_integration_boundary.md
+++ b/docs/agent_integration_boundary.md
@@ -13,6 +13,13 @@ Fail-closed enforcement requires an interception point before real tool executio
 
 If you cannot intercept tool calls, Gait can still add observe/report/regress value, but it cannot block side effects inline.
 
+Concrete boundary touchpoints:
+
+- call `gait gate eval` at the final adapter or middleware dispatch site before execution
+- pass `--context-envelope <context_envelope.json>` whenever policy requires context evidence; raw context digest or freshness claims are not enough
+- keep `verdict != allow` as non-executing in the adapter response
+- use `gait demo --json` for machine-readable wrapper or CI smoke checks
+
 ## Integration Tiers
 
 ## Tier A: Full Runtime Interception (Best Fit)

--- a/docs/approval_runbook.md
+++ b/docs/approval_runbook.md
@@ -62,19 +62,19 @@ Trigger and response matrix:
 
 ## Step 1A: Context-Required Re-evaluation (When Policy Demands Context Evidence)
 
-Before token minting for context-required rules, validate intent context linkage:
+Before token minting for context-required rules, validate the exact boundary input that production will supply:
 
 ```bash
-gait gate eval --policy <policy.yaml> --intent <intent.json> --json
+gait gate eval --policy <policy.yaml> --intent <intent.json> --context-envelope <context_envelope.json> --json
 ```
 
-Intent context requirements:
+Authoritative context requirements:
 
-- `context.context_set_digest` present
-- `context.context_evidence_mode=required` when policy requires required mode
-- optional freshness bound satisfied (`context.auth_context.context_age_seconds <= max_context_age_seconds`)
+- `context_set_digest`, `context_evidence_mode`, and `context_age_seconds` are derived from the verified context envelope during evaluation.
+- freshness is computed from envelope timestamps (`records[].retrieved_at`, or `created_at` when no records are present).
+- raw `intent.context_set_digest`, `intent.context_evidence_mode`, or `context.auth_context.context_age_seconds` claims do not satisfy context-required policy on their own.
 
-If any requirement fails, do not mint approval token. Fix intent context and re-evaluate.
+If the envelope is missing, stale, mismatched, or rejected, do not mint approval token. Fix the boundary input and re-evaluate.
 
 ## Step 2: Mint Approval Token
 

--- a/docs/contracts/contextspec_v1.md
+++ b/docs/contracts/contextspec_v1.md
@@ -166,7 +166,7 @@ A context envelope is a deterministic JSON artifact that captures what context m
 
 ### When does context evidence fail-closed?
 
-When policy requires context evidence for a high-risk action class and the evidence is missing, stale, or not supplied through a verified context envelope, the gate blocks execution with an explicit reason code.
+When policy requires context evidence for a high-risk action class and the evidence is missing, stale, or not supplied through a verified context envelope, the gate blocks execution with an explicit reason code. Raw `intent.context_set_digest`, `intent.context_evidence_mode`, and `context.auth_context.context_age_seconds` claims are stripped before evaluation unless a matching envelope is verified at the boundary.
 
 ### What privacy modes are available?
 

--- a/docs/contracts/primitive_contract.md
+++ b/docs/contracts/primitive_contract.md
@@ -108,6 +108,7 @@ Consumer obligations:
 
 - MUST fail closed for high-risk paths when intent cannot be evaluated.
 - MUST NOT execute side effects on non-`allow` outcomes.
+- MUST treat incoming `context.context_set_digest`, `context.context_evidence_mode`, and `context.auth_context.context_age_seconds` as transport claims only; context-required enforcement becomes authoritative only after `gait gate eval` binds a verified `--context-envelope` at the boundary.
 
 Script mode semantics:
 

--- a/docs/hardening/contracts.md
+++ b/docs/hardening/contracts.md
@@ -74,3 +74,13 @@ Mapped hardening epics: `H5`, `H6`.
 - Integrity artifacts (checksums/signatures/provenance) are verified before release completion.
 
 Mapped hardening epics: `H7`, `H9`, `H12`.
+
+### NFR-09 Boundary Authenticity And Contract-Recovery Guards
+
+- Context-required gate paths MUST ignore unverified context digest/mode/age claims and only bind those fields from a verified `--context-envelope`.
+- Equal-priority rule renames MUST NOT change verdict or reason-code outcomes.
+- Durable job append failures MUST either roll back state or preserve a deterministic pending-recovery marker until reconciliation succeeds.
+- Machine-readable SDK/demo capture MUST consume `gait demo --json`; human demo text is not a stable automation surface.
+- These guards are release-blocking and MUST remain wired into fast/core/release CI lanes.
+
+Mapped hardening epics: `W1`, `W2`, `W3`, `W4`.

--- a/docs/hardening/release_checklist.md
+++ b/docs/hardening/release_checklist.md
@@ -13,8 +13,14 @@ Use this checklist before creating a release tag. Items marked "MANDATORY" are r
   - `make test-v2-3-acceptance`
   - `make test-v2-4-acceptance`
   - `make test-v2-5-acceptance`
+  - `make test-v2-6-acceptance`
   - `make test-context-conformance`
   - `make test-context-chaos`
+- [ ] Boundary contract repro guards pass:
+  - `go test ./cmd/gait -count=1 -run 'TestRunGateEvalRequiresVerifiedContextEnvelopeForContextPolicies|TestPolicyTestEqualPriorityRenamesDoNotChangeVerdict'`
+  - `go test ./core/gate -count=1 -run 'TestEvaluatePolicyDetailedEqualPriorityRenameDoesNotChangeVerdict'`
+  - `go test ./core/jobruntime -count=1 -run 'TestSubmitAppendFailureRollsBackNewJob|TestMutationAppendFailureRollsBackStateAndRetrySucceeds|TestMutationAppendFailureWithDurableEventPreservesPendingMarker'`
+  - `cd sdk/python && PYTHONPATH=. uv run --python 3.13 --extra dev pytest tests/test_client.py -q -k 'capture_demo_runpack_uses_json_cli_contract or capture_demo_runpack_malformed_json_raises_command_error'`
 - [ ] Full local UAT passes: `bash scripts/test_uat_local.sh`
   - verify `.uat_local/summary.txt` contains `UAT COMPLETE: PASS`
 - [ ] CI `hardening` job is green on the release commit.
@@ -50,6 +56,9 @@ Use this checklist before creating a release tag. Items marked "MANDATORY" are r
   - `v2_3_gate`
   - `v2_4_gate`
   - `v2_5_gate`
+  - `v2_6_gate`
+  - `boundary_repro_gate`
+  - `hardening_gate`
 - [ ] Checksums generated and verified.
 - [ ] Signatures/provenance artifacts generated and verifiable.
 - [ ] Homebrew formula asset rendered from release checksums (`dist/gait.rb`).

--- a/docs/hardening/risk_register.md
+++ b/docs/hardening/risk_register.md
@@ -14,9 +14,19 @@ This register tracks the highest-risk runtime and operational failure modes for 
 | HR-08 | Integrity checks skipped in release pipeline edge cases | High | Low | `H7`, `H12` | Release owner | v1.7 |
 | HR-09 | Misconfigured key sources produce ambiguous runtime behavior | High | Medium | `H8` | Security maintainer | v1.7 |
 | HR-10 | Resource pressure causes degraded reliability | Medium | Medium | `H11` | Performance owner | v1.8 |
+| HR-11 | Raw context digest/mode/age claims accidentally satisfy context-required gate checks without a verified envelope | Critical | Medium | `W1`, `W4` | Gate maintainer | v2.6 |
+| HR-12 | Equal-priority rule rename changes verdict or reason-code outcomes | High | Medium | `W3`, `W4` | Gate maintainer | v2.6 |
+| HR-13 | Python SDK automation depends on human `gait demo` text output instead of the JSON contract | Medium | Medium | `W3`, `W4` | SDK maintainer | v2.6 |
 
 ## Register Policy
 
 - Update this register whenever a hardening story changes risk posture.
 - Keep one accountable owner per risk.
 - Do not close a risk without test evidence or explicit exception rationale.
+
+## Release-Blocking Guard Map
+
+- `HR-02`: `TestSubmitAppendFailureRollsBackNewJob`, `TestMutationAppendFailureRollsBackStateAndRetrySucceeds`, `TestMutationAppendFailureWithDurableEventPreservesPendingMarker`
+- `HR-11`: `TestRunGateEvalRequiresVerifiedContextEnvelopeForContextPolicies`
+- `HR-12`: `TestEvaluatePolicyDetailedEqualPriorityRenameDoesNotChangeVerdict`, `TestPolicyTestEqualPriorityRenamesDoNotChangeVerdict`
+- `HR-13`: `test_capture_demo_runpack_uses_json_cli_contract`, `test_capture_demo_runpack_malformed_json_raises_command_error`

--- a/docs/integration_checklist.md
+++ b/docs/integration_checklist.md
@@ -64,13 +64,21 @@ Choose the highest tier you can support:
 
 Reference: `docs/agent_integration_boundary.md`.
 
+## Boundary Touchpoints To Wire
+
+- Wrapper or sidecar: call `gait gate eval` immediately before the real tool side effect.
+- Context-required policies: pass `--context-envelope <context_envelope.json>` from the local capture boundary; raw intent context fields are not authoritative by themselves.
+- SDK or CI automation: use `gait demo --json` for machine-readable smoke checks and handoff metadata.
+- CI regression loop: persist the trace or runpack from that same boundary, then wire `gait regress bootstrap --from ... --json --junit ...`.
+
 ## Core Track (First Integration, Required)
 
 Run these first. Stop if expected output is missing.
 
 1. First artifact:
-- `gait demo`
-- expect `run_id=...` and `ticket_footer=GAIT run_id=...`
+- operator path: `gait demo`
+- machine path: `gait demo --json`
+- expect either the human `run_id=...` / `ticket_footer=GAIT run_id=...` summary or JSON `ok=true` with `run_id`
 2. Verify artifact:
 - `gait verify run_demo --json`
 - expect `ok=true`
@@ -133,6 +141,8 @@ gait run record \
 - verify deterministic reason codes:
 - `context_evidence_missing`
 - `context_set_digest_missing`
+- `context_evidence_mode_mismatch`
+- `context_freshness_exceeded`
 
 Wrkr inventory enrichment (optional, local-file only):
 

--- a/docs/policy_authoring.md
+++ b/docs/policy_authoring.md
@@ -44,6 +44,11 @@ When multiple rules at the same priority match one intent, Gait evaluates the en
 
 If you need one rule to win unconditionally, give it a strictly lower numeric `priority` instead of relying on rule names.
 
+## Migration Notes
+
+- For context-required policies, runtime enforcement now requires a verified `--context-envelope` on `gait gate eval`; raw intent context claims are not enough to satisfy `require_context_evidence`, `required_context_evidence_mode`, or `max_context_age_seconds`.
+- If a policy review depends on a same-priority rule "winning" by name, change the numeric `priority` instead. Equal-priority names are no longer part of the verdict contract.
+
 ## Repo-Root Policy Contract
 
 The default onboarding contract is the repo-root file `.gait.yaml`.
@@ -156,6 +161,7 @@ This gives fast feedback for enum values and unknown keys before runtime.
 - Keep policy files formatted by `policy fmt --write` before review.
 - Review policy changes with fixture deltas and matched-rule evidence, not raw YAML diff alone.
 - Include equal-priority overlap fixtures in CI when multiple rules intentionally target the same tool surface.
+- For context-required fixtures, include a `gait gate eval --context-envelope ... --json` lane so CI exercises the same boundary contract as production.
 - Keep the repo-default contract truthful: if docs say `.gait.yaml`, examples should use `.gait.yaml` unless a custom path is the point of the example.
 
 ## Signing Key Lifecycle (Local)

--- a/docs/sdk/python.md
+++ b/docs/sdk/python.md
@@ -39,6 +39,10 @@ The SDK executes commands via `subprocess.run(...)` with a bounded timeout.
 - demo capture consumes machine-readable `gait demo --json` output only
 - non-zero exits raise `GaitCommandError` with command, exit code, stdout, and stderr
 
+## Migration Note
+
+If existing wrapper automation scraped the human `gait demo` text output, switch it to `capture_demo_runpack(...)` or `gait demo --json`. The human text form is not a stable SDK contract.
+
 ## Binary Resolution And Errors
 
 The SDK expects `gait` to be available on `PATH` by default.


### PR DESCRIPTION
## Problem
Epic W4 required the shipped docs, LLM docs, CI wiring, and release-trust surfaces to reflect the corrected runtime contracts for verified context evidence, equal-priority policy semantics, and JSON-only SDK demo capture.

## Changes
- sync README, operator docs, contract docs, and LLM docs to the verified `--context-envelope` boundary contract and JSON-only SDK demo capture
- add explicit repro-guard jobs to `pr-fast` and `ci`
- add `v2_6_gate`, `boundary_repro_gate`, and `hardening_gate` to release gating
- update hardening contracts, risk register, and release checklist to make the W4 guards release-blocking

## Validation
- `make test-docs-consistency`
- `make test-docs-storyline`
- `./gait gate eval --policy ./examples/policy/base_high_risk.yaml --intent ./examples/policy/intents/intent_delete.json --json`
- temp bootstrap smoke: `gait init --json` then `gait check --json`
- `make lint-fast`
- `make test-fast`
- targeted repro guards for `cmd/gait`, `core/gate`, `core/jobruntime`, and `sdk/python/tests/test_client.py`
- `make test-v2-6-acceptance`
- `make test-context-conformance`
- `make test-context-chaos`
- `make test-hardening-acceptance`
- `make test-chaos`
- `make test-adapter-parity`
- `make test-contracts`
- `./gait doctor --json`
- `make prepush-full`
