### PR TITLE
W2: sync launch docs and prod guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ gait verify run_demo --json
 gait regress bootstrap --from run_demo --json --junit ./gait-out/junit.xml
 ```
 
-Before high-risk production enforcement, start from the canonical hardened template at `examples/config/oss_prod_template.yaml` and require `gait doctor --production-readiness --json` to return `ok=true`. The full path is documented in `docs/install.md`.
+Before high-risk production enforcement, start from the canonical hardened template at `examples/config/oss_prod_template.yaml` from a repo checkout, or fetch that same file from the repo if you installed only the binary. Then require `gait doctor --production-readiness --json` to return `ok=true`. The full path is documented in `docs/install.md`.
 
 `gait init --json` writes `.gait.yaml` and returns a real scaffold summary like:
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,9 @@ Start here:
 # Install
 curl -fsSL https://raw.githubusercontent.com/Clyra-AI/gait/main/scripts/install.sh | bash
 
+# Machine-readable install probe
+gait version --json
+
 # Bootstrap repo policy-as-code
 gait init --json
 gait check --json
@@ -88,6 +91,8 @@ gait verify run_demo --json
 # Turn the same artifact into a CI gate
 gait regress bootstrap --from run_demo --json --junit ./gait-out/junit.xml
 ```
+
+Before high-risk production enforcement, start from the canonical hardened template at `examples/config/oss_prod_template.yaml` and require `gait doctor --production-readiness --json` to return `ok=true`. The full path is documented in `docs/install.md`.
 
 `gait init --json` writes `.gait.yaml` and returns a real scaffold summary like:
 

--- a/docs-site/public/llm/contracts.md
+++ b/docs-site/public/llm/contracts.md
@@ -6,6 +6,7 @@ Stable OSS contracts include:
   - includes first-class export surfaces: `gait pack export --otel-out ...` and `--postgres-sql-out ...` for observability and metadata indexing.
 - **ContextSpec v1**: Deterministic context evidence envelopes with privacy-aware modes and fail-closed enforcement. Required context-proof checks are satisfied through a verified `--context-envelope` input on `gait gate eval`, `gait mcp proxy`, or `gait mcp serve`, rather than raw intent claims.
 - **Primitive Contract**: Four deterministic primitives — capture, enforce, regress, diagnose.
+- **CLI Meta Contract**: `gait --help` is text-only and exits `0`; machine-readable version discovery uses `gait version --json` or the `--version` / `-v` aliases.
 - **Python SDK Demo Contract**: machine-readable SDK/demo capture consumes `gait demo --json` output only; the human text form is non-contractual.
 - **Repo Policy Contract**: `gait init` writes `.gait.yaml`; `gait check` reports the live contract (`default_verdict`, `rule_count`, `gap_warnings`).
 - **Equal-Priority Policy Semantics**: when multiple rules at the same priority match one intent, Gait evaluates that priority tier and applies the most restrictive verdict rather than depending on rule names.

--- a/docs-site/public/llm/faq.md
+++ b/docs-site/public/llm/faq.md
@@ -40,7 +40,7 @@ For context-required policies, the gate only trusts a verified `--context-envelo
 
 ## How do I know install is valid and high-risk enforcement is production-ready?
 
-Use `gait version --json` as the machine-readable install probe. For `oss-prod`, copy `examples/config/oss_prod_template.yaml` into `.gait/config.yaml`, run `gait check --json`, then require `gait doctor --production-readiness --json` to return `ok=true` before treating high-risk enforcement as production-ready.
+Use `gait version --json` as the machine-readable install probe. For `oss-prod`, use the canonical template at `examples/config/oss_prod_template.yaml`: copy it from a repo checkout, or fetch that same file after a binary-only install, then run `gait check --json` and require `gait doctor --production-readiness --json` to return `ok=true` before treating high-risk enforcement as production-ready.
 
 ## Can I replay an agent run without re-executing real API calls?
 

--- a/docs-site/public/llm/faq.md
+++ b/docs-site/public/llm/faq.md
@@ -6,7 +6,7 @@ Gait enforces fail-closed policy before agent tool side effects execute and keep
 
 ## What should teams run first?
 
-Run `gait init --json`, `gait check --json`, `gait demo` for the operator path, `gait demo --json` for wrappers/SDKs, then `gait verify run_demo --json` and `gait regress bootstrap --from run_demo --json --junit ./gait-out/junit.xml`.
+Run `gait version --json`, `gait init --json`, `gait check --json`, `gait demo` for the operator path, `gait demo --json` for wrappers/SDKs, then `gait verify run_demo --json` and `gait regress bootstrap --from run_demo --json --junit ./gait-out/junit.xml`.
 
 ## What problem does Gait solve for long-running agent work?
 
@@ -38,13 +38,17 @@ Context evidence is deterministic proof of what context material the model was w
 
 For context-required policies, the gate only trusts a verified `--context-envelope` input; raw context digest, mode, or age claims inside the intent are not sufficient on their own.
 
+## How do I know install is valid and high-risk enforcement is production-ready?
+
+Use `gait version --json` as the machine-readable install probe. For `oss-prod`, copy `examples/config/oss_prod_template.yaml` into `.gait/config.yaml`, run `gait check --json`, then require `gait doctor --production-readiness --json` to return `ok=true` before treating high-risk enforcement as production-ready.
+
 ## Can I replay an agent run without re-executing real API calls?
 
 Yes. `gait run replay` uses recorded results as deterministic stubs so you can debug safely. `gait pack diff` then shows exactly what changed between two runs, including context drift classification.
 
 ## How does Gait integrate with agent frameworks?
 
-Gait provides wrapper or sidecar, Python SDK, and MCP boundary modes. The official LangChain surface is middleware with optional callback correlation; enforcement still happens only at the tool boundary.
+Gait provides wrapper or sidecar, Python SDK, and MCP boundary modes. The official LangChain surface is middleware with optional callback correlation; enforcement still happens only at the tool boundary. Claude Code remains a reference adapter, and its hook/runtime/input errors fail closed by default unless an operator explicitly opts into unsafe fail-open behavior.
 
 ## Can Gait pre-approve known multi-step scripts?
 

--- a/docs-site/public/llm/product.md
+++ b/docs-site/public/llm/product.md
@@ -33,7 +33,7 @@ When to use:
 - incidents must become deterministic CI regressions
 - teams need signed portable evidence instead of dashboard-only traces
 - teams want truthful repo bootstrap commands before wiring a full integration
-- teams need a documented path from demo mode to `oss-prod` readiness using `examples/config/oss_prod_template.yaml` plus `gait doctor --production-readiness --json`
+- teams need a documented path from demo mode to `oss-prod` readiness using `examples/config/oss_prod_template.yaml` from a repo checkout, or that same file fetched after a binary-only install, plus `gait doctor --production-readiness --json`
 
 When not to use:
 

--- a/docs-site/public/llm/product.md
+++ b/docs-site/public/llm/product.md
@@ -10,13 +10,14 @@ It provides seven OSS primitives:
 4. **Jobs**: Dispatch multi-step, multi-hour agent work with checkpoints, pause/resume/stop/cancel, approval gates, deterministic stop reasons, and emergency-stop preemption evidence.
 5. **Voice**: Gate high-stakes spoken commitments before they are uttered with SayToken capability tokens and callpack artifacts.
 6. **Context Evidence**: Deterministic proof of what context the model was working from at decision time. Privacy-aware envelopes with fail-closed enforcement when evidence is missing, and context-required gate checks bind digest/mode/freshness from a verified `--context-envelope`.
-7. **Doctor**: Diagnose first-run environment issues with stable JSON output.
+7. **Doctor**: Diagnose first-run environment issues with stable JSON output. `gait doctor --production-readiness --json` is the explicit gate before claiming high-risk `oss-prod` readiness.
 
 Secondary boundary surfaces:
 
 - **MCP Trust**: evaluate local trust snapshots for MCP server admission with `gait mcp verify`, `gait mcp proxy`, and `gait mcp serve`.
 - **Trace**: observe-only wrapper mode with `gait trace` for integrations that already emit Gait trace references.
 - **LangChain Middleware**: official Python middleware with optional callback correlation; callbacks never decide allow or block behavior, and demo capture stays bound to `gait demo --json`.
+- **Reference Adapters**: `examples/integrations/claude_code/` remains a reference lane; its hook/runtime/input errors fail closed by default and `GAIT_CLAUDE_UNSAFE_FAIL_OPEN=1` is an unsafe opt-in override.
 
 Gait is vendor-neutral and offline-first for core workflows: capture, verify, diff, policy evaluation, regressions, and voice/context verification all run without network dependencies.
 
@@ -32,6 +33,7 @@ When to use:
 - incidents must become deterministic CI regressions
 - teams need signed portable evidence instead of dashboard-only traces
 - teams want truthful repo bootstrap commands before wiring a full integration
+- teams need a documented path from demo mode to `oss-prod` readiness using `examples/config/oss_prod_template.yaml` plus `gait doctor --production-readiness --json`
 
 When not to use:
 

--- a/docs-site/public/llm/quickstart.md
+++ b/docs-site/public/llm/quickstart.md
@@ -62,10 +62,15 @@ Boundary touchpoints:
 
 Use `gait policy test` and `gait gate eval --simulate` before enforce rollout on high-risk tool-call boundaries. `gait enforce` is a bounded wrapper for integrations that already emit Gait trace references.
 
-Before high-risk production enforcement, seed the canonical hardened config from a repo checkout and require readiness to pass:
+Before high-risk production enforcement, seed the canonical hardened config and require readiness to pass:
 
 ```bash
+# From a repo checkout:
 cp examples/config/oss_prod_template.yaml .gait/config.yaml
+
+# Or, if you installed only the binary:
+curl -fsSL https://raw.githubusercontent.com/Clyra-AI/gait/main/examples/config/oss_prod_template.yaml -o .gait/config.yaml
+
 gait check --json
 gait doctor --production-readiness --json
 ```

--- a/docs-site/public/llm/quickstart.md
+++ b/docs-site/public/llm/quickstart.md
@@ -6,6 +6,9 @@ Use this when you need deterministic control plus evidence at agent tool boundar
 # Install
 curl -fsSL https://raw.githubusercontent.com/Clyra-AI/gait/main/scripts/install.sh | bash
 
+# Machine-readable install probe
+gait version --json
+
 # Bootstrap repo policy-as-code
 gait init --json
 gait check --json
@@ -40,6 +43,8 @@ verify=ok
 
 For SDKs and wrappers, prefer the JSON form and treat the text form as human-facing output only.
 
+For binary discovery and install automation, use `gait version --json` (or `gait --version --json` / `gait -v --json`). `gait --help` is text-only and exits `0`.
+
 Context-required policies must pass `--context-envelope <context_envelope.json>` on `gait gate eval`, `gait mcp proxy`, or `gait mcp serve`; raw intent context claims are not authoritative by themselves.
 
 Then continue with one integration seam:
@@ -56,6 +61,16 @@ Boundary touchpoints:
 - machine-readable smoke path: `gait demo --json`
 
 Use `gait policy test` and `gait gate eval --simulate` before enforce rollout on high-risk tool-call boundaries. `gait enforce` is a bounded wrapper for integrations that already emit Gait trace references.
+
+Before high-risk production enforcement, seed the canonical hardened config from a repo checkout and require readiness to pass:
+
+```bash
+cp examples/config/oss_prod_template.yaml .gait/config.yaml
+gait check --json
+gait doctor --production-readiness --json
+```
+
+Do not treat `oss-prod` enforcement as production-ready until that doctor command reports `ok=true`.
 
 Wrapper lane example:
 

--- a/docs-site/public/llms.txt
+++ b/docs-site/public/llms.txt
@@ -58,7 +58,7 @@
 - `gait --help` is text-only and exits `0`; machine consumers should use `gait version --json`, `gait --version --json`, or `gait -v --json`.
 - Machine-readable wrappers and SDKs use `gait demo --json`; the text form is human-facing only.
 - `examples/integrations/claude_code/` is a reference adapter; hook/runtime/input errors fail closed by default and `GAIT_CLAUDE_UNSAFE_FAIL_OPEN=1` is an unsafe opt-in override.
-- High-risk enforcement is not production-ready until `gait doctor --production-readiness --json` returns `ok=true`, typically from config seeded by `examples/config/oss_prod_template.yaml`.
+- High-risk enforcement is not production-ready until `gait doctor --production-readiness --json` returns `ok=true`, typically from config seeded by `examples/config/oss_prod_template.yaml` from a repo checkout or by fetching that same file after a binary-only install.
 - `gait init` writes `.gait.yaml`; `gait check` reports the live policy contract and gap warnings.
 - Offline verification for packs, runpacks, and traces.
 - Structured intent model for policy decisions, not free-form prompt filtering.

--- a/docs-site/public/llms.txt
+++ b/docs-site/public/llms.txt
@@ -13,6 +13,7 @@
 - gait mcp serve --policy <policy.yaml> [--context-envelope <context_envelope.json>]
 - gait demo
 - gait demo --json
+- gait version --json
 - gait verify <run_id|path>
 - gait test -- <child command...>
 - gait enforce -- <child command...>
@@ -30,6 +31,7 @@
 - gait job submit --id <job_id> --policy <policy.yaml> --identity <id>
 - gait voice token mint --intent <intent.json> --policy <policy.yaml>
 - gait doctor --json
+- gait doctor --production-readiness --json
 - gait ui
 
 ## Tool Boundary
@@ -53,7 +55,10 @@
 ## Safety Model
 - Fail-closed by default for ambiguous high-risk policy outcomes.
 - Equal-priority rule overlaps resolve to the most restrictive verdict for that priority tier, not by rule name ordering.
+- `gait --help` is text-only and exits `0`; machine consumers should use `gait version --json`, `gait --version --json`, or `gait -v --json`.
 - Machine-readable wrappers and SDKs use `gait demo --json`; the text form is human-facing only.
+- `examples/integrations/claude_code/` is a reference adapter; hook/runtime/input errors fail closed by default and `GAIT_CLAUDE_UNSAFE_FAIL_OPEN=1` is an unsafe opt-in override.
+- High-risk enforcement is not production-ready until `gait doctor --production-readiness --json` returns `ok=true`, typically from config seeded by `examples/config/oss_prod_template.yaml`.
 - `gait init` writes `.gait.yaml`; `gait check` reports the live policy contract and gap warnings.
 - Offline verification for packs, runpacks, and traces.
 - Structured intent model for policy decisions, not free-form prompt filtering.

--- a/docs/agent_integration_boundary.md
+++ b/docs/agent_integration_boundary.md
@@ -92,6 +92,7 @@ What Gait cannot do (without interception):
 
 - Tier A quickstart: `examples/integrations/openai_agents/quickstart.py`
 - Tier A/B transport path: `gait mcp serve --context-envelope ./context_envelope.json`
+- Reference adapter note: `examples/integrations/claude_code/gait-gate.sh` fails closed on hook/runtime/input errors by default; `GAIT_CLAUDE_UNSAFE_FAIL_OPEN=1` is a debugging-only unsafe override, not a promoted lane.
 - Tier C fallback: `gait report top`, `gait capture`, `gait regress add`, `gait regress run` (or `gait regress bootstrap` for the one-command path)
 
 ## Related Docs

--- a/docs/hardening/release_checklist.md
+++ b/docs/hardening/release_checklist.md
@@ -9,6 +9,7 @@ Use this checklist before creating a release tag. Items marked "MANDATORY" are r
   - Go coverage >= 85%
   - Python coverage >= 85%
 - [ ] `make test-hardening-acceptance` passes.
+- [ ] `make test-install-path-versions` passes.
 - [ ] Versioned acceptance/context gates pass:
   - `make test-v2-3-acceptance`
   - `make test-v2-4-acceptance`
@@ -68,6 +69,8 @@ Use this checklist before creating a release tag. Items marked "MANDATORY" are r
 ## 6) Operational Readiness (RECOMMENDED)
 
 - [ ] `gait doctor --json` includes green checks for hooks, cache, lock staleness, temp writeability, and key-source ambiguity.
+- [ ] Install and release docs point operators to `examples/config/oss_prod_template.yaml` and require `gait doctor --production-readiness --json` before claiming `oss-prod` readiness.
+- [ ] Installer/Homebrew/manual verification uses `gait version --json` as the machine-readable binary probe.
 - [ ] Correlation IDs and operational events are emitted in opt-in logs where enabled.
 - [ ] Homebrew tap install/test smoke passes for the release:
   - `brew reinstall Clyra-AI/tap/gait`

--- a/docs/homebrew.md
+++ b/docs/homebrew.md
@@ -60,6 +60,7 @@ brew update
 brew tap Clyra-AI/tap
 brew reinstall Clyra-AI/tap/gait
 brew test Clyra-AI/tap/gait
+gait version --json
 gait demo --json
 ```
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -92,12 +92,17 @@ Before production use, apply hardened defaults and validate readiness:
 
 ```bash
 gait init --json
+# From a repo checkout:
 cp examples/config/oss_prod_template.yaml .gait/config.yaml
+
+# Or, if you installed only the binary:
+curl -fsSL https://raw.githubusercontent.com/Clyra-AI/gait/main/examples/config/oss_prod_template.yaml -o .gait/config.yaml
+
 gait check --json
 gait doctor --production-readiness --json
 ```
 
-Use `examples/config/oss_prod_template.yaml` as the canonical hardened starting point, then review the environment variable names, listener, and retention values for your deployment before enforcing. High-risk runtime boundaries are not production-ready until `gait doctor --production-readiness --json` reports `ok=true`.
+Use `examples/config/oss_prod_template.yaml` as the canonical hardened starting point, whether you copy it from a repo checkout or fetch that same file after a binary-only install. Then review the environment variable names, listener, and retention values for your deployment before enforcing. High-risk runtime boundaries are not production-ready until `gait doctor --production-readiness --json` reports `ok=true`.
 
 If PATH is still not updated, run directly once:
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -73,6 +73,7 @@ bash scripts/install.sh --version vX.Y.Z --install-dir ~/.local/bin
 ## Verify Installation
 
 ```bash
+gait version --json
 gait doctor --json
 gait demo
 gait verify run_demo
@@ -91,35 +92,12 @@ Before production use, apply hardened defaults and validate readiness:
 
 ```bash
 gait init --json
-cat > .gait/config.yaml <<'YAML'
-gate:
-  policy: .gait.yaml
-  profile: oss-prod
-  key_mode: prod
-  private_key_env: GAIT_PRIVATE_KEY
-  credential_broker: env
-  credential_env_prefix: GAIT_BROKER_TOKEN_
-  rate_limit_state: ./gait-out/gate_rate_limits.json
-
-mcp_serve:
-  enabled: true
-  listen: 127.0.0.1:8787
-  auth_mode: token
-  auth_token_env: GAIT_MCP_TOKEN
-  max_request_bytes: 1048576
-  http_verdict_status: strict
-  allow_client_artifact_paths: false
-
-retention:
-  trace_ttl: 168h
-  session_ttl: 336h
-  export_ttl: 168h
-YAML
+cp examples/config/oss_prod_template.yaml .gait/config.yaml
 gait check --json
 gait doctor --production-readiness --json
 ```
 
-Production readiness must report `ok=true` before enforcing high-risk runtime boundaries.
+Use `examples/config/oss_prod_template.yaml` as the canonical hardened starting point, then review the environment variable names, listener, and retention values for your deployment before enforcing. High-risk runtime boundaries are not production-ready until `gait doctor --production-readiness --json` reports `ok=true`.
 
 If PATH is still not updated, run directly once:
 
@@ -143,6 +121,7 @@ curl -fsSL https://raw.githubusercontent.com/Clyra-AI/gait/main/scripts/quicksta
 4. Open a new shell and run:
 
 ```powershell
+gait.exe version --json
 gait.exe doctor --json
 gait.exe demo
 gait.exe verify run_demo
@@ -170,7 +149,7 @@ Yes. Download the Windows binary from the GitHub release and add it to your PATH
 
 ### How do I verify the install worked?
 
-Run `gait doctor --json`. All checks should pass. Then run `gait demo` to create your first signed artifact.
+Run `gait version --json` and `gait doctor --json`. Then run `gait demo` to create your first signed artifact. Before claiming high-risk production readiness, require `gait doctor --production-readiness --json` to return `ok=true`.
 
 ### Can I install via Homebrew?
 

--- a/docs/integration_checklist.md
+++ b/docs/integration_checklist.md
@@ -203,7 +203,7 @@ Reference adapters:
 - `examples/integrations/autogpt/`
 - `examples/integrations/gastown/`
 - `examples/integrations/voice_reference/`
-- `examples/integrations/claude_code/`
+- `examples/integrations/claude_code/` (reference adapter; hook/runtime/input errors fail closed by default, `GAIT_CLAUDE_UNSAFE_FAIL_OPEN=1` is an explicit unsafe override)
 - sidecar path: `examples/sidecar/gate_sidecar.py`
 - MCP proxy/serve: `gait mcp proxy`, `gait mcp serve`
 

--- a/docs/launch/faq_objections.md
+++ b/docs/launch/faq_objections.md
@@ -27,7 +27,7 @@ Runpack, Gate, Regress, and Doctor all run offline-first with local artifacts.
 ## "Can we fail-open for velocity?"
 
 Default posture for high-risk paths is fail-closed.
-Staged rollout exists via `--simulate`; enforcement modes should not silently bypass policy.
+Staged rollout exists via `--simulate`; enforcement modes should not silently bypass policy. Reference adapters such as the Claude Code hook also fail closed by default, and any fail-open behavior must be explicit, unsafe, and kept out of promoted launch flows.
 
 ## "Are we locked into Gait-specific infra?"
 

--- a/docs/wiki/Operator-FAQ.md
+++ b/docs/wiki/Operator-FAQ.md
@@ -11,7 +11,7 @@ Yes for core workflows. Policy bootstrap, recording, verifying, diffing, replay,
 
 ## Is fail-open supported?
 
-Default is fail-closed for high-risk paths. Simulation mode exists for staged rollout.
+Default is fail-closed for high-risk paths. The Claude Code reference hook also fails closed on hook/runtime/input errors by default; `GAIT_CLAUDE_UNSAFE_FAIL_OPEN=1` is an explicit unsafe override only. Simulation mode exists for staged rollout.
 
 ## How do we prove what happened?
 
@@ -25,6 +25,7 @@ Gait is not a framework replacement; it owns the execution verdict and evidence 
 ## How do we keep reports deterministic?
 
 - Use `--json` outputs.
+- Use `gait version --json` for install probes and `gait doctor --production-readiness --json` before calling high-risk enforcement production-ready.
 - Preserve canonical artifacts under `gait-out/`.
 - Run regress fixtures in CI.
 


### PR DESCRIPTION
## Problem
- launch-facing repo docs and LLM docs still lag the shipped W1 contract
- install and quickstart guidance still make the path from demo mode to `oss-prod` readiness harder to follow than necessary

## Changes
- sync repo docs and LLM docs to the repaired version/help and fail-closed adapter contract
- make official vs reference adapter wording explicit where it matters for launch messaging
- point production guidance at `examples/config/oss_prod_template.yaml`
- use `gait version --json` as the machine-readable install probe
- require `gait doctor --production-readiness --json` before calling high-risk enforcement production-ready

## Validation
- `make prepush-full`
- `make test-docs-consistency`
- `make test-docs-storyline`
- `bash scripts/test_adoption_smoke.sh`
- `make test-v2-6-acceptance`
- `./gait doctor --production-readiness --json` (expected structured fail on clean checkout; fix path now documented)
- `make test-install-path-versions`
- `make test-release-smoke`
- `make test-hardening-acceptance`
- `make prepush`
- `make codeql`
