### PR TITLE
W1: fix launch blocker contracts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -358,6 +358,14 @@ jobs:
         shell: bash
         run: |
           make test-install
+      - name: Install/version JSON contract checks
+        shell: bash
+        run: |
+          if command -v brew >/dev/null 2>&1; then
+            make test-install-path-versions
+          else
+            bash scripts/test_cli_version_install_paths.sh --skip-brew
+          fi
 
   contracts:
     needs: changes

--- a/.github/workflows/pr-fast.yml
+++ b/.github/workflows/pr-fast.yml
@@ -54,6 +54,12 @@ jobs:
           PYTHONPATH: .
         run: |
           make test-fast
+      - name: CLI contract tests
+        run: |
+          go test ./cmd/gait -count=1
+      - name: Claude Code hook contract
+        run: |
+          bash scripts/test_claude_code_hook_contract.sh
       - name: Validate scenario fixtures
         run: |
           bash scripts/validate_scenarios.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,8 +131,12 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
       - name: Run release hardening gate
         run: |
+          bash scripts/test_claude_code_hook_contract.sh
           make test-hardening-acceptance
 
   release:

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ BENCH_REGEX := Benchmark(EvaluatePolicyTypical|VerifyZipTypical|DiffRunpacksTypi
 BENCH_OUTPUT ?= perf/bench_output.txt
 BENCH_BASELINE ?= perf/bench_baseline.json
 
-.PHONY: fmt lint lint-fast codeql test test-fast test-scenarios prepush prepush-full github-guardrails github-guardrails-strict test-hardening test-hardening-acceptance test-chaos test-e2e test-acceptance test-v1-6-acceptance test-v1-7-acceptance test-v1-8-acceptance test-v2-3-acceptance test-v2-4-acceptance test-v2-5-acceptance test-v2-6-acceptance test-voice-acceptance test-context-conformance test-context-chaos test-packspec-tck test-script-intent-acceptance test-ui-acceptance test-ui-unit test-ui-e2e-smoke test-ui-perf test-adoption test-adapter-parity test-ecosystem-automation test-release-smoke test-install test-install-path-versions test-contracts test-intent-receipt-conformance test-ci-regress-template test-ci-portability-templates test-live-connectors test-skill-supply-chain test-runtime-slo test-ent-consumer-contract test-uat-local test-openclaw-skill-install test-beads-bridge test-docs-storyline test-docs-consistency test-demo-recording openclaw-skill-install build bench bench-check bench-budgets context-budgets skills-validate ecosystem-validate ecosystem-release-notes demo-90s demo-hero-gif homebrew-formula wiki-publish tool-allowlist-policy ui-build ui-sync ui-deps-check
+.PHONY: fmt lint lint-fast codeql test test-fast test-scenarios prepush prepush-full github-guardrails github-guardrails-strict test-hardening test-hardening-acceptance test-chaos test-e2e test-acceptance test-v1-6-acceptance test-v1-7-acceptance test-v1-8-acceptance test-v2-3-acceptance test-v2-4-acceptance test-v2-5-acceptance test-v2-6-acceptance test-voice-acceptance test-context-conformance test-context-chaos test-packspec-tck test-script-intent-acceptance test-ui-acceptance test-ui-unit test-ui-e2e-smoke test-ui-perf test-claude-code-hook-contract test-adoption test-adapter-parity test-ecosystem-automation test-release-smoke test-install test-install-path-versions test-contracts test-intent-receipt-conformance test-ci-regress-template test-ci-portability-templates test-live-connectors test-skill-supply-chain test-runtime-slo test-ent-consumer-contract test-uat-local test-openclaw-skill-install test-beads-bridge test-docs-storyline test-docs-consistency test-demo-recording openclaw-skill-install build bench bench-check bench-budgets context-budgets skills-validate ecosystem-validate ecosystem-release-notes demo-90s demo-hero-gif homebrew-formula wiki-publish tool-allowlist-policy ui-build ui-sync ui-deps-check
 .PHONY: hooks
 .PHONY: docs-site-install docs-site-build docs-site-lint docs-site-check
 
@@ -174,6 +174,9 @@ test-ui-perf:
 	$(GO) build -o ./gait ./cmd/gait
 	$(PYTHON) scripts/check_ui_budgets.py ./gait perf/ui_budgets.json perf/ui_budget_report.json
 
+test-claude-code-hook-contract:
+	bash scripts/test_claude_code_hook_contract.sh
+
 test-adoption:
 	bash scripts/test_adoption_smoke.sh
 
@@ -186,6 +189,7 @@ test-ecosystem-automation:
 	bash scripts/test_ci_portability_templates.sh
 
 test-release-smoke: build
+	bash scripts/test_claude_code_hook_contract.sh ./gait
 	bash scripts/test_release_smoke.sh ./gait
 
 test-install: build

--- a/README.md
+++ b/README.md
@@ -249,10 +249,10 @@ gait doctor [--production-readiness] [adoption]    Diagnostics + readiness
 gait policy init|validate|fmt|simulate|test        Policy authoring workflows
 gait keys init|rotate|verify                       Signing key lifecycle
 gait ui                                            Local playground
-gait version                                       Print version
+gait version [--json] [--explain]                  Print version
 ```
 
-All commands support `--json`. Most support `--explain`.
+Most commands support `--json`. Machine-readable version output is available via `gait version --json`, `gait --version --json`, and `gait -v --json`. Root help (`gait --help`) is text-only and exits `0`. Most commands support `--explain`.
 
 ## Feedback
 

--- a/cmd/gait/explain.go
+++ b/cmd/gait/explain.go
@@ -14,6 +14,15 @@ func hasExplainFlag(arguments []string) bool {
 	return false
 }
 
+func hasJSONFlag(arguments []string) bool {
+	for _, argument := range arguments {
+		if strings.TrimSpace(argument) == "--json" {
+			return true
+		}
+	}
+	return false
+}
+
 func writeExplain(text string) int {
 	fmt.Println(text)
 	return exitOK

--- a/cmd/gait/main.go
+++ b/cmd/gait/main.go
@@ -15,6 +15,11 @@ import (
 // version is stamped at release time via ldflags; default stays dev for local builds.
 var version = "0.0.0-dev"
 
+type versionOutput struct {
+	OK      bool   `json:"ok"`
+	Version string `json:"version"`
+}
+
 type telemetryStreamHealth struct {
 	Attempts int64 `json:"attempts"`
 	Success  int64 `json:"success"`
@@ -56,6 +61,10 @@ func run(arguments []string) int {
 func runDispatch(arguments []string) int {
 	if len(arguments) < 2 {
 		fmt.Println("gait", version)
+		return exitOK
+	}
+	if isTopLevelHelp(arguments[1]) {
+		printUsage()
 		return exitOK
 	}
 	if arguments[1] == "--explain" {
@@ -126,15 +135,34 @@ func runDispatch(arguments []string) int {
 	case "ui":
 		return runUI(arguments[2:])
 	case "version", "--version", "-v":
-		if hasExplainFlag(arguments[2:]) {
-			return writeExplain("Print the CLI version.")
-		}
-		fmt.Println("gait", version)
-		return exitOK
+		return runVersion(arguments[2:])
 	default:
 		printUsage()
 		return exitInvalidInput
 	}
+}
+
+func isTopLevelHelp(argument string) bool {
+	switch strings.TrimSpace(argument) {
+	case "--help", "-h", "help":
+		return true
+	default:
+		return false
+	}
+}
+
+func runVersion(arguments []string) int {
+	if hasExplainFlag(arguments) {
+		return writeExplain("Print the CLI version.")
+	}
+	if hasJSONFlag(arguments) {
+		return writeJSONOutput(versionOutput{
+			OK:      true,
+			Version: version,
+		}, exitOK)
+	}
+	fmt.Println("gait", version)
+	return exitOK
 }
 
 func normalizeAdoptionCommand(arguments []string) string {
@@ -146,6 +174,8 @@ func normalizeAdoptionCommand(arguments []string) string {
 		return "unknown"
 	}
 	switch command {
+	case "--help", "-h", "help":
+		return "help"
 	case "--version", "-v", "version":
 		return "version"
 	case "--explain":

--- a/cmd/gait/main_test.go
+++ b/cmd/gait/main_test.go
@@ -30,6 +30,9 @@ func TestRunDispatch(t *testing.T) {
 	if code := run([]string{"gait"}); code != exitOK {
 		t.Fatalf("run without args: expected %d got %d", exitOK, code)
 	}
+	if code := run([]string{"gait", "--help"}); code != exitOK {
+		t.Fatalf("run root help: expected %d got %d", exitOK, code)
+	}
 	if code := run([]string{"gait", "--explain"}); code != exitOK {
 		t.Fatalf("run explain: expected %d got %d", exitOK, code)
 	}
@@ -224,6 +227,77 @@ func TestRunDispatch(t *testing.T) {
 	}
 }
 
+func TestRunDispatchRootHelpWritesUsage(t *testing.T) {
+	raw := captureStdout(t, func() {
+		if code := run([]string{"gait", "--help"}); code != exitOK {
+			t.Fatalf("run root help: expected %d got %d", exitOK, code)
+		}
+	})
+	if !strings.Contains(raw, "Usage:\n") {
+		t.Fatalf("root help missing usage banner: %q", raw)
+	}
+	if !strings.Contains(raw, "gait version [--json] [--explain]") {
+		t.Fatalf("root help missing version contract line: %q", raw)
+	}
+}
+
+func TestRunDispatchVersionJSONAliases(t *testing.T) {
+	testCases := []struct {
+		name string
+		args []string
+	}{
+		{name: "version", args: []string{"gait", "version", "--json"}},
+		{name: "version alias", args: []string{"gait", "--version", "--json"}},
+		{name: "short alias", args: []string{"gait", "-v", "--json"}},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			raw := captureStdout(t, func() {
+				if code := run(testCase.args); code != exitOK {
+					t.Fatalf("run version json: expected %d got %d", exitOK, code)
+				}
+			})
+
+			var output versionOutput
+			if err := json.Unmarshal([]byte(raw), &output); err != nil {
+				t.Fatalf("decode version json: %v raw=%q", err, raw)
+			}
+			expected := versionOutput{
+				OK:      true,
+				Version: version,
+			}
+			if output != expected {
+				t.Fatalf("unexpected version output: got=%#v want=%#v", output, expected)
+			}
+		})
+	}
+}
+
+func TestRunDispatchVersionTextAliases(t *testing.T) {
+	testCases := []struct {
+		name string
+		args []string
+	}{
+		{name: "version", args: []string{"gait", "version"}},
+		{name: "version alias", args: []string{"gait", "--version"}},
+		{name: "short alias", args: []string{"gait", "-v"}},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			raw := captureStdout(t, func() {
+				if code := run(testCase.args); code != exitOK {
+					t.Fatalf("run version text: expected %d got %d", exitOK, code)
+				}
+			})
+			if strings.TrimSpace(raw) != "gait "+version {
+				t.Fatalf("unexpected version text: %q", raw)
+			}
+		})
+	}
+}
+
 func TestTopLevelUsageIncludesSessionAndMCPServe(t *testing.T) {
 	raw := captureStdout(t, func() {
 		printUsage()
@@ -240,6 +314,7 @@ func TestTopLevelUsageIncludesSessionAndMCPServe(t *testing.T) {
 		"gait run session checkpoint",
 		"gait gateway ingest",
 		"gait mcp serve --policy <policy.yaml>",
+		"gait version [--json] [--explain]",
 	} {
 		if !strings.Contains(raw, snippet) {
 			t.Fatalf("top-level usage missing %q", snippet)

--- a/cmd/gait/verify.go
+++ b/cmd/gait/verify.go
@@ -706,7 +706,7 @@ func printUsage() {
 	fmt.Println("  gait verify chain --run <run_id|path> [--trace <trace.json>] [--pack <evidence_pack.zip>] [--profile standard|strict] [--require-signature] [--public-key <path>|--public-key-env <VAR>] [--json] [--explain]")
 	fmt.Println("  gait verify session-chain --chain <session_chain.json> [--profile standard|strict] [--require-signature] [--public-key <path>|--public-key-env <VAR>] [--json] [--explain]")
 	fmt.Println("  gait ui [--listen 127.0.0.1:7980] [--open-browser=true|false] [--allow-non-loopback] [--json] [--explain]")
-	fmt.Println("  gait version")
+	fmt.Println("  gait version [--json] [--explain]")
 }
 
 func printVerifyUsage() {

--- a/examples/integrations/README.md
+++ b/examples/integrations/README.md
@@ -13,7 +13,7 @@ Reference adapters:
 - `openclaw`
 - `autogpt`
 - `gastown`
-- `claude_code`
+- `claude_code` (reference adapter; hook errors fail closed by default, `GAIT_CLAUDE_UNSAFE_FAIL_OPEN=1` is an unsafe opt-in override)
 - `voice_reference`
 - `template` (canonical copy/paste template)
 

--- a/examples/integrations/claude_code/README.md
+++ b/examples/integrations/claude_code/README.md
@@ -1,6 +1,6 @@
 # Claude Code Quickstart
 
-This integration demonstrates two first-party paths for Claude Code:
+This reference integration demonstrates two local Claude Code paths:
 
 - wrapper parity quickstart (`quickstart.py`)
 - PreToolUse hook interception (`gait-gate.sh`)
@@ -45,4 +45,9 @@ Expected decision mapping:
 - gait `block` -> Claude `permissionDecision=deny`
 - gait `require_approval` -> Claude `permissionDecision=ask`
 
-By default hook errors fail open (`allow`). Set `GAIT_CLAUDE_STRICT=1` for fail-closed (`deny`) on hook/runtime errors.
+Hook/runtime/input errors fail closed (`deny`) by default. If you intentionally need permissive debugging behavior, set `GAIT_CLAUDE_UNSAFE_FAIL_OPEN=1`.
+
+Migration note:
+
+- `GAIT_CLAUDE_STRICT=0` no longer enables fail-open behavior.
+- Existing users who relied on fail-open defaults must opt in explicitly with `GAIT_CLAUDE_UNSAFE_FAIL_OPEN=1`.

--- a/examples/integrations/claude_code/gait-gate.sh
+++ b/examples/integrations/claude_code/gait-gate.sh
@@ -6,7 +6,25 @@ repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 gait_bin="${GAIT_BIN:-gait}"
 policy_path="${GAIT_CLAUDE_POLICY:-${repo_root}/examples/policy/base_high_risk.yaml}"
 trace_dir="${GAIT_CLAUDE_TRACE_DIR:-${repo_root}/gait-out/integrations/claude_code/hooks}"
-strict_mode="${GAIT_CLAUDE_STRICT:-0}"
+unsafe_fail_open="${GAIT_CLAUDE_UNSAFE_FAIL_OPEN:-0}"
+
+is_truthy() {
+  local raw="${1:-}"
+  local normalized
+  normalized="$(printf '%s' "$raw" | tr '[:upper:]' '[:lower:]')"
+  case "$normalized" in
+    1|true|yes|on)
+      return 0
+      ;;
+  esac
+  return 1
+}
+
+if is_truthy "$unsafe_fail_open"; then
+  unsafe_fail_open=1
+else
+  unsafe_fail_open=0
+fi
 
 emit_response() {
   local decision="$1"
@@ -15,13 +33,14 @@ emit_response() {
   DECISION="$decision" REASON="$reason" TRACE_PATH="$trace_path" python3 - <<'PY'
 import json
 import os
+from pathlib import Path
 
 payload = {
     "permissionDecision": os.environ["DECISION"],
     "permissionDecisionReason": os.environ["REASON"],
 }
 trace_path = os.environ.get("TRACE_PATH", "").strip()
-if trace_path:
+if trace_path and Path(trace_path).exists():
     payload["tracePath"] = trace_path
 print(json.dumps(payload))
 PY
@@ -29,7 +48,11 @@ PY
 
 payload="$(cat)"
 if [[ -z "${payload//[[:space:]]/}" ]]; then
-  emit_response "allow" "gait hook: empty payload (fail-open)" ""
+  if [[ "$unsafe_fail_open" -eq 1 ]]; then
+    emit_response "allow" "gait hook: empty payload (unsafe fail-open)" ""
+  else
+    emit_response "deny" "gait hook: empty payload (fail-closed)" ""
+  fi
   exit 0
 fi
 
@@ -50,13 +73,14 @@ proxy_output="$($gait_bin mcp proxy \
 proxy_exit=$?
 set -e
 
-PROXY_EXIT="$proxy_exit" PROXY_OUTPUT="$proxy_output" STRICT_MODE="$strict_mode" TRACE_PATH="$trace_path" python3 - <<'PY'
+PROXY_EXIT="$proxy_exit" PROXY_OUTPUT="$proxy_output" UNSAFE_FAIL_OPEN="$unsafe_fail_open" TRACE_PATH="$trace_path" python3 - <<'PY'
 import json
 import os
+from pathlib import Path
 
 proxy_exit = int(os.environ["PROXY_EXIT"])
 proxy_output = os.environ.get("PROXY_OUTPUT", "")
-strict_mode = os.environ.get("STRICT_MODE", "0").strip().lower() in {"1", "true", "yes", "on"}
+unsafe_fail_open = os.environ.get("UNSAFE_FAIL_OPEN", "0").strip().lower() in {"1", "true", "yes", "on"}
 trace_path = os.environ.get("TRACE_PATH", "").strip()
 
 def emit(decision: str, reason: str) -> None:
@@ -64,14 +88,18 @@ def emit(decision: str, reason: str) -> None:
         "permissionDecision": decision,
         "permissionDecisionReason": reason,
     }
-    if trace_path:
+    if trace_path and Path(trace_path).exists():
         payload["tracePath"] = trace_path
     print(json.dumps(payload))
 
+failure_reason = f"gait hook proxy failure exit={proxy_exit}"
+decoded_valid = True
 try:
     decoded = json.loads(proxy_output) if proxy_output.strip() else {}
 except json.JSONDecodeError:
     decoded = {}
+    decoded_valid = False
+    failure_reason = f"gait hook invalid proxy output exit={proxy_exit}"
 
 if isinstance(decoded, dict):
     verdict = str(decoded.get("verdict", "")).strip().lower()
@@ -92,9 +120,11 @@ if isinstance(decoded, dict):
         detail = f" reason_codes={reason_text}" if reason_text else ""
         emit("ask", f"gait verdict=require_approval{detail}")
         raise SystemExit(0)
+    if decoded_valid and proxy_output.strip() and proxy_exit == 0:
+        failure_reason = f"gait hook undecidable verdict={verdict or 'missing'} exit={proxy_exit}"
 
-if strict_mode:
-    emit("deny", f"gait hook error exit={proxy_exit} (strict mode)")
+if unsafe_fail_open:
+    emit("allow", f"{failure_reason} (unsafe fail-open)")
 else:
-    emit("allow", f"gait hook error exit={proxy_exit} (fail-open)")
+    emit("deny", f"{failure_reason} (fail-closed)")
 PY

--- a/scripts/test_adoption_smoke.sh
+++ b/scripts/test_adoption_smoke.sh
@@ -62,6 +62,9 @@ for field in ("runpack", "verify_json", "regress_init_json", "regress_run_json",
         raise SystemExit(f"quickstart artifact missing: {field}={parsed[field]}")
 PY
 
+echo "==> claude code hook contract"
+bash scripts/test_claude_code_hook_contract.sh ./gait
+
 echo "==> integration adapter smoke"
 bash scripts/test_adapter_parity.sh
 python3 examples/integrations/template/quickstart.py --scenario allow

--- a/scripts/test_claude_code_hook_contract.sh
+++ b/scripts/test_claude_code_hook_contract.sh
@@ -1,0 +1,191 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+CALLER_PWD="$(pwd)"
+
+usage() {
+  cat <<'EOF'
+Validate Claude Code hook decision contract.
+
+Usage:
+  test_claude_code_hook_contract.sh [path-to-gait-binary]
+EOF
+}
+
+if [[ $# -gt 1 ]]; then
+  usage >&2
+  exit 2
+fi
+
+if [[ $# -eq 1 ]]; then
+  if [[ "$1" = /* ]]; then
+    BIN_PATH="$1"
+  else
+    BIN_PATH="${CALLER_PWD}/$1"
+  fi
+else
+  BIN_PATH="${REPO_ROOT}/gait"
+  (
+    cd "${REPO_ROOT}"
+    go build -o "${BIN_PATH}" ./cmd/gait
+  )
+fi
+
+if [[ ! -x "${BIN_PATH}" ]]; then
+  echo "binary is not executable: ${BIN_PATH}" >&2
+  exit 2
+fi
+
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "${WORK_DIR}"' EXIT
+
+TRACE_DIR="${WORK_DIR}/traces"
+mkdir -p "${TRACE_DIR}"
+
+BASE_PAYLOAD='{"session_id":"sess-claude-hook","tool_name":"Write","tool_input":{"path":"/tmp/gait-claude-hook.json","content":"ok"},"hook_event_name":"PreToolUse"}'
+
+run_hook() {
+  local policy_path="$1"
+  local gait_bin="$2"
+  local payload="${3-}"
+  shift 3
+
+  if [[ -n "$payload" ]]; then
+    printf '%s\n' "$payload" | env \
+      GAIT_BIN="$gait_bin" \
+      GAIT_CLAUDE_POLICY="$policy_path" \
+      GAIT_CLAUDE_TRACE_DIR="$TRACE_DIR" \
+      "$@" \
+      "${REPO_ROOT}/examples/integrations/claude_code/gait-gate.sh"
+    return
+  fi
+
+  printf '' | env \
+    GAIT_BIN="$gait_bin" \
+    GAIT_CLAUDE_POLICY="$policy_path" \
+    GAIT_CLAUDE_TRACE_DIR="$TRACE_DIR" \
+    "$@" \
+    "${REPO_ROOT}/examples/integrations/claude_code/gait-gate.sh"
+}
+
+assert_response() {
+  local output="$1"
+  local expected_decision="$2"
+  local reason_contains="$3"
+  local trace_expectation="$4"
+  OUTPUT="$output" EXPECTED_DECISION="$expected_decision" REASON_CONTAINS="$reason_contains" TRACE_EXPECTATION="$trace_expectation" python3 - <<'PY'
+import json
+import os
+from pathlib import Path
+
+payload = json.loads(os.environ["OUTPUT"])
+expected_decision = os.environ["EXPECTED_DECISION"]
+reason_contains = os.environ["REASON_CONTAINS"]
+trace_expectation = os.environ["TRACE_EXPECTATION"]
+
+decision = str(payload.get("permissionDecision", ""))
+if decision != expected_decision:
+    raise SystemExit(
+        f"permissionDecision mismatch: expected={expected_decision} got={decision} payload={payload}"
+    )
+
+reason = str(payload.get("permissionDecisionReason", ""))
+if reason_contains and reason_contains not in reason:
+    raise SystemExit(
+        f"permissionDecisionReason missing substring {reason_contains!r}: {reason}"
+    )
+
+trace_path = str(payload.get("tracePath", ""))
+if trace_expectation == "required":
+    if not trace_path:
+        raise SystemExit(f"tracePath missing: {payload}")
+    if not Path(trace_path).exists():
+        raise SystemExit(f"tracePath does not exist: {trace_path}")
+elif trace_expectation == "absent":
+    if trace_path:
+        raise SystemExit(f"tracePath expected absent, got {trace_path}")
+else:
+    if trace_path and not Path(trace_path).exists():
+        raise SystemExit(f"tracePath does not exist: {trace_path}")
+PY
+}
+
+echo "==> nominal verdict mapping"
+for scenario in allow block require_approval; do
+  output="$(
+    run_hook \
+      "${REPO_ROOT}/examples/integrations/claude_code/policy_${scenario}.yaml" \
+      "${BIN_PATH}" \
+      "${BASE_PAYLOAD}"
+  )"
+  printf '%s\n' "$output"
+  expected_decision="allow"
+  if [[ "$scenario" == "block" ]]; then
+    expected_decision="deny"
+  elif [[ "$scenario" == "require_approval" ]]; then
+    expected_decision="ask"
+  fi
+  assert_response "$output" "$expected_decision" "gait verdict=" "required"
+done
+
+echo "==> broken gait binary fails closed by default"
+output="$(
+  run_hook \
+    "${REPO_ROOT}/examples/integrations/claude_code/policy_allow.yaml" \
+    "/definitely/missing/path" \
+    "${BASE_PAYLOAD}"
+)"
+printf '%s\n' "$output"
+assert_response "$output" "deny" "fail-closed" "absent"
+
+echo "==> empty payload fails closed by default"
+output="$(
+  run_hook \
+    "${REPO_ROOT}/examples/integrations/claude_code/policy_allow.yaml" \
+    "${BIN_PATH}" \
+    ""
+  )"
+printf '%s\n' "$output"
+assert_response "$output" "deny" "empty payload" "absent"
+
+echo "==> malformed payload fails closed by default"
+output="$(
+  run_hook \
+    "${REPO_ROOT}/examples/integrations/claude_code/policy_allow.yaml" \
+    "${BIN_PATH}" \
+    '{"session_id":"sess-bad","tool_name":"Write"'
+)"
+printf '%s\n' "$output"
+assert_response "$output" "deny" "fail-closed" "optional"
+
+echo "==> invalid proxy output fails closed by default"
+FAKE_GAIT="${WORK_DIR}/fake-gait"
+cat > "${FAKE_GAIT}" <<'EOF'
+#!/usr/bin/env bash
+printf 'not-json\n'
+exit 0
+EOF
+chmod 0755 "${FAKE_GAIT}"
+output="$(
+  run_hook \
+    "${REPO_ROOT}/examples/integrations/claude_code/policy_allow.yaml" \
+    "${FAKE_GAIT}" \
+    "${BASE_PAYLOAD}"
+)"
+printf '%s\n' "$output"
+assert_response "$output" "deny" "invalid proxy output" "absent"
+
+echo "==> explicit unsafe fail-open override remains opt-in"
+output="$(
+  run_hook \
+    "${REPO_ROOT}/examples/integrations/claude_code/policy_allow.yaml" \
+    "/definitely/missing/path" \
+    "${BASE_PAYLOAD}" \
+    GAIT_CLAUDE_UNSAFE_FAIL_OPEN=1
+)"
+printf '%s\n' "$output"
+assert_response "$output" "allow" "unsafe fail-open" "absent"
+
+echo "claude code hook contract: pass"

--- a/scripts/test_cli_version_install_paths.sh
+++ b/scripts/test_cli_version_install_paths.sh
@@ -103,6 +103,25 @@ extract_version() {
   "$bin" --version | awk 'NR==1{print $2}'
 }
 
+extract_version_json() {
+  local bin="$1"
+  local selector="$2"
+  local raw
+  raw="$("$bin" "$selector" --json)"
+  JSON_PAYLOAD="$raw" python3 - <<'PY'
+import json
+import os
+
+payload = json.loads(os.environ["JSON_PAYLOAD"])
+if payload.get("ok") is not True:
+    raise SystemExit(f"expected ok=true, got {payload}")
+version = payload.get("version")
+if not isinstance(version, str) or not version:
+    raise SystemExit(f"version field missing or invalid: {payload}")
+print(version)
+PY
+}
+
 assert_version() {
   local label="$1"
   local bin="$2"
@@ -113,6 +132,14 @@ assert_version() {
     echo "${label}: expected version ${expected}, got ${got}" >&2
     exit 1
   fi
+  for selector in version --version -v; do
+    local json_got
+    json_got="$(extract_version_json "$bin" "$selector")"
+    if [[ "$json_got" != "$expected" ]]; then
+      echo "${label} (${selector} --json): expected version ${expected}, got ${json_got}" >&2
+      exit 1
+    fi
+  done
   echo "${label}: version ${got}"
 }
 


### PR DESCRIPTION
## Problem
- the Claude Code reference hook still failed open on empty input and proxy/runtime failures
- `gait --help` exited with invalid input
- `gait version --json` and alias forms were not machine-readable despite public contract claims

## Changes
- make the Claude Code hook fail closed by default and add explicit unsafe opt-in fail-open behavior
- add deterministic Claude hook contract coverage and wire it into local/CI/release lanes
- add explicit root help handling with exit `0`
- add stable JSON version output for `version`, `--version`, and `-v`
- update install/version smoke coverage and tighten README/integration contract wording

## Validation
- `./gait doctor --json`
- `make prepush-full`
- `bash scripts/test_claude_code_hook_contract.sh`
- `bash scripts/test_adoption_smoke.sh`
- `bash scripts/test_adapter_parity.sh`
- `make test-hardening-acceptance`
- `make test-chaos`
- `go test ./cmd/gait -count=1`
- `make test-install-path-versions`
- `make test-v2-6-acceptance`
- `make prepush`
