### PR TITLE
Clarify public onboarding contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Official onboarding lanes:
 - Inline wrapper or sidecar: call `gait gate eval` in your dispatcher before real execution.
 - MCP boundary: use `gait mcp verify` for trust preflight, then `gait mcp proxy` or `gait mcp serve`.
 - Python SDK: thin subprocess ergonomics over the local Go binary, including official LangChain middleware with optional callback correlation.
-- Observe-only path: `gait trace --json -- <child command...>` for integrations that already emit Gait trace references.
+- Observe-only path: `gait trace --json -- <child command...>` for integrations that already emit Gait trace references. Wrapper JSON reports `boundary_contract=explicit_trace_reference`, `trace_reference_required=true`, and stable `failure_reason` values when that seam is missing or invalid.
 
 Other frameworks are named publicly only when an in-repo lane exists and clears the integration scorecard threshold.
 
@@ -55,6 +55,29 @@ Start here:
 - [`docs/agent_integration_boundary.md`](docs/agent_integration_boundary.md)
 - [`docs/mcp_capability_matrix.md`](docs/mcp_capability_matrix.md)
 - [`docs/sdk/python.md`](docs/sdk/python.md)
+
+## Framework Lanes
+
+Official lanes:
+
+- OpenAI Agents: wrapper or sidecar boundary with deterministic allow/block/approval quickstarts in [`examples/integrations/openai_agents/`](examples/integrations/openai_agents/)
+- LangChain: official middleware with optional callback correlation in [`examples/integrations/langchain/`](examples/integrations/langchain/)
+
+Reference adapters:
+
+- Autogen, OpenClaw, AutoGPT, Gastown, Claude Code, Voice Reference, and the template lane live in [`examples/integrations/README.md`](examples/integrations/README.md)
+
+Promotion rule:
+
+- A framework is only named as an official lane when an in-repo implementation exists and clears the integration scorecard threshold.
+- CrewAI is not an official Gait lane today.
+
+Official lane quickstart commands:
+
+```bash
+python3 examples/integrations/openai_agents/quickstart.py --scenario allow
+(cd sdk/python && uv run --python 3.13 --extra langchain python ../../examples/integrations/langchain/quickstart.py --scenario allow)
+```
 
 ## When To Use Gait
 
@@ -101,6 +124,21 @@ Before high-risk production enforcement, start from the canonical hardened templ
   "ok": true,
   "policy_path": ".gait.yaml",
   "template": "baseline-highrisk",
+  "detected_signals": [
+    {
+      "code": "framework.langchain",
+      "category": "framework",
+      "value": "langchain",
+      "confidence": "high"
+    }
+  ],
+  "generated_rules": [
+    {
+      "id": "starter.block.destructive",
+      "name": "block-destructive-tools",
+      "effect": "block"
+    }
+  ],
   "next_commands": [
     "gait check --policy .gait.yaml --json",
     "gait policy validate .gait.yaml --json",
@@ -117,7 +155,14 @@ Before high-risk production enforcement, start from the canonical hardened templ
   "policy_path": ".gait.yaml",
   "default_verdict": "block",
   "rule_count": 7,
-  "summary": "policy ok: default_verdict=block rules=7 gap_warnings=1"
+  "findings": [
+    {
+      "code": "repo.generated_rules_available",
+      "severity": "info",
+      "detected_surface": "repo.signals"
+    }
+  ],
+  "summary": "policy ok: default_verdict=block rules=7 findings=2 gap_warnings=1"
 }
 ```
 
@@ -145,6 +190,13 @@ Migration notes:
 - If an older integration relied on raw intent context fields to satisfy `require_context_evidence`, move that proof to a verified `--context-envelope` input.
 - If tooling parsed `gait demo` text output, switch it to `gait demo --json` or the Python SDK helper surface.
 
+Draft proposal migration notes:
+
+- Use the shipped repo-root policy DSL: `schema_id`, `schema_version`, `default_verdict`, optional `fail_closed`, optional `mcp_trust`, and `rules`.
+- Do not treat `version`, `name`, `boundaries`, `defaults`, `trust_sources`, or `unknown_server` as alternate supported policy syntax.
+- Use `gait mcp verify`, not `gait mcp-verify`.
+- Use `gait capture --out ...`, not `gait capture --save-as ...`.
+
 No account. No API key. No hosted dependency.
 
 ## Simple End-To-End Scenario
@@ -162,16 +214,18 @@ See [`docs/scenarios/simple_agent_tool_boundary.md`](docs/scenarios/simple_agent
 **Durable jobs** — checkpointed long-running work with pause/resume/cancel, approvals, and deterministic stop reasons.
 
 **MCP trust** — evaluate local trust snapshots with `gait mcp verify`, then enforce via `gait mcp proxy` or `gait mcp serve`.
+`gait mcp verify --json` reports `trust_model=local_snapshot` and `snapshot_path` when MCP trust is configured.
 
 **Voice and context evidence** — fail-closed gating for spoken commitments and missing-context high-risk decisions.
 
-## Differentiation
+## Gait Vs Observability
 
-Gait is complementary to observability products.
+Gait is complementary to observability products such as LangSmith, Langfuse, and AgentOps.
 
-- Observability tools help you inspect what happened after the fact.
+- LangSmith, Langfuse, and AgentOps focus on hosted tracing, analytics, and after-the-fact inspection.
 - Gait decides whether a tool action may execute, emits a signed trace for that decision, and makes the artifact reusable in CI.
-- External scanners and registries can feed Gait. Gait enforces at the action boundary; it does not replace the scanner.
+- The practical model is camera plus gate: use observability to inspect, and use Gait to enforce at the action boundary before side effects land.
+- External scanners and registries can feed Gait. Gait enforces at the action boundary; it does not replace the scanner or dashboard.
 
 ## CI Adoption
 

--- a/cmd/gait/error_output.go
+++ b/cmd/gait/error_output.go
@@ -49,8 +49,18 @@ func marshalOutputWithErrorEnvelope(output any, exitCode int) ([]byte, error) {
 		category := coreerrors.Category(asString(result["error_category"]))
 		result["retryable"] = defaultRetryable(category)
 	}
+	hint, migration := migrationMetadataFromError(errorText)
 	if strings.TrimSpace(asString(result["hint"])) == "" {
-		result["hint"] = defaultHint(exitCode)
+		if hint != "" {
+			result["hint"] = hint
+		} else {
+			result["hint"] = defaultHint(exitCode)
+		}
+	}
+	if migration != nil {
+		if _, exists := result["migration"]; !exists {
+			result["migration"] = migration
+		}
 	}
 	return marshalJSON(result)
 }

--- a/cmd/gait/error_output_test.go
+++ b/cmd/gait/error_output_test.go
@@ -153,3 +153,31 @@ func TestMarshalOutputWithProvidedEnvelopeFields(t *testing.T) {
 		t.Fatalf("expected custom retryable to be preserved, got %#v", decoded["retryable"])
 	}
 }
+
+func TestMarshalOutputWithLegacyMigrationMetadata(t *testing.T) {
+	payload := map[string]any{
+		"ok":    false,
+		"error": legacyCommandError("gait mcp-verify", "gait mcp verify"),
+	}
+	encoded, err := marshalOutputWithErrorEnvelope(payload, exitInvalidInput)
+	if err != nil {
+		t.Fatalf("marshalOutputWithErrorEnvelope: %v", err)
+	}
+	decoded := map[string]any{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		t.Fatalf("decode enveloped output: %v", err)
+	}
+	if decoded["hint"] != "use `gait mcp verify` instead" {
+		t.Fatalf("unexpected hint: %#v", decoded["hint"])
+	}
+	migration, ok := decoded["migration"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected migration object, got %#v", decoded["migration"])
+	}
+	if migration["kind"] != "command" {
+		t.Fatalf("unexpected migration kind: %#v", migration["kind"])
+	}
+	if migration["replacement_command"] != "gait mcp verify" {
+		t.Fatalf("unexpected replacement command: %#v", migration["replacement_command"])
+	}
+}

--- a/cmd/gait/main.go
+++ b/cmd/gait/main.go
@@ -136,9 +136,10 @@ func runDispatch(arguments []string) int {
 		return runUI(arguments[2:])
 	case "version", "--version", "-v":
 		return runVersion(arguments[2:])
+	case "mcp-verify":
+		return writeRootInputError(arguments, legacyCommandError("gait mcp-verify", "gait mcp verify"))
 	default:
-		printUsage()
-		return exitInvalidInput
+		return writeRootInputError(arguments, "unknown command: "+strings.TrimSpace(arguments[1]))
 	}
 }
 

--- a/cmd/gait/main_test.go
+++ b/cmd/gait/main_test.go
@@ -298,6 +298,35 @@ func TestRunDispatchVersionTextAliases(t *testing.T) {
 	}
 }
 
+func TestRunDispatchLegacyMCPVerifyJSONGuidance(t *testing.T) {
+	raw := captureStdout(t, func() {
+		if code := run([]string{"gait", "mcp-verify", "--json"}); code != exitInvalidInput {
+			t.Fatalf("run legacy mcp-verify: expected %d got %d", exitInvalidInput, code)
+		}
+	})
+
+	decoded := map[string]any{}
+	if err := json.Unmarshal([]byte(raw), &decoded); err != nil {
+		t.Fatalf("decode legacy mcp-verify output: %v raw=%q", err, raw)
+	}
+	if decoded["error"] != legacyCommandError("gait mcp-verify", "gait mcp verify") {
+		t.Fatalf("unexpected error: %#v", decoded["error"])
+	}
+	if decoded["hint"] != "use `gait mcp verify` instead" {
+		t.Fatalf("unexpected hint: %#v", decoded["hint"])
+	}
+	migration, ok := decoded["migration"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected migration object, got %#v", decoded["migration"])
+	}
+	if migration["kind"] != "command" {
+		t.Fatalf("unexpected migration kind: %#v", migration["kind"])
+	}
+	if migration["replacement_command"] != "gait mcp verify" {
+		t.Fatalf("unexpected replacement command: %#v", migration["replacement_command"])
+	}
+}
+
 func TestTopLevelUsageIncludesSessionAndMCPServe(t *testing.T) {
 	raw := captureStdout(t, func() {
 		printUsage()
@@ -319,6 +348,17 @@ func TestTopLevelUsageIncludesSessionAndMCPServe(t *testing.T) {
 		if !strings.Contains(raw, snippet) {
 			t.Fatalf("top-level usage missing %q", snippet)
 		}
+	}
+}
+
+func TestWrapperHelpMentionsExplicitTraceRequirement(t *testing.T) {
+	raw := captureStdout(t, func() {
+		if code := runTest([]string{"--help"}); code != exitOK {
+			t.Fatalf("run test help: expected %d got %d", exitOK, code)
+		}
+	})
+	if !strings.Contains(raw, "child command must emit trace_path=<path>") {
+		t.Fatalf("wrapper help missing trace seam note: %q", raw)
 	}
 }
 
@@ -1066,6 +1106,12 @@ func TestInitAndCheckPolicyContract(t *testing.T) {
 	if len(initResult.Detection.Frameworks) != 1 || initResult.Detection.Frameworks[0] != "langchain" {
 		t.Fatalf("unexpected init detection: %#v", initResult.Detection)
 	}
+	if len(initResult.DetectedSignals) == 0 {
+		t.Fatalf("expected detected signals in init output: %#v", initResult)
+	}
+	if len(initResult.GeneratedRules) == 0 {
+		t.Fatalf("expected generated starter rules in init output: %#v", initResult)
+	}
 	if initResult.Contract.RepoPolicyPath != ".gait.yaml" || initResult.Contract.ProjectDefaultsPath != ".gait/config.yaml" || initResult.Contract.RegressConfigPath != "gait.yaml" {
 		t.Fatalf("unexpected contract paths: %#v", initResult.Contract)
 	}
@@ -1075,6 +1121,9 @@ func TestInitAndCheckPolicyContract(t *testing.T) {
 	}
 	if !strings.Contains(string(rawPolicy), "# detected_frameworks: langchain") {
 		t.Fatalf("generated policy missing detection hints: %s", string(rawPolicy))
+	}
+	if !strings.Contains(string(rawPolicy), "# generated_rules:") {
+		t.Fatalf("generated policy missing starter rule comments: %s", string(rawPolicy))
 	}
 	if code := runPolicyValidate([]string{"./.gait.yaml", "--json"}); code != exitOK {
 		t.Fatalf("runPolicyValidate generated policy: expected %d got %d", exitOK, code)
@@ -1100,20 +1149,39 @@ func TestInitAndCheckPolicyContract(t *testing.T) {
 	if len(checkResult.GapWarnings) == 0 {
 		t.Fatalf("expected gap warnings in check output")
 	}
+	if len(checkResult.Findings) == 0 {
+		t.Fatalf("expected structured findings in check output: %#v", checkResult)
+	}
+	if len(checkResult.NextCommands) == 0 {
+		t.Fatalf("expected next commands in check output: %#v", checkResult)
+	}
 }
 
 func TestWrapperCommandsRequireTraceAndPromoteNonAllowVerdicts(t *testing.T) {
 	workDir := t.TempDir()
 	withWorkingDir(t, workDir)
 
-	noTraceCode := runTest([]string{
-		"--json",
-		"--",
-		os.Args[0],
-		"-test.run=TestWrapperChildProcess",
+	var noTraceCode int
+	noTraceRaw := captureStdout(t, func() {
+		noTraceCode = runTest([]string{
+			"--json",
+			"--",
+			os.Args[0],
+			"-test.run=TestWrapperChildProcess",
+		})
 	})
 	if noTraceCode != exitInvalidInput {
 		t.Fatalf("runTest without child mode env: expected %d got %d", exitInvalidInput, noTraceCode)
+	}
+	var noTraceOutput wrapperOutput
+	if err := json.Unmarshal([]byte(noTraceRaw), &noTraceOutput); err != nil {
+		t.Fatalf("decode no-trace wrapper output: %v", err)
+	}
+	if noTraceOutput.FailureReason != wrapperFailureReasonMissingTraceRef {
+		t.Fatalf("unexpected no-trace failure reason: %#v", noTraceOutput)
+	}
+	if noTraceOutput.BoundaryContract != wrapperBoundaryContractExplicitTrace || !noTraceOutput.TraceReferenceRequired {
+		t.Fatalf("unexpected no-trace boundary contract: %#v", noTraceOutput)
 	}
 
 	tracePath := filepath.Join(workDir, "trace_block.json")
@@ -1142,6 +1210,9 @@ func TestWrapperCommandsRequireTraceAndPromoteNonAllowVerdicts(t *testing.T) {
 	if len(testOutput.TracePaths) != 1 || testOutput.TracePaths[0] != tracePath {
 		t.Fatalf("unexpected test trace paths: %#v", testOutput.TracePaths)
 	}
+	if testOutput.BoundaryContract != wrapperBoundaryContractExplicitTrace || !testOutput.TraceReferenceRequired {
+		t.Fatalf("unexpected test wrapper boundary contract: %#v", testOutput)
+	}
 
 	var traceCode int
 	traceRaw := captureStdout(t, func() {
@@ -1162,6 +1233,9 @@ func TestWrapperCommandsRequireTraceAndPromoteNonAllowVerdicts(t *testing.T) {
 	if traceOutput.Mode != "trace" || len(traceOutput.TracePaths) != 1 || traceOutput.TracePaths[0] != tracePath {
 		t.Fatalf("unexpected trace wrapper output: %#v", traceOutput)
 	}
+	if traceOutput.BoundaryContract != wrapperBoundaryContractExplicitTrace || !traceOutput.TraceReferenceRequired {
+		t.Fatalf("unexpected trace wrapper boundary contract: %#v", traceOutput)
+	}
 
 	var enforceCode int
 	enforceRaw := captureStdout(t, func() {
@@ -1176,6 +1250,9 @@ func TestWrapperCommandsRequireTraceAndPromoteNonAllowVerdicts(t *testing.T) {
 	}
 	if len(enforceOutput.VerdictCounts) != 1 || enforceOutput.VerdictCounts[0].Verdict != "block" {
 		t.Fatalf("unexpected enforce verdict counts: %#v", enforceOutput.VerdictCounts)
+	}
+	if enforceOutput.BoundaryContract != wrapperBoundaryContractExplicitTrace || !enforceOutput.TraceReferenceRequired {
+		t.Fatalf("unexpected enforce wrapper boundary contract: %#v", enforceOutput)
 	}
 
 	invalidTracePath := filepath.Join(workDir, "trace_invalid.json")
@@ -1194,6 +1271,9 @@ func TestWrapperCommandsRequireTraceAndPromoteNonAllowVerdicts(t *testing.T) {
 	}
 	if !strings.Contains(invalidEnforceOutput.Error, "fails closed") {
 		t.Fatalf("expected fail-closed error, got %#v", invalidEnforceOutput)
+	}
+	if invalidEnforceOutput.FailureReason != wrapperFailureReasonInvalidTraceArtifact {
+		t.Fatalf("unexpected invalid-trace failure reason: %#v", invalidEnforceOutput)
 	}
 }
 
@@ -1223,6 +1303,9 @@ func TestWrapperTimeoutIsDeterministic(t *testing.T) {
 	}
 	if !output.TimedOut {
 		t.Fatalf("expected timed_out=true: %#v", output)
+	}
+	if output.FailureReason != wrapperFailureReasonChildTimedOut {
+		t.Fatalf("unexpected timeout failure reason: %#v", output)
 	}
 }
 
@@ -1274,6 +1357,35 @@ func TestCaptureAndRegressAddFlow(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(workDir, "gait.yaml")); err != nil {
 		t.Fatalf("regress config missing: %v", err)
+	}
+}
+
+func TestRunCaptureLegacySaveAsJSONGuidance(t *testing.T) {
+	raw := captureStdout(t, func() {
+		if code := runCapture([]string{"--from", "run_demo", "--save-as", "capture.json", "--json"}); code != exitInvalidInput {
+			t.Fatalf("runCapture legacy save-as: expected %d got %d", exitInvalidInput, code)
+		}
+	})
+
+	decoded := map[string]any{}
+	if err := json.Unmarshal([]byte(raw), &decoded); err != nil {
+		t.Fatalf("decode capture legacy save-as output: %v raw=%q", err, raw)
+	}
+	if decoded["error"] != legacyFlagError("--save-as", "--out") {
+		t.Fatalf("unexpected capture error: %#v", decoded["error"])
+	}
+	if decoded["hint"] != "use `--out` instead" {
+		t.Fatalf("unexpected capture hint: %#v", decoded["hint"])
+	}
+	migration, ok := decoded["migration"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected migration object, got %#v", decoded["migration"])
+	}
+	if migration["kind"] != "flag" {
+		t.Fatalf("unexpected migration kind: %#v", migration["kind"])
+	}
+	if migration["replacement_flag"] != "--out" {
+		t.Fatalf("unexpected replacement flag: %#v", migration["replacement_flag"])
 	}
 }
 
@@ -1413,11 +1525,111 @@ func TestOnboardingAndWrapperHelperBranches(t *testing.T) {
 	if got := summarizeDetectedToolsForComment([]string{"a", "b", "c", "d", "e", "f", "g", "h", "i"}); !strings.Contains(got, "(+1 more)") {
 		t.Fatalf("expected summarized tool overflow, got %q", got)
 	}
-	if warnings := buildPolicyGapWarnings(gatecore.Policy{DefaultVerdict: "allow"}, repoDetection{}); len(warnings) == 0 {
-		t.Fatalf("expected gap warnings for permissive empty policy")
+	findings := buildPolicyReadinessFindings(gatecore.Policy{DefaultVerdict: "allow"}, repoDetection{}, nil, nil, nil)
+	if len(findingsToWarnings(findings)) == 0 {
+		t.Fatalf("expected readiness findings for permissive empty policy")
 	}
 	if detection := summarizeRepoDetection(schemascout.InventorySnapshot{Items: []schemascout.InventoryItem{{Kind: "tool", Name: "delete_user", Tags: []string{"framework:langchain"}}}}); len(detection.Frameworks) != 1 || detection.Frameworks[0] != "langchain" {
 		t.Fatalf("unexpected summarized detection: %#v", detection)
+	}
+}
+
+func TestOnboardingSignalClassificationHelpers(t *testing.T) {
+	detection := repoDetection{
+		Frameworks: []string{"langchain", " ", "openai_agents"},
+		ToolNames: []string{
+			"DeleteUser",
+			"UpdateTicket",
+			"RefundInvoice",
+			"postgres.query",
+			"acme.sync",
+			"__hidden_tool",
+			"HTTP",
+			strings.Repeat("x", 49),
+		},
+	}
+
+	signals, generated, unknown := deriveRepoSignalsAndStarterRules(detection)
+	if len(signals) < 6 {
+		t.Fatalf("expected multiple derived signals, got %#v", signals)
+	}
+	if len(generated) != 2 {
+		t.Fatalf("expected destructive and approval starter rules, got %#v", generated)
+	}
+	if len(unknown) != 1 || len(unknown[0].Evidence) != 1 || unknown[0].Evidence[0] != "acme.sync" {
+		t.Fatalf("expected unclassified dotted tool evidence, got %#v", unknown)
+	}
+
+	commentLines := renderStarterRuleComments(generated, unknown)
+	commentBlock := strings.Join(commentLines, "\n")
+	for _, snippet := range []string{
+		"# generated_rules:",
+		"# unknown_signals:",
+		"starter.block.destructive",
+		"starter.require_approval.state_change",
+		"acme.sync",
+	} {
+		if !strings.Contains(commentBlock, snippet) {
+			t.Fatalf("expected %q in starter comment block: %s", snippet, commentBlock)
+		}
+	}
+
+	normalized := normalizeActionCandidateTools([]string{
+		" DeleteUser ",
+		"acme.sync",
+		"HTTP",
+		"__skip",
+		strings.Repeat("z", 49),
+		"postgres.query",
+	})
+	if len(normalized) != 3 {
+		t.Fatalf("unexpected normalized tool count: %#v", normalized)
+	}
+	for _, expected := range []string{"acme.sync", "deleteuser", "postgres.query"} {
+		found := false
+		for _, actual := range normalized {
+			if actual == expected {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("expected normalized tool %q in %#v", expected, normalized)
+		}
+	}
+	if !isAllUpper("HTTP") || isAllUpper("Http") || isAllUpper("1234") {
+		t.Fatalf("unexpected isAllUpper classification")
+	}
+	if got := limitStrings([]string{"a", "b", "c"}, 0); len(got) != 3 {
+		t.Fatalf("limitStrings with zero limit should preserve values: %#v", got)
+	}
+
+	findings := buildPolicyReadinessFindings(gatecore.Policy{
+		DefaultVerdict: "require_approval",
+		Rules: []gatecore.PolicyRule{
+			{
+				Effect: "block",
+				Match: gatecore.PolicyMatch{
+					ToolNames: []string{"other.tool"},
+				},
+			},
+		},
+	}, detection, signals, generated, unknown)
+	warnings := findingsToWarnings(findings)
+	for _, code := range []string{"repo.tool_inventory_name_mismatch", "repo.generated_rules_available", "repo.manual_review_required"} {
+		found := false
+		for _, finding := range findings {
+			if finding.Code == code {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("expected finding %q in %#v", code, findings)
+		}
+	}
+	if len(warnings) < len(findings) {
+		t.Fatalf("expected warnings to preserve all finding summaries: warnings=%#v findings=%#v", warnings, findings)
 	}
 }
 
@@ -2230,6 +2442,37 @@ func TestPolicyValidateFmtAndMatchedRuleOutput(t *testing.T) {
 	mustWriteFile(t, invalidPolicyPath, "default_verdit: allow\n")
 	if code := runPolicyValidate([]string{"--json", invalidPolicyPath}); code != exitInvalidInput {
 		t.Fatalf("runPolicyValidate unknown field: expected %d got %d", exitInvalidInput, code)
+	}
+
+	legacyPolicyPath := filepath.Join(workDir, "policy_legacy.yaml")
+	mustWriteFile(t, legacyPolicyPath, strings.Join([]string{
+		"version: 1",
+		"defaults:",
+		"  action: block",
+		"unknown_server: block",
+	}, "\n")+"\n")
+	legacyRaw := captureStdout(t, func() {
+		if code := runPolicyValidate([]string{"--json", legacyPolicyPath}); code != exitInvalidInput {
+			t.Fatalf("runPolicyValidate legacy fields: expected %d got %d", exitInvalidInput, code)
+		}
+	})
+	legacyOutput := map[string]any{}
+	if err := json.Unmarshal([]byte(legacyRaw), &legacyOutput); err != nil {
+		t.Fatalf("decode legacy policy validate output: %v raw=%q", err, legacyRaw)
+	}
+	if legacyOutput["hint"] != "use the repo-root `.gait.yaml` contract: `schema_id`, `schema_version`, `default_verdict`, optional `fail_closed`, optional `mcp_trust`, and `rules`" {
+		t.Fatalf("unexpected legacy policy hint: %#v", legacyOutput["hint"])
+	}
+	migration, ok := legacyOutput["migration"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected policy migration object, got %#v", legacyOutput["migration"])
+	}
+	if migration["kind"] != "policy_fields" {
+		t.Fatalf("unexpected migration kind: %#v", migration["kind"])
+	}
+	deprecatedFields, ok := migration["deprecated_fields"].([]any)
+	if !ok || len(deprecatedFields) != 3 {
+		t.Fatalf("unexpected deprecated_fields payload: %#v", migration["deprecated_fields"])
 	}
 }
 

--- a/cmd/gait/main_test.go
+++ b/cmd/gait/main_test.go
@@ -1567,11 +1567,16 @@ func TestOnboardingSignalClassificationHelpers(t *testing.T) {
 		"# unknown_signals:",
 		"starter.block.destructive",
 		"starter.require_approval.state_change",
+		"#         match:",
+		"#           tool_names:",
 		"acme.sync",
 	} {
 		if !strings.Contains(commentBlock, snippet) {
 			t.Fatalf("expected %q in starter comment block: %s", snippet, commentBlock)
 		}
+	}
+	if strings.Contains(commentBlock, "match.tool_names") {
+		t.Fatalf("starter comment block should render nested match YAML, got %s", commentBlock)
 	}
 
 	normalized := normalizeActionCandidateTools([]string{
@@ -1628,8 +1633,11 @@ func TestOnboardingSignalClassificationHelpers(t *testing.T) {
 			t.Fatalf("expected finding %q in %#v", code, findings)
 		}
 	}
-	if len(warnings) < len(findings) {
-		t.Fatalf("expected warnings to preserve all finding summaries: warnings=%#v findings=%#v", warnings, findings)
+	if len(warnings) >= len(findings) {
+		t.Fatalf("expected warning filter to reduce findings to actionable warnings: warnings=%#v findings=%#v", warnings, findings)
+	}
+	if len(warnings) != 1 || !strings.Contains(warnings[0], "detected tool inventory names do not match") {
+		t.Fatalf("expected only warning-level gap warnings, got %#v", warnings)
 	}
 }
 

--- a/cmd/gait/mcp.go
+++ b/cmd/gait/mcp.go
@@ -56,14 +56,16 @@ type mcpProxyOutput struct {
 }
 
 type mcpVerifyOutput struct {
-	OK          bool                         `json:"ok"`
-	ServerID    string                       `json:"server_id,omitempty"`
-	ServerName  string                       `json:"server_name,omitempty"`
-	Verdict     string                       `json:"verdict,omitempty"`
-	ReasonCodes []string                     `json:"reason_codes,omitempty"`
-	Violations  []string                     `json:"violations,omitempty"`
-	MCPTrust    *schemagate.MCPTrustDecision `json:"mcp_trust,omitempty"`
-	Error       string                       `json:"error,omitempty"`
+	OK           bool                         `json:"ok"`
+	ServerID     string                       `json:"server_id,omitempty"`
+	ServerName   string                       `json:"server_name,omitempty"`
+	TrustModel   string                       `json:"trust_model,omitempty"`
+	SnapshotPath string                       `json:"snapshot_path,omitempty"`
+	Verdict      string                       `json:"verdict,omitempty"`
+	ReasonCodes  []string                     `json:"reason_codes,omitempty"`
+	Violations   []string                     `json:"violations,omitempty"`
+	MCPTrust     *schemagate.MCPTrustDecision `json:"mcp_trust,omitempty"`
+	Error        string                       `json:"error,omitempty"`
 }
 
 type mcpProxyEvalOptions struct {
@@ -217,7 +219,7 @@ func runMCPProxy(arguments []string) int {
 
 func runMCPVerify(arguments []string) int {
 	if hasExplainFlag(arguments) {
-		return writeExplain("Evaluate optional MCP server trust policy against a local server description without executing a tool call.")
+		return writeExplain("Evaluate optional MCP server trust policy against a local server description and local trust snapshot without executing a tool call or performing a hosted registry lookup.")
 	}
 	arguments = reorderInterspersedFlags(arguments, map[string]bool{
 		"policy":     true,
@@ -262,10 +264,12 @@ func runMCPVerify(arguments []string) int {
 	trustDecision := mcp.EvaluateServerTrust(policy.MCPTrust, server, resolvedRiskClass, time.Now().UTC())
 	if trustDecision == nil {
 		return writeMCPVerifyOutput(jsonOutput, mcpVerifyOutput{
-			OK:         true,
-			ServerID:   strings.TrimSpace(server.ServerID),
-			ServerName: strings.TrimSpace(server.ServerName),
-			Verdict:    "allow",
+			OK:           true,
+			ServerID:     strings.TrimSpace(server.ServerID),
+			ServerName:   strings.TrimSpace(server.ServerName),
+			TrustModel:   mcpVerifyTrustModel(policy),
+			SnapshotPath: strings.TrimSpace(policy.MCPTrust.SnapshotPath),
+			Verdict:      "allow",
 		}, exitOK)
 	}
 
@@ -283,14 +287,23 @@ func runMCPVerify(arguments []string) int {
 	}
 	ok := exitCode == exitOK
 	return writeMCPVerifyOutput(jsonOutput, mcpVerifyOutput{
-		OK:          ok,
-		ServerID:    trustDecision.ServerID,
-		ServerName:  trustDecision.ServerName,
-		Verdict:     verdict,
-		ReasonCodes: append([]string(nil), trustDecision.ReasonCodes...),
-		Violations:  violations,
-		MCPTrust:    trustDecision,
+		OK:           ok,
+		ServerID:     trustDecision.ServerID,
+		ServerName:   trustDecision.ServerName,
+		TrustModel:   mcpVerifyTrustModel(policy),
+		SnapshotPath: strings.TrimSpace(policy.MCPTrust.SnapshotPath),
+		Verdict:      verdict,
+		ReasonCodes:  append([]string(nil), trustDecision.ReasonCodes...),
+		Violations:   violations,
+		MCPTrust:     trustDecision,
 	}, exitCode)
+}
+
+func mcpVerifyTrustModel(policy gate.Policy) string {
+	if strings.TrimSpace(policy.MCPTrust.SnapshotPath) == "" {
+		return ""
+	}
+	return "local_snapshot"
 }
 
 func readMCPServerInfo(path string) (*mcp.ServerInfo, error) {
@@ -1016,6 +1029,7 @@ func printMCPProxyUsage() {
 func printMCPVerifyUsage() {
 	fmt.Println("Usage:")
 	fmt.Println("  gait mcp verify --policy <policy.yaml> --server <server.json> [--risk-class <class>] [--json] [--explain]")
+	fmt.Println("  note: trust preflight reads mcp_trust.snapshot from a local file; scanners and registries stay outside the evaluator")
 }
 
 func normalizeMCPContextEnvelopePath(path string) (string, error) {

--- a/cmd/gait/mcp_test.go
+++ b/cmd/gait/mcp_test.go
@@ -240,6 +240,12 @@ func TestRunMCPVerifyTrustPolicy(t *testing.T) {
 	if !output.OK || output.MCPTrust == nil || output.MCPTrust.Status != "trusted" {
 		t.Fatalf("expected trusted verify output, got %#v", output)
 	}
+	if output.TrustModel != "local_snapshot" {
+		t.Fatalf("expected local snapshot trust model, got %#v", output)
+	}
+	if output.SnapshotPath != "./trust_snapshot.json" {
+		t.Fatalf("expected snapshot path in output, got %#v", output)
+	}
 }
 
 func TestRunMCPVerifyInfersPolicyRiskClass(t *testing.T) {
@@ -297,6 +303,12 @@ func TestRunMCPVerifyBlockedAndReadServerErrors(t *testing.T) {
 	if output.OK || output.MCPTrust == nil || output.MCPTrust.Status != "unknown" {
 		t.Fatalf("expected unknown blocked verify output, got %#v", output)
 	}
+	if output.TrustModel != "local_snapshot" {
+		t.Fatalf("expected local snapshot trust model, got %#v", output)
+	}
+	if output.SnapshotPath != "./trust_snapshot.json" {
+		t.Fatalf("expected snapshot path in blocked output, got %#v", output)
+	}
 
 	badServerPath := filepath.Join(workDir, "bad_server.json")
 	mustWriteFile(t, badServerPath, `{`)
@@ -311,6 +323,17 @@ func TestWriteMCPVerifyOutputTextModes(t *testing.T) {
 	}
 	if code := writeMCPVerifyOutput(false, mcpVerifyOutput{OK: false, Error: "bad"}, exitInvalidInput); code != exitInvalidInput {
 		t.Fatalf("writeMCPVerifyOutput error expected %d got %d", exitInvalidInput, code)
+	}
+}
+
+func TestRunMCPVerifyHelpMentionsLocalSnapshot(t *testing.T) {
+	raw := captureStdout(t, func() {
+		if code := runMCPVerify([]string{"--help"}); code != exitOK {
+			t.Fatalf("runMCPVerify help expected %d got %d", exitOK, code)
+		}
+	})
+	if !strings.Contains(raw, "mcp_trust.snapshot") {
+		t.Fatalf("expected local snapshot note in help, got %q", raw)
 	}
 }
 

--- a/cmd/gait/migration_guidance.go
+++ b/cmd/gait/migration_guidance.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	gatecore "github.com/Clyra-AI/gait/core/gate"
+)
+
+const (
+	legacyCommandPrefix = "deprecated command spelling: "
+	legacyFlagPrefix    = "deprecated flag spelling: "
+	legacyPolicyPrefix  = "legacy policy proposal fields are not supported ["
+)
+
+type migrationMetadata struct {
+	Kind               string                                `json:"kind"`
+	DeprecatedCommand  string                                `json:"deprecated_command,omitempty"`
+	ReplacementCommand string                                `json:"replacement_command,omitempty"`
+	DeprecatedFlag     string                                `json:"deprecated_flag,omitempty"`
+	ReplacementFlag    string                                `json:"replacement_flag,omitempty"`
+	DeprecatedFields   []string                              `json:"deprecated_fields,omitempty"`
+	FieldReplacements  []gatecore.LegacyPolicyFieldMigration `json:"field_replacements,omitempty"`
+}
+
+func legacyCommandError(deprecated string, replacement string) string {
+	return legacyCommandPrefix + strings.TrimSpace(deprecated) + " -> " + strings.TrimSpace(replacement)
+}
+
+func legacyFlagError(deprecated string, replacement string) string {
+	return legacyFlagPrefix + strings.TrimSpace(deprecated) + " -> " + strings.TrimSpace(replacement)
+}
+
+func migrationMetadataFromError(errorText string) (string, *migrationMetadata) {
+	trimmed := strings.TrimSpace(errorText)
+	switch {
+	case strings.HasPrefix(trimmed, legacyCommandPrefix):
+		body := strings.TrimSpace(strings.TrimPrefix(trimmed, legacyCommandPrefix))
+		parts := strings.SplitN(body, "->", 2)
+		if len(parts) != 2 {
+			return "", nil
+		}
+		deprecated := strings.TrimSpace(parts[0])
+		replacement := strings.TrimSpace(parts[1])
+		return fmt.Sprintf("use `%s` instead", replacement), &migrationMetadata{
+			Kind:               "command",
+			DeprecatedCommand:  deprecated,
+			ReplacementCommand: replacement,
+		}
+	case strings.HasPrefix(trimmed, legacyFlagPrefix):
+		body := strings.TrimSpace(strings.TrimPrefix(trimmed, legacyFlagPrefix))
+		parts := strings.SplitN(body, "->", 2)
+		if len(parts) != 2 {
+			return "", nil
+		}
+		deprecated := strings.TrimSpace(parts[0])
+		replacement := strings.TrimSpace(parts[1])
+		return fmt.Sprintf("use `%s` instead", replacement), &migrationMetadata{
+			Kind:            "flag",
+			DeprecatedFlag:  deprecated,
+			ReplacementFlag: replacement,
+		}
+	case strings.Contains(trimmed, legacyPolicyPrefix):
+		fieldNames := parseLegacyPolicyFieldNames(trimmed)
+		if len(fieldNames) == 0 {
+			return "", nil
+		}
+		replacements := gatecore.LegacyPolicyFieldMigrations(fieldNames)
+		return "use the repo-root `.gait.yaml` contract: `schema_id`, `schema_version`, `default_verdict`, optional `fail_closed`, optional `mcp_trust`, and `rules`", &migrationMetadata{
+			Kind:              "policy_fields",
+			DeprecatedFields:  fieldNames,
+			FieldReplacements: replacements,
+		}
+	default:
+		return "", nil
+	}
+}
+
+func parseLegacyPolicyFieldNames(errorText string) []string {
+	start := strings.Index(errorText, legacyPolicyPrefix)
+	if start == -1 {
+		return nil
+	}
+	start += len(legacyPolicyPrefix)
+	end := strings.Index(errorText[start:], "]")
+	if end == -1 {
+		return nil
+	}
+	body := errorText[start : start+end]
+	parts := strings.Split(body, ",")
+	fields := make([]string, 0, len(parts))
+	for _, part := range parts {
+		trimmed := strings.TrimSpace(part)
+		if trimmed == "" {
+			continue
+		}
+		fields = append(fields, trimmed)
+	}
+	return fields
+}
+
+func containsArgument(arguments []string, needle string) bool {
+	for _, argument := range arguments {
+		trimmed := strings.TrimSpace(argument)
+		if trimmed == needle || strings.HasPrefix(trimmed, needle+"=") {
+			return true
+		}
+	}
+	return false
+}
+
+func writeRootInputError(arguments []string, errorText string) int {
+	output := map[string]any{
+		"ok":    false,
+		"error": strings.TrimSpace(errorText),
+	}
+	if hasJSONFlag(arguments[1:]) {
+		return writeJSONOutput(output, exitInvalidInput)
+	}
+	fmt.Printf("error: %s\n", strings.TrimSpace(errorText))
+	if hint, _ := migrationMetadataFromError(errorText); hint != "" {
+		fmt.Printf("hint: %s\n", hint)
+	}
+	printUsage()
+	return exitInvalidInput
+}

--- a/cmd/gait/onboarding.go
+++ b/cmd/gait/onboarding.go
@@ -37,25 +37,32 @@ type repoDetection struct {
 }
 
 type initOutput struct {
-	OK           bool            `json:"ok"`
-	Template     string          `json:"template,omitempty"`
-	PolicyPath   string          `json:"policy_path,omitempty"`
-	Detection    repoDetection   `json:"detection,omitempty"`
-	Contract     surfaceContract `json:"contract"`
-	NextCommands []string        `json:"next_commands,omitempty"`
-	Error        string          `json:"error,omitempty"`
+	OK              bool            `json:"ok"`
+	Template        string          `json:"template,omitempty"`
+	PolicyPath      string          `json:"policy_path,omitempty"`
+	Detection       repoDetection   `json:"detection,omitempty"`
+	DetectedSignals []repoSignal    `json:"detected_signals,omitempty"`
+	GeneratedRules  []generatedRule `json:"generated_rules,omitempty"`
+	UnknownSignals  []repoSignal    `json:"unknown_signals,omitempty"`
+	Contract        surfaceContract `json:"contract"`
+	NextCommands    []string        `json:"next_commands,omitempty"`
+	Error           string          `json:"error,omitempty"`
 }
 
 type checkOutput struct {
-	OK             bool            `json:"ok"`
-	PolicyPath     string          `json:"policy_path,omitempty"`
-	DefaultVerdict string          `json:"default_verdict,omitempty"`
-	RuleCount      int             `json:"rule_count,omitempty"`
-	Detection      repoDetection   `json:"detection,omitempty"`
-	Contract       surfaceContract `json:"contract"`
-	GapWarnings    []string        `json:"gap_warnings,omitempty"`
-	Summary        string          `json:"summary,omitempty"`
-	Error          string          `json:"error,omitempty"`
+	OK              bool               `json:"ok"`
+	PolicyPath      string             `json:"policy_path,omitempty"`
+	DefaultVerdict  string             `json:"default_verdict,omitempty"`
+	RuleCount       int                `json:"rule_count,omitempty"`
+	Detection       repoDetection      `json:"detection,omitempty"`
+	DetectedSignals []repoSignal       `json:"detected_signals,omitempty"`
+	UnknownSignals  []repoSignal       `json:"unknown_signals,omitempty"`
+	Contract        surfaceContract    `json:"contract"`
+	Findings        []readinessFinding `json:"findings,omitempty"`
+	GapWarnings     []string           `json:"gap_warnings,omitempty"`
+	NextCommands    []string           `json:"next_commands,omitempty"`
+	Summary         string             `json:"summary,omitempty"`
+	Error           string             `json:"error,omitempty"`
 }
 
 type captureOutput struct {
@@ -73,7 +80,7 @@ type captureOutput struct {
 
 func runInit(arguments []string) int {
 	if hasExplainFlag(arguments) {
-		return writeExplain("Write a deterministic starter repo policy at .gait.yaml and report local framework hints without changing existing regress or project-defaults files.")
+		return writeExplain("Write a deterministic starter repo policy at .gait.yaml, report repo signals, and emit conservative starter rule suggestions without changing existing regress or project-defaults files.")
 	}
 	arguments = reorderInterspersedFlags(arguments, map[string]bool{
 		"template": true,
@@ -132,6 +139,7 @@ func runInit(arguments []string) int {
 	if err != nil {
 		return writeInitOutput(jsonOutput, initOutput{OK: false, Contract: currentSurfaceContract(), Error: err.Error()}, exitCodeForError(err, exitInvalidInput))
 	}
+	detectedSignals, generatedRules, unknownSignals := deriveRepoSignalsAndStarterRules(detection)
 
 	trimmedOutPath := strings.TrimSpace(outPath)
 	if trimmedOutPath == "" {
@@ -158,17 +166,20 @@ func runInit(arguments []string) int {
 		}
 	}
 
-	rendered := renderInitPolicy(templateBody, detection)
+	rendered := renderInitPolicy(templateBody, detection, generatedRules, unknownSignals)
 	if err := os.WriteFile(trimmedOutPath, []byte(rendered), 0o600); err != nil {
 		return writeInitOutput(jsonOutput, initOutput{OK: false, Contract: currentSurfaceContract(), Error: err.Error()}, exitCodeForError(err, exitInvalidInput))
 	}
 
 	return writeInitOutput(jsonOutput, initOutput{
-		OK:         true,
-		Template:   resolvedTemplate,
-		PolicyPath: trimmedOutPath,
-		Detection:  detection,
-		Contract:   currentSurfaceContract(),
+		OK:              true,
+		Template:        resolvedTemplate,
+		PolicyPath:      trimmedOutPath,
+		Detection:       detection,
+		DetectedSignals: detectedSignals,
+		GeneratedRules:  generatedRules,
+		UnknownSignals:  unknownSignals,
+		Contract:        currentSurfaceContract(),
 		NextCommands: []string{
 			fmt.Sprintf("gait check --policy %s --json", trimmedOutPath),
 			fmt.Sprintf("gait policy validate %s --json", trimmedOutPath),
@@ -179,7 +190,7 @@ func runInit(arguments []string) int {
 
 func runCheck(arguments []string) int {
 	if hasExplainFlag(arguments) {
-		return writeExplain("Validate a repo policy file, then report deterministic gap warnings against local tool and framework hints without mutating the workspace.")
+		return writeExplain("Validate a repo policy file, then report deterministic readiness findings and compatibility gap warnings against local repo signals without mutating the workspace.")
 	}
 	arguments = reorderInterspersedFlags(arguments, map[string]bool{
 		"policy": true,
@@ -245,28 +256,44 @@ func runCheck(arguments []string) int {
 		}, exitCodeForError(err, exitInvalidInput))
 	}
 
-	gapWarnings := buildPolicyGapWarnings(policy, detection)
+	detectedSignals, generatedRules, unknownSignals := deriveRepoSignalsAndStarterRules(detection)
+	findings := buildPolicyReadinessFindings(policy, detection, detectedSignals, generatedRules, unknownSignals)
+	gapWarnings := findingsToWarnings(findings)
 	summary := fmt.Sprintf(
-		"policy ok: default_verdict=%s rules=%d gap_warnings=%d",
+		"policy ok: default_verdict=%s rules=%d findings=%d gap_warnings=%d",
 		policy.DefaultVerdict,
 		len(policy.Rules),
+		len(findings),
 		len(gapWarnings),
 	)
 	return writeCheckOutput(jsonOutput, checkOutput{
-		OK:             true,
-		PolicyPath:     trimmedPolicyPath,
-		DefaultVerdict: policy.DefaultVerdict,
-		RuleCount:      len(policy.Rules),
-		Detection:      detection,
-		Contract:       currentSurfaceContract(),
-		GapWarnings:    gapWarnings,
-		Summary:        summary,
+		OK:              true,
+		PolicyPath:      trimmedPolicyPath,
+		DefaultVerdict:  policy.DefaultVerdict,
+		RuleCount:       len(policy.Rules),
+		Detection:       detection,
+		DetectedSignals: detectedSignals,
+		UnknownSignals:  unknownSignals,
+		Contract:        currentSurfaceContract(),
+		Findings:        findings,
+		GapWarnings:     gapWarnings,
+		NextCommands: []string{
+			fmt.Sprintf("gait policy validate %s --json", trimmedPolicyPath),
+			fmt.Sprintf("gait policy test %s examples/policy/intents/intent_delete.json --json", trimmedPolicyPath),
+		},
+		Summary: summary,
 	}, exitOK)
 }
 
 func runCapture(arguments []string) int {
 	if hasExplainFlag(arguments) {
 		return writeExplain("Resolve an explicit runpack, trace, or session-chain source and persist a portable capture receipt for later regress import.")
+	}
+	if containsArgument(arguments, "--save-as") {
+		return writeCaptureOutput(hasJSONFlag(arguments), captureOutput{
+			OK:    false,
+			Error: legacyFlagError("--save-as", "--out"),
+		}, exitInvalidInput)
 	}
 	arguments = reorderInterspersedFlags(arguments, map[string]bool{
 		"from":       true,
@@ -498,7 +525,7 @@ func sortedKeys(values map[string]struct{}) []string {
 	return keys
 }
 
-func renderInitPolicy(templateBody string, detection repoDetection) string {
+func renderInitPolicy(templateBody string, detection repoDetection, generatedRules []generatedRule, unknownSignals []repoSignal) string {
 	lines := []string{
 		"# gait init starter policy",
 		fmt.Sprintf("# repo_policy_path: %s", projectconfig.RepoPolicyPath),
@@ -511,6 +538,7 @@ func renderInitPolicy(templateBody string, detection repoDetection) string {
 	if toolSummary := summarizeDetectedToolsForComment(detection.ToolNames); toolSummary != "" {
 		lines = append(lines, fmt.Sprintf("# detected_tools: %s", toolSummary))
 	}
+	lines = append(lines, renderStarterRuleComments(generatedRules, unknownSignals)...)
 	body := strings.TrimLeft(templateBody, "\n")
 	if !strings.HasSuffix(body, "\n") {
 		body += "\n"
@@ -532,59 +560,6 @@ func summarizeDetectedToolsForComment(toolNames []string) string {
 		summary = fmt.Sprintf("%s (+%d more)", summary, len(toolNames)-limit)
 	}
 	return summary
-}
-
-func buildPolicyGapWarnings(policy gate.Policy, detection repoDetection) []string {
-	warnings := []string{}
-	if len(policy.Rules) == 0 {
-		warnings = append(warnings, "policy defines no explicit rules; only default_verdict will apply")
-	}
-	if strings.EqualFold(strings.TrimSpace(policy.DefaultVerdict), "allow") {
-		warnings = append(warnings, "default_verdict=allow is permissive; high-risk repos usually prefer require_approval or block")
-	}
-
-	hasNonAllowRule := false
-	matchedToolNames := map[string]struct{}{}
-	for _, rule := range policy.Rules {
-		effect := strings.ToLower(strings.TrimSpace(rule.Effect))
-		if effect == "" {
-			effect = strings.ToLower(strings.TrimSpace(rule.Action))
-		}
-		if effect != "" && effect != "allow" {
-			hasNonAllowRule = true
-		}
-		if toolName := strings.TrimSpace(rule.Match.ToolName); toolName != "" {
-			matchedToolNames[toolName] = struct{}{}
-		}
-		for _, toolName := range rule.Match.ToolNames {
-			trimmed := strings.TrimSpace(toolName)
-			if trimmed != "" {
-				matchedToolNames[trimmed] = struct{}{}
-			}
-		}
-	}
-	if !hasNonAllowRule {
-		warnings = append(warnings, "policy has no non-allow rules; enforce paths will not block or require approval")
-	}
-	if len(detection.Frameworks) == 0 {
-		warnings = append(warnings, "no supported framework tools were detected locally; review whether this repo has an explicit Gait interception seam yet")
-	}
-	if len(detection.ToolNames) > 0 && len(matchedToolNames) == 0 {
-		warnings = append(warnings, "detected tool inventory but no explicit tool_name/tool_names coverage was found; review policy coverage manually")
-	}
-	if len(detection.ToolNames) > 0 && len(matchedToolNames) > 0 {
-		covered := false
-		for _, detectedTool := range detection.ToolNames {
-			if _, ok := matchedToolNames[strings.TrimSpace(detectedTool)]; ok {
-				covered = true
-				break
-			}
-		}
-		if !covered {
-			warnings = append(warnings, "detected tool inventory names do not match explicit policy tool_name/tool_names entries; normalize tool naming before rollout")
-		}
-	}
-	return warnings
 }
 
 func writeCaptureReceipt(path string, output captureOutput) error {

--- a/cmd/gait/onboarding_signals.go
+++ b/cmd/gait/onboarding_signals.go
@@ -1,0 +1,380 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/Clyra-AI/gait/core/gate"
+)
+
+type repoSignal struct {
+	Code       string   `json:"code"`
+	Category   string   `json:"category"`
+	Value      string   `json:"value,omitempty"`
+	Confidence string   `json:"confidence,omitempty"`
+	Evidence   []string `json:"evidence,omitempty"`
+	Reason     string   `json:"reason,omitempty"`
+}
+
+type generatedRule struct {
+	ID             string   `json:"id"`
+	Name           string   `json:"name"`
+	Effect         string   `json:"effect"`
+	Priority       int      `json:"priority"`
+	MatchToolNames []string `json:"match_tool_names,omitempty"`
+	ReasonCodes    []string `json:"reason_codes,omitempty"`
+	Confidence     string   `json:"confidence,omitempty"`
+	Rationale      string   `json:"rationale,omitempty"`
+}
+
+type readinessFinding struct {
+	Code            string   `json:"code"`
+	Severity        string   `json:"severity"`
+	Summary         string   `json:"summary"`
+	DetectedSurface string   `json:"detected_surface,omitempty"`
+	Remediation     string   `json:"remediation,omitempty"`
+	Evidence        []string `json:"evidence,omitempty"`
+}
+
+func deriveRepoSignalsAndStarterRules(detection repoDetection) ([]repoSignal, []generatedRule, []repoSignal) {
+	signals := make([]repoSignal, 0, len(detection.Frameworks)+3)
+	generated := []generatedRule{}
+	unknown := []repoSignal{}
+
+	for _, framework := range detection.Frameworks {
+		trimmed := strings.TrimSpace(framework)
+		if trimmed == "" {
+			continue
+		}
+		signals = append(signals, repoSignal{
+			Code:       "framework." + trimmed,
+			Category:   "framework",
+			Value:      trimmed,
+			Confidence: "high",
+			Evidence:   []string{trimmed},
+			Reason:     "supported framework tag detected by scout",
+		})
+	}
+
+	candidateTools := normalizeActionCandidateTools(detection.ToolNames)
+	if len(candidateTools) == 0 {
+		return signals, generated, unknown
+	}
+
+	classified := map[string][]string{
+		"destructive":  {},
+		"state_change": {},
+		"payment":      {},
+		"data_store":   {},
+	}
+	seenClassified := map[string]struct{}{}
+	for _, toolName := range candidateTools {
+		switch {
+		case matchesAnyFragment(toolName, "delete", "remove", "drop", "destroy", "truncate"):
+			classified["destructive"] = append(classified["destructive"], toolName)
+			seenClassified[toolName] = struct{}{}
+		case matchesAnyFragment(toolName, "stripe", "payment", "charge", "refund", "billing", "invoice"):
+			classified["payment"] = append(classified["payment"], toolName)
+			seenClassified[toolName] = struct{}{}
+		case matchesAnyFragment(toolName, "postgres", "database", "db", "sql"):
+			classified["data_store"] = append(classified["data_store"], toolName)
+			seenClassified[toolName] = struct{}{}
+		case matchesAnyFragment(toolName, "write", "update", "create", "set", "save", "submit", "approve", "cancel", "pause", "resume", "restart"):
+			classified["state_change"] = append(classified["state_change"], toolName)
+			seenClassified[toolName] = struct{}{}
+		}
+	}
+
+	appendSignal := func(code string, category string, evidence []string, reason string) {
+		if len(evidence) == 0 {
+			return
+		}
+		signals = append(signals, repoSignal{
+			Code:       code,
+			Category:   category,
+			Value:      category,
+			Confidence: "high",
+			Evidence:   evidence,
+			Reason:     reason,
+		})
+	}
+
+	appendSignal("tool.destructive", "destructive_tools", classified["destructive"], "likely destructive tool names detected")
+	appendSignal("tool.state_change", "state_change_tools", classified["state_change"], "likely state-changing tool names detected")
+	appendSignal("tool.payment", "payment_tools", classified["payment"], "payment or billing tool names detected")
+	appendSignal("tool.data_store", "data_store_tools", classified["data_store"], "database or data-store tool names detected")
+
+	if len(classified["destructive"]) > 0 {
+		generated = append(generated, generatedRule{
+			ID:             "starter.block.destructive",
+			Name:           "block-destructive-tools",
+			Effect:         "block",
+			Priority:       10,
+			MatchToolNames: limitStrings(classified["destructive"], 6),
+			ReasonCodes:    []string{"destructive_tool_blocked"},
+			Confidence:     "high",
+			Rationale:      "detected likely destructive tool names",
+		})
+	}
+	approvalTools := mergeUniqueSorted(nil, classified["state_change"])
+	approvalTools = mergeUniqueSorted(approvalTools, classified["payment"])
+	approvalTools = mergeUniqueSorted(approvalTools, classified["data_store"])
+	if len(approvalTools) > 0 {
+		generated = append(generated, generatedRule{
+			ID:             "starter.require_approval.state_change",
+			Name:           "require-approval-state-changing-tools",
+			Effect:         "require_approval",
+			Priority:       20,
+			MatchToolNames: limitStrings(approvalTools, 8),
+			ReasonCodes:    []string{"approval_required_for_state_change"},
+			Confidence:     "high",
+			Rationale:      "detected likely state-changing, payment, or data-store tool names",
+		})
+	}
+
+	unclassified := make([]string, 0, len(candidateTools))
+	for _, toolName := range candidateTools {
+		if _, ok := seenClassified[toolName]; ok {
+			continue
+		}
+		unclassified = append(unclassified, toolName)
+	}
+	if len(unclassified) > 0 {
+		unknown = append(unknown, repoSignal{
+			Code:       "tool.unclassified",
+			Category:   "unclassified_tools",
+			Value:      "manual_review",
+			Confidence: "low",
+			Evidence:   limitStrings(unclassified, 8),
+			Reason:     "candidate tool names were detected but did not match a high-confidence starter rule pattern",
+		})
+	}
+
+	return signals, generated, unknown
+}
+
+func buildPolicyReadinessFindings(policy gate.Policy, detection repoDetection, signals []repoSignal, generated []generatedRule, unknown []repoSignal) []readinessFinding {
+	findings := []readinessFinding{}
+	if len(policy.Rules) == 0 {
+		findings = append(findings, readinessFinding{
+			Code:            "policy.no_rules",
+			Severity:        "warning",
+			Summary:         "policy defines no explicit rules; only default_verdict will apply",
+			DetectedSurface: "policy.rules",
+			Remediation:     "add explicit rules or review generated starter suggestions from `gait init --json`",
+		})
+	}
+	if strings.EqualFold(strings.TrimSpace(policy.DefaultVerdict), "allow") {
+		findings = append(findings, readinessFinding{
+			Code:            "policy.default_allow",
+			Severity:        "warning",
+			Summary:         "default_verdict=allow is permissive; high-risk repos usually prefer require_approval or block",
+			DetectedSurface: "policy.default_verdict",
+			Remediation:     "set `default_verdict` to `require_approval` or `block` before production rollout",
+		})
+	}
+
+	hasNonAllowRule := false
+	matchedToolNames := map[string]struct{}{}
+	for _, rule := range policy.Rules {
+		effect := strings.ToLower(strings.TrimSpace(rule.Effect))
+		if effect == "" {
+			effect = strings.ToLower(strings.TrimSpace(rule.Action))
+		}
+		if effect != "" && effect != "allow" {
+			hasNonAllowRule = true
+		}
+		if toolName := strings.TrimSpace(rule.Match.ToolName); toolName != "" {
+			matchedToolNames[toolName] = struct{}{}
+		}
+		for _, toolName := range rule.Match.ToolNames {
+			trimmed := strings.TrimSpace(toolName)
+			if trimmed != "" {
+				matchedToolNames[trimmed] = struct{}{}
+			}
+		}
+	}
+
+	if !hasNonAllowRule {
+		findings = append(findings, readinessFinding{
+			Code:            "policy.no_non_allow_rules",
+			Severity:        "warning",
+			Summary:         "policy has no non-allow rules; enforce paths will not block or require approval",
+			DetectedSurface: "policy.rules",
+			Remediation:     "add `block` or `require_approval` rules for state-changing or destructive tool classes",
+		})
+	}
+	if len(detection.Frameworks) == 0 {
+		findings = append(findings, readinessFinding{
+			Code:            "repo.no_supported_framework_detected",
+			Severity:        "info",
+			Summary:         "no supported framework tools were detected locally; review whether this repo has an explicit Gait interception seam yet",
+			DetectedSurface: "repo.frameworks",
+			Remediation:     "wire one explicit tool boundary before relying on runtime enforcement",
+		})
+	}
+
+	if len(detection.ToolNames) > 0 && len(matchedToolNames) == 0 {
+		findings = append(findings, readinessFinding{
+			Code:            "repo.tool_inventory_uncovered",
+			Severity:        "warning",
+			Summary:         "detected tool inventory but no explicit tool_name/tool_names coverage was found",
+			DetectedSurface: "repo.tools",
+			Remediation:     "add explicit `match.tool_name` or `match.tool_names` coverage for detected tool surfaces",
+			Evidence:        limitStrings(normalizeActionCandidateTools(detection.ToolNames), 8),
+		})
+	}
+	if len(detection.ToolNames) > 0 && len(matchedToolNames) > 0 {
+		covered := false
+		for _, detectedTool := range detection.ToolNames {
+			if _, ok := matchedToolNames[strings.TrimSpace(detectedTool)]; ok {
+				covered = true
+				break
+			}
+		}
+		if !covered {
+			findings = append(findings, readinessFinding{
+				Code:            "repo.tool_inventory_name_mismatch",
+				Severity:        "warning",
+				Summary:         "detected tool inventory names do not match explicit policy tool_name/tool_names entries",
+				DetectedSurface: "repo.tools",
+				Remediation:     "normalize detected tool names and policy `match.tool_name` / `match.tool_names` entries before rollout",
+				Evidence:        limitStrings(normalizeActionCandidateTools(detection.ToolNames), 8),
+			})
+		}
+	}
+	if len(generated) > 0 {
+		ids := make([]string, 0, len(generated))
+		for _, rule := range generated {
+			ids = append(ids, rule.ID)
+		}
+		findings = append(findings, readinessFinding{
+			Code:            "repo.generated_rules_available",
+			Severity:        "info",
+			Summary:         "repo-aware starter rule suggestions are available from local detection",
+			DetectedSurface: "repo.signals",
+			Remediation:     "review the generated starter rules in `.gait.yaml` comments and either adopt or discard them explicitly",
+			Evidence:        ids,
+		})
+	}
+	if len(unknown) > 0 {
+		findings = append(findings, readinessFinding{
+			Code:            "repo.manual_review_required",
+			Severity:        "info",
+			Summary:         "some detected surfaces require manual review because they did not match a high-confidence starter rule pattern",
+			DetectedSurface: "repo.signals",
+			Remediation:     "review `unknown_signals` and decide whether to add custom policy rules",
+			Evidence:        limitStrings(unknown[0].Evidence, 8),
+		})
+	}
+	if len(signals) == 0 {
+		findings = append(findings, readinessFinding{
+			Code:            "repo.no_high_confidence_signals",
+			Severity:        "info",
+			Summary:         "no high-confidence repo signals were detected for starter rule synthesis",
+			DetectedSurface: "repo.signals",
+			Remediation:     "continue with the baseline template and add custom rules manually",
+		})
+	}
+
+	return findings
+}
+
+func findingsToWarnings(findings []readinessFinding) []string {
+	warnings := make([]string, 0, len(findings))
+	for _, finding := range findings {
+		if strings.TrimSpace(finding.Summary) == "" {
+			continue
+		}
+		warnings = append(warnings, finding.Summary)
+	}
+	return warnings
+}
+
+func renderStarterRuleComments(rules []generatedRule, unknown []repoSignal) []string {
+	lines := []string{}
+	if len(rules) > 0 {
+		lines = append(lines, "# generated_rules:")
+		for _, rule := range rules {
+			lines = append(lines, fmt.Sprintf("#   - id: %s", rule.ID))
+			lines = append(lines, fmt.Sprintf("#     rationale: %s", rule.Rationale))
+			lines = append(lines, "#     suggested_yaml:")
+			lines = append(lines, fmt.Sprintf("#       - name: %s", rule.Name))
+			lines = append(lines, fmt.Sprintf("#         priority: %d", rule.Priority))
+			lines = append(lines, fmt.Sprintf("#         effect: %s", rule.Effect))
+			if len(rule.MatchToolNames) > 0 {
+				lines = append(lines, fmt.Sprintf("#         match.tool_names: [%s]", strings.Join(rule.MatchToolNames, ", ")))
+			}
+			if len(rule.ReasonCodes) > 0 {
+				lines = append(lines, fmt.Sprintf("#         reason_codes: [%s]", strings.Join(rule.ReasonCodes, ", ")))
+			}
+		}
+	}
+	if len(unknown) > 0 {
+		lines = append(lines, "# unknown_signals:")
+		for _, signal := range unknown {
+			lines = append(lines, fmt.Sprintf("#   - code: %s", signal.Code))
+			if len(signal.Evidence) > 0 {
+				lines = append(lines, fmt.Sprintf("#     evidence: [%s]", strings.Join(signal.Evidence, ", ")))
+			}
+			if signal.Reason != "" {
+				lines = append(lines, fmt.Sprintf("#     reason: %s", signal.Reason))
+			}
+		}
+	}
+	return lines
+}
+
+func normalizeActionCandidateTools(toolNames []string) []string {
+	candidates := make([]string, 0, len(toolNames))
+	for _, toolName := range toolNames {
+		trimmed := strings.TrimSpace(toolName)
+		if trimmed == "" || strings.HasPrefix(trimmed, "_") || strings.HasPrefix(trimmed, "__") {
+			continue
+		}
+		if strings.Contains(trimmed, ".") {
+			candidates = append(candidates, strings.ToLower(trimmed))
+			continue
+		}
+		if isAllUpper(trimmed) {
+			continue
+		}
+		if len(trimmed) > 48 {
+			continue
+		}
+		if matchesAnyFragment(trimmed, "write", "update", "create", "set", "save", "delete", "remove", "drop", "destroy", "truncate", "approve", "cancel", "pause", "resume", "restart", "stripe", "payment", "charge", "refund", "billing", "invoice", "postgres", "database", "db", "sql") {
+			candidates = append(candidates, strings.ToLower(trimmed))
+		}
+	}
+	return uniqueSortedStrings(candidates)
+}
+
+func matchesAnyFragment(value string, fragments ...string) bool {
+	lower := strings.ToLower(strings.TrimSpace(value))
+	for _, fragment := range fragments {
+		if strings.Contains(lower, fragment) {
+			return true
+		}
+	}
+	return false
+}
+
+func isAllUpper(value string) bool {
+	hasLetter := false
+	for _, ch := range value {
+		if ch >= 'a' && ch <= 'z' {
+			return false
+		}
+		if ch >= 'A' && ch <= 'Z' {
+			hasLetter = true
+		}
+	}
+	return hasLetter
+}
+
+func limitStrings(values []string, limit int) []string {
+	if limit <= 0 || len(values) <= limit {
+		return append([]string(nil), values...)
+	}
+	return append([]string(nil), values[:limit]...)
+}

--- a/cmd/gait/onboarding_signals.go
+++ b/cmd/gait/onboarding_signals.go
@@ -283,6 +283,9 @@ func buildPolicyReadinessFindings(policy gate.Policy, detection repoDetection, s
 func findingsToWarnings(findings []readinessFinding) []string {
 	warnings := make([]string, 0, len(findings))
 	for _, finding := range findings {
+		if !strings.EqualFold(strings.TrimSpace(finding.Severity), "warning") {
+			continue
+		}
 		if strings.TrimSpace(finding.Summary) == "" {
 			continue
 		}
@@ -303,7 +306,8 @@ func renderStarterRuleComments(rules []generatedRule, unknown []repoSignal) []st
 			lines = append(lines, fmt.Sprintf("#         priority: %d", rule.Priority))
 			lines = append(lines, fmt.Sprintf("#         effect: %s", rule.Effect))
 			if len(rule.MatchToolNames) > 0 {
-				lines = append(lines, fmt.Sprintf("#         match.tool_names: [%s]", strings.Join(rule.MatchToolNames, ", ")))
+				lines = append(lines, "#         match:")
+				lines = append(lines, fmt.Sprintf("#           tool_names: [%s]", strings.Join(rule.MatchToolNames, ", ")))
 			}
 			if len(rule.ReasonCodes) > 0 {
 				lines = append(lines, fmt.Sprintf("#         reason_codes: [%s]", strings.Join(rule.ReasonCodes, ", ")))

--- a/cmd/gait/wrapper.go
+++ b/cmd/gait/wrapper.go
@@ -18,21 +18,34 @@ type wrapperVerdictCount struct {
 }
 
 type wrapperOutput struct {
-	OK            bool                  `json:"ok"`
-	Mode          string                `json:"mode,omitempty"`
-	Command       []string              `json:"command,omitempty"`
-	Cwd           string                `json:"cwd,omitempty"`
-	ChildExitCode int                   `json:"child_exit_code,omitempty"`
-	TimedOut      bool                  `json:"timed_out,omitempty"`
-	DurationMS    int64                 `json:"duration_ms,omitempty"`
-	VerdictCounts []wrapperVerdictCount `json:"verdict_counts,omitempty"`
-	TracePaths    []string              `json:"trace_paths,omitempty"`
-	RunpackPaths  []string              `json:"runpack_paths,omitempty"`
-	Stdout        string                `json:"stdout,omitempty"`
-	Stderr        string                `json:"stderr,omitempty"`
-	Warnings      []string              `json:"warnings,omitempty"`
-	Error         string                `json:"error,omitempty"`
+	OK                     bool                  `json:"ok"`
+	Mode                   string                `json:"mode,omitempty"`
+	Command                []string              `json:"command,omitempty"`
+	Cwd                    string                `json:"cwd,omitempty"`
+	BoundaryContract       string                `json:"boundary_contract,omitempty"`
+	TraceReferenceRequired bool                  `json:"trace_reference_required,omitempty"`
+	FailureReason          string                `json:"failure_reason,omitempty"`
+	ChildExitCode          int                   `json:"child_exit_code,omitempty"`
+	TimedOut               bool                  `json:"timed_out,omitempty"`
+	DurationMS             int64                 `json:"duration_ms,omitempty"`
+	VerdictCounts          []wrapperVerdictCount `json:"verdict_counts,omitempty"`
+	TracePaths             []string              `json:"trace_paths,omitempty"`
+	RunpackPaths           []string              `json:"runpack_paths,omitempty"`
+	Stdout                 string                `json:"stdout,omitempty"`
+	Stderr                 string                `json:"stderr,omitempty"`
+	Warnings               []string              `json:"warnings,omitempty"`
+	Error                  string                `json:"error,omitempty"`
 }
+
+const (
+	wrapperBoundaryContractExplicitTrace = "explicit_trace_reference"
+
+	wrapperFailureReasonChildStartFailed     = "child_start_failed"
+	wrapperFailureReasonChildWaitFailed      = "child_wait_failed"
+	wrapperFailureReasonChildTimedOut        = "child_timed_out"
+	wrapperFailureReasonMissingTraceRef      = "missing_trace_reference"
+	wrapperFailureReasonInvalidTraceArtifact = "invalid_trace_artifact"
+)
 
 func runTest(arguments []string) int {
 	return runWrapperMode("test", arguments)
@@ -133,11 +146,14 @@ func executeWrapperCommand(opts wrapperOptions) (wrapperOutput, int) {
 
 	if err := cmd.Start(); err != nil {
 		return wrapperOutput{
-			OK:      false,
-			Mode:    opts.Mode,
-			Command: append([]string(nil), opts.Command...),
-			Cwd:     opts.Cwd,
-			Error:   err.Error(),
+			OK:                     false,
+			Mode:                   opts.Mode,
+			Command:                append([]string(nil), opts.Command...),
+			Cwd:                    opts.Cwd,
+			BoundaryContract:       wrapperBoundaryContractExplicitTrace,
+			TraceReferenceRequired: true,
+			FailureReason:          wrapperFailureReasonChildStartFailed,
+			Error:                  err.Error(),
 		}, exitCodeForError(err, exitInternalFailure)
 	}
 
@@ -167,13 +183,15 @@ func executeWrapperCommand(opts wrapperOptions) (wrapperOutput, int) {
 	}
 
 	output := wrapperOutput{
-		Mode:       opts.Mode,
-		Command:    append([]string(nil), opts.Command...),
-		Cwd:        opts.Cwd,
-		TimedOut:   timedOut,
-		DurationMS: time.Since(startedAt).Milliseconds(),
-		Stdout:     stdout.String(),
-		Stderr:     stderr.String(),
+		Mode:                   opts.Mode,
+		Command:                append([]string(nil), opts.Command...),
+		Cwd:                    opts.Cwd,
+		BoundaryContract:       wrapperBoundaryContractExplicitTrace,
+		TraceReferenceRequired: true,
+		TimedOut:               timedOut,
+		DurationMS:             time.Since(startedAt).Milliseconds(),
+		Stdout:                 stdout.String(),
+		Stderr:                 stderr.String(),
 	}
 	if cmd.ProcessState != nil {
 		output.ChildExitCode = cmd.ProcessState.ExitCode()
@@ -188,21 +206,25 @@ func executeWrapperCommand(opts wrapperOptions) (wrapperOutput, int) {
 
 	if timedOut {
 		output.OK = false
+		output.FailureReason = wrapperFailureReasonChildTimedOut
 		output.Error = fmt.Sprintf("child command timed out after %s", opts.Timeout)
 		return output, exitInternalFailure
 	}
 	if waitErr != nil && output.ChildExitCode == 0 {
 		output.OK = false
+		output.FailureReason = wrapperFailureReasonChildWaitFailed
 		output.Error = waitErr.Error()
 		return output, exitInternalFailure
 	}
 	if len(tracePaths) == 0 {
 		output.OK = false
+		output.FailureReason = wrapperFailureReasonMissingTraceRef
 		output.Error = "child command did not emit a Gait trace reference; wrappers require an explicit Gait interception seam"
 		return output, exitInvalidInput
 	}
 	if opts.Mode == "enforce" && invalidTraceCount > 0 {
 		output.OK = false
+		output.FailureReason = wrapperFailureReasonInvalidTraceArtifact
 		output.Error = "child command emitted an invalid Gait trace artifact; enforce mode fails closed"
 		return output, exitPolicyBlocked
 	}
@@ -291,6 +313,12 @@ func uniquePaths(paths []string) []string {
 }
 
 func writeWrapperOutput(jsonOutput bool, output wrapperOutput, exitCode int) int {
+	if output.BoundaryContract == "" {
+		output.BoundaryContract = wrapperBoundaryContractExplicitTrace
+	}
+	if !output.TraceReferenceRequired {
+		output.TraceReferenceRequired = true
+	}
 	if jsonOutput {
 		return writeJSONOutput(output, exitCode)
 	}
@@ -309,4 +337,5 @@ func writeWrapperOutput(jsonOutput bool, output wrapperOutput, exitCode int) int
 func printWrapperUsage(mode string) {
 	fmt.Println("Usage:")
 	fmt.Printf("  gait %s [--cwd .] [--timeout 30s] [--json] -- <child command...>\n", mode)
+	fmt.Println("  note: child command must emit trace_path=<path>; wrappers do not auto-instrument arbitrary runtimes")
 }

--- a/core/gate/policy.go
+++ b/core/gate/policy.go
@@ -242,6 +242,14 @@ func LoadPolicyFile(path string) (Policy, error) {
 }
 
 func ParsePolicyYAML(data []byte) (Policy, error) {
+	legacyFields, err := detectLegacyPolicyFieldMigrations(data)
+	if err != nil {
+		return Policy{}, fmt.Errorf("parse policy yaml: %w", err)
+	}
+	if len(legacyFields) > 0 {
+		return Policy{}, fmt.Errorf("parse policy yaml: %w", LegacyPolicyContractError{Fields: legacyFields})
+	}
+
 	var policy Policy
 	if err := yaml.UnmarshalWithOptions(data, &policy, yaml.Strict(), yaml.DisallowUnknownField()); err != nil {
 		formatted := strings.TrimSpace(yaml.FormatError(err, false, false))

--- a/core/gate/policy_migration.go
+++ b/core/gate/policy_migration.go
@@ -1,0 +1,153 @@
+package gate
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/goccy/go-yaml"
+)
+
+type LegacyPolicyFieldMigration struct {
+	Field             string   `json:"field"`
+	ReplacementFields []string `json:"replacement_fields,omitempty"`
+	Note              string   `json:"note,omitempty"`
+}
+
+type LegacyPolicyContractError struct {
+	Fields []LegacyPolicyFieldMigration
+}
+
+func (err LegacyPolicyContractError) Error() string {
+	if len(err.Fields) == 0 {
+		return "legacy policy proposal fields are not supported"
+	}
+	fieldNames := make([]string, 0, len(err.Fields))
+	details := make([]string, 0, len(err.Fields))
+	for _, field := range err.Fields {
+		fieldNames = append(fieldNames, field.Field)
+		if len(field.ReplacementFields) == 0 {
+			if strings.TrimSpace(field.Note) == "" {
+				details = append(details, field.Field+"->remove")
+				continue
+			}
+			details = append(details, fmt.Sprintf("%s->%s", field.Field, field.Note))
+			continue
+		}
+		detail := fmt.Sprintf("%s->%s", field.Field, strings.Join(field.ReplacementFields, "|"))
+		if strings.TrimSpace(field.Note) != "" {
+			detail += " (" + field.Note + ")"
+		}
+		details = append(details, detail)
+	}
+	return fmt.Sprintf(
+		"legacy policy proposal fields are not supported [%s]: %s",
+		strings.Join(fieldNames, ", "),
+		strings.Join(details, "; "),
+	)
+}
+
+var legacyPolicyFieldOrder = []string{
+	"version",
+	"name",
+	"boundaries",
+	"defaults",
+	"trust_sources",
+	"unknown_server",
+}
+
+var legacyPolicyFieldDetails = map[string]LegacyPolicyFieldMigration{
+	"version": {
+		Field:             "version",
+		ReplacementFields: []string{"schema_id", "schema_version"},
+		Note:              "set schema_id=gait.gate.policy and schema_version=1.0.0",
+	},
+	"name": {
+		Field: "name",
+		Note:  "remove the top-level policy name; rule names remain under rules[].name when needed",
+	},
+	"boundaries": {
+		Field:             "boundaries",
+		ReplacementFields: []string{"rules", "mcp_trust"},
+	},
+	"defaults": {
+		Field:             "defaults",
+		ReplacementFields: []string{"default_verdict", "fail_closed"},
+	},
+	"trust_sources": {
+		Field:             "trust_sources",
+		ReplacementFields: []string{"mcp_trust.snapshot"},
+		Note:              "render external trust data to a local snapshot before evaluation",
+	},
+	"unknown_server": {
+		Field:             "unknown_server",
+		ReplacementFields: []string{"mcp_trust.action"},
+		Note:              "enforce unknown servers through local snapshot coverage and a fail-closed action",
+	},
+}
+
+func LegacyPolicyFieldMigrations(fieldNames []string) []LegacyPolicyFieldMigration {
+	seen := map[string]struct{}{}
+	for _, fieldName := range fieldNames {
+		trimmed := strings.TrimSpace(fieldName)
+		if trimmed == "" {
+			continue
+		}
+		if _, ok := legacyPolicyFieldDetails[trimmed]; !ok {
+			continue
+		}
+		seen[trimmed] = struct{}{}
+	}
+	if len(seen) == 0 {
+		return nil
+	}
+	details := make([]LegacyPolicyFieldMigration, 0, len(seen))
+	orderIndex := map[string]int{}
+	for idx, field := range legacyPolicyFieldOrder {
+		orderIndex[field] = idx
+	}
+	ordered := make([]string, 0, len(seen))
+	for field := range seen {
+		ordered = append(ordered, field)
+	}
+	sort.Slice(ordered, func(i, j int) bool {
+		left, leftOK := orderIndex[ordered[i]]
+		right, rightOK := orderIndex[ordered[j]]
+		switch {
+		case leftOK && rightOK:
+			return left < right
+		case leftOK:
+			return true
+		case rightOK:
+			return false
+		default:
+			return ordered[i] < ordered[j]
+		}
+	})
+	for _, field := range ordered {
+		details = append(details, legacyPolicyFieldDetails[field])
+	}
+	return details
+}
+
+func detectLegacyPolicyFieldMigrations(data []byte) ([]LegacyPolicyFieldMigration, error) {
+	var raw any
+	if err := yaml.Unmarshal(data, &raw); err != nil {
+		return nil, nil
+	}
+	root, ok := raw.(map[string]any)
+	if !ok {
+		return nil, nil
+	}
+	fieldNames := make([]string, 0, len(root))
+	for key := range root {
+		trimmed := strings.TrimSpace(key)
+		if _, exists := legacyPolicyFieldDetails[trimmed]; exists {
+			fieldNames = append(fieldNames, trimmed)
+		}
+	}
+	if len(fieldNames) == 0 {
+		return nil, nil
+	}
+	return LegacyPolicyFieldMigrations(fieldNames), nil
+}

--- a/core/gate/policy_test.go
+++ b/core/gate/policy_test.go
@@ -285,6 +285,30 @@ func TestParsePolicyYAMLRejectsUnknownFields(t *testing.T) {
 	}
 }
 
+func TestParsePolicyYAMLRejectsLegacyProposalFieldsWithMigrationDetails(t *testing.T) {
+	_, err := ParsePolicyYAML([]byte(strings.Join([]string{
+		"version: 1",
+		"defaults:",
+		"  action: block",
+		"trust_sources:",
+		"  - snyk",
+	}, "\n") + "\n"))
+	if err == nil {
+		t.Fatalf("expected parse failure for legacy proposal fields")
+	}
+	raw := err.Error()
+	for _, snippet := range []string{
+		"legacy policy proposal fields are not supported [version, defaults, trust_sources]",
+		"version->schema_id|schema_version",
+		"defaults->default_verdict|fail_closed",
+		"trust_sources->mcp_trust.snapshot",
+	} {
+		if !strings.Contains(raw, snippet) {
+			t.Fatalf("expected %q in error, got %q", snippet, raw)
+		}
+	}
+}
+
 func TestEvaluatePolicyRuleMatchDeterministic(t *testing.T) {
 	policy, err := ParsePolicyYAML([]byte(`
 default_verdict: allow

--- a/docs-site/public/llm/contracts.md
+++ b/docs-site/public/llm/contracts.md
@@ -8,10 +8,14 @@ Stable OSS contracts include:
 - **Primitive Contract**: Four deterministic primitives — capture, enforce, regress, diagnose.
 - **CLI Meta Contract**: `gait --help` is text-only and exits `0`; machine-readable version discovery uses `gait version --json` or the `--version` / `-v` aliases.
 - **Python SDK Demo Contract**: machine-readable SDK/demo capture consumes `gait demo --json` output only; the human text form is non-contractual.
-- **Repo Policy Contract**: `gait init` writes `.gait.yaml`; `gait check` reports the live contract (`default_verdict`, `rule_count`, `gap_warnings`).
+- **Repo Policy Contract**: `gait init` writes `.gait.yaml` and returns `detected_signals`, `generated_rules`, and `unknown_signals`; `gait check` reports the live contract with `default_verdict`, `rule_count`, structured `findings`, compatibility `gap_warnings`, and `next_commands`.
+- **Draft Proposal Migration Contract**: keep the shipped policy DSL (`schema_id`, `schema_version`, `default_verdict`, optional `fail_closed`, optional `mcp_trust`, `rules`); proposal keys like `version`, `name`, `boundaries`, `defaults`, `trust_sources`, and `unknown_server` return deterministic migration guidance instead of enabling a second DSL.
+- **CLI Migration Contract**: use `gait mcp verify` rather than `gait mcp-verify`, and `gait capture --out ...` rather than `gait capture --save-as ...`.
 - **Equal-Priority Policy Semantics**: when multiple rules at the same priority match one intent, Gait evaluates that priority tier and applies the most restrictive verdict rather than depending on rule names.
 - **MCP Trust + Trace Onboarding**: local MCP trust snapshots and observe-only `gait trace` are additive onboarding contracts over the same signed trace and policy surfaces.
   - `mcp_trust.snapshot` must point at a local file; scanners and registries remain complementary inputs.
+  - `gait mcp verify --json` reports `trust_model=local_snapshot` and `snapshot_path` when MCP trust is configured.
+  - wrapper JSON reports `boundary_contract=explicit_trace_reference`, `trace_reference_required=true`, and stable `failure_reason` values such as `missing_trace_reference` and `invalid_trace_artifact`.
 - **Script Governance Contract**: Script intent steps, deterministic `script_hash`, Wrkr-derived context matching fields, and signed approved-script registry entries.
 - **Intent+Receipt Spec**: Structured tool-call intent with deterministic receipt generation.
 - **Endpoint Action Model**: Maps tool-call intent to policy-evaluated action outcomes.

--- a/docs-site/public/llm/faq.md
+++ b/docs-site/public/llm/faq.md
@@ -8,6 +8,8 @@ Gait enforces fail-closed policy before agent tool side effects execute and keep
 
 Run `gait version --json`, `gait init --json`, `gait check --json`, `gait demo` for the operator path, `gait demo --json` for wrappers/SDKs, then `gait verify run_demo --json` and `gait regress bootstrap --from run_demo --json --junit ./gait-out/junit.xml`.
 
+`gait init --json` returns `detected_signals`, conservative `generated_rules`, and `unknown_signals`. `gait check --json` reports structured `findings` and `next_commands` in addition to compatibility `gap_warnings`.
+
 ## What problem does Gait solve for long-running agent work?
 
 Multi-step and multi-hour agent jobs fail mid-flight, losing state and provenance. Gait dispatches durable jobs with checkpointed state, pause/resume/stop/cancel, and deterministic stop reasons so work survives failures and stays auditable.
@@ -49,6 +51,18 @@ Yes. `gait run replay` uses recorded results as deterministic stubs so you can d
 ## How does Gait integrate with agent frameworks?
 
 Gait provides wrapper or sidecar, Python SDK, and MCP boundary modes. The official LangChain surface is middleware with optional callback correlation; enforcement still happens only at the tool boundary. Claude Code remains a reference adapter, and its hook/runtime/input errors fail closed by default unless an operator explicitly opts into unsafe fail-open behavior.
+
+Official lanes today are OpenAI Agents and LangChain. Reference adapters stay in-repo, but they are not promoted into official launch claims until they clear the scorecard threshold. CrewAI is not an official lane today.
+
+If you use `gait test`, `gait enforce`, or `gait trace`, the child integration must emit a `trace_path=<path>` seam. Wrapper JSON makes that explicit with `boundary_contract=explicit_trace_reference`, `trace_reference_required=true`, and stable `failure_reason` values such as `missing_trace_reference` or `invalid_trace_artifact`.
+
+`gait mcp verify` is also local-snapshot-based: `mcp_trust.snapshot` points to a local file, and `gait mcp verify --json` reports `trust_model=local_snapshot` and `snapshot_path` rather than performing a hosted registry lookup.
+
+## Why not just use LangSmith, Langfuse, or AgentOps?
+
+Those tools are useful for hosted tracing and analytics. Gait solves a different problem: it gates execution before tool side effects happen and emits signed evidence that can be reused in CI, incident review, and audit trails.
+
+The practical model is camera plus gate, not camera or gate.
 
 ## Can Gait pre-approve known multi-step scripts?
 

--- a/docs-site/public/llm/product.md
+++ b/docs-site/public/llm/product.md
@@ -2,6 +2,8 @@
 
 Gait is the offline-first policy-as-code runtime for AI agent tool calls. It bootstraps repo policy with `gait init` and `gait check`, enforces fail-closed verdicts at the tool boundary, captures signed evidence, and turns incidents into deterministic CI regressions.
 
+Repo bootstrap stays machine-readable: `gait init --json` returns repo `detected_signals`, conservative `generated_rules`, and `unknown_signals`, while `gait check --json` reports structured `findings` plus `next_commands` for readiness follow-up.
+
 It provides seven OSS primitives:
 
 1. **Gate**: Evaluate structured tool-call intent against YAML policy with fail-closed enforcement. Supports destructive plan/apply boundaries, destructive budgets, multi-step script rollups, Wrkr context enrichment, and signed approved-script fast-path allow.
@@ -18,6 +20,13 @@ Secondary boundary surfaces:
 - **Trace**: observe-only wrapper mode with `gait trace` for integrations that already emit Gait trace references.
 - **LangChain Middleware**: official Python middleware with optional callback correlation; callbacks never decide allow or block behavior, and demo capture stays bound to `gait demo --json`.
 - **Reference Adapters**: `examples/integrations/claude_code/` remains a reference lane; its hook/runtime/input errors fail closed by default and `GAIT_CLAUDE_UNSAFE_FAIL_OPEN=1` is an unsafe opt-in override.
+
+Official framework lanes today:
+
+- OpenAI Agents
+- LangChain middleware
+
+Reference adapters stay in-repo but outside official-lane claims until they clear the promotion scorecard. CrewAI is not an official lane today.
 
 Gait is vendor-neutral and offline-first for core workflows: capture, verify, diff, policy evaluation, regressions, and voice/context verification all run without network dependencies.
 
@@ -40,6 +49,12 @@ When not to use:
 - no Gait CLI/artifact path is available in the runtime
 - workflow has no tool-side effects and no evidence requirements
 - you only want a hosted observability dashboard without offline verification or deterministic replay
+
+Observability comparison:
+
+- LangSmith, Langfuse, and AgentOps focus on hosted tracing and analytics.
+- Gait is the execution-boundary gate that decides whether the tool action may run and emits signed evidence for CI and audit reuse.
+- The model is camera plus gate, not camera or gate.
 
 Canonical docs:
 

--- a/docs-site/public/llm/quickstart.md
+++ b/docs-site/public/llm/quickstart.md
@@ -29,8 +29,8 @@ gait regress bootstrap --from run_demo --json --junit ./gait-out/junit.xml
 Expected bootstrap shape:
 
 ```json
-{"ok":true,"policy_path":".gait.yaml","template":"baseline-highrisk"}
-{"ok":true,"policy_path":".gait.yaml","default_verdict":"block","rule_count":7}
+{"ok":true,"policy_path":".gait.yaml","template":"baseline-highrisk","detected_signals":[{"code":"framework.langchain","category":"framework","value":"langchain","confidence":"high"}],"generated_rules":[{"id":"starter.block.destructive","name":"block-destructive-tools","effect":"block"}]}
+{"ok":true,"policy_path":".gait.yaml","default_verdict":"block","rule_count":7,"findings":[{"code":"repo.generated_rules_available","severity":"info","detected_surface":"repo.signals"}]}
 ```
 
 Expected demo shape:

--- a/docs-site/public/llms.txt
+++ b/docs-site/public/llms.txt
@@ -41,6 +41,8 @@
 - Context-required policies must receive `--context-envelope <context_envelope.json>` at that boundary; raw context digest/mode/age claims are not authoritative alone.
 - For `gait mcp serve`, same-host callers may use `call.context.context_envelope_path` only when the server explicitly enables `--allow-client-artifact-paths`.
 - Official LangChain lane: middleware with optional callback correlation, not a separate policy engine.
+- Official framework lanes today: OpenAI Agents and LangChain middleware.
+- Reference adapters stay in-repo but outside official-lane claims until they clear the promotion scorecard threshold. CrewAI is not an official lane today.
 
 ## When To Use
 - You need enforceable policy decisions before agent tool side effects.
@@ -60,11 +62,17 @@
 - `examples/integrations/claude_code/` is a reference adapter; hook/runtime/input errors fail closed by default and `GAIT_CLAUDE_UNSAFE_FAIL_OPEN=1` is an unsafe opt-in override.
 - High-risk enforcement is not production-ready until `gait doctor --production-readiness --json` returns `ok=true`, typically from config seeded by `examples/config/oss_prod_template.yaml` from a repo checkout or by fetching that same file after a binary-only install.
 - `gait init` writes `.gait.yaml`; `gait check` reports the live policy contract and gap warnings.
+- Repo bootstrap JSON: `gait init --json` returns `detected_signals`, conservative `generated_rules`, and `unknown_signals`; `gait check --json` returns structured `findings`, compatibility `gap_warnings`, and `next_commands`.
+- Draft proposal migration: use `schema_id`, `schema_version`, `default_verdict`, optional `fail_closed`, optional `mcp_trust`, and `rules`, not `version`, `name`, `boundaries`, `defaults`, `trust_sources`, or `unknown_server`.
+- CLI migration: use `gait mcp verify`, not `gait mcp-verify`, and `gait capture --out ...`, not `gait capture --save-as ...`.
+- Wrapper JSON contract: `gait test`, `gait enforce`, and `gait trace` require `trace_path=<path>` from the child integration and expose `boundary_contract=explicit_trace_reference`, `trace_reference_required=true`, and stable `failure_reason` values for missing or invalid seams.
+- MCP trust JSON contract: `gait mcp verify --json` reports `trust_model=local_snapshot` and `snapshot_path`; trust evaluation stays offline-first and file-based.
 - Offline verification for packs, runpacks, and traces.
 - Structured intent model for policy decisions, not free-form prompt filtering.
 - SayToken capability tokens for voice agent commitment gating.
 - Context evidence envelopes with fail-closed enforcement when evidence is missing, stale, or not supplied through a verified `--context-envelope` gate input.
 - MCP trust stays file-based and offline-first: external tool finds, Gait enforces.
+- Observability comparison: LangSmith, Langfuse, and AgentOps are complementary hosted tracing/analytics products; Gait is the execution-boundary gate.
 
 ## Canonical Docs
 - /docs/policy_authoring/

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,7 +21,7 @@ Extended first-class surfaces:
 
 1. `README.md` for the product wedge and first five commands
 2. `docs/policy_authoring.md` for `.gait.yaml`, validation, and rollout workflow
-3. `docs/integration_checklist.md` for shipped wrapper, MCP, and SDK lanes
+3. `docs/integration_checklist.md` for official OpenAI Agents and LangChain lanes plus the reference-adapter promotion rules
 4. `docs/agent_integration_boundary.md` for tool-boundary placement rules
 5. `docs/ci_regress_kit.md` for incident-to-CI adoption
 

--- a/docs/agent_integration_boundary.md
+++ b/docs/agent_integration_boundary.md
@@ -63,6 +63,7 @@ Constraints:
 - normalization quality depends on payload completeness at boundary
 - enforcement reliability depends on strict middleware placement
 - `gait test` and `gait enforce` do not auto-instrument arbitrary runtimes; they require emitted Gait trace references from the child integration
+- wrapper JSON now makes that boundary explicit with `boundary_contract=explicit_trace_reference`, `trace_reference_required=true`, and stable `failure_reason` values such as `missing_trace_reference` or `invalid_trace_artifact`
 
 ## Tier C: Managed/Preloaded Agent Products (Limited Interception)
 

--- a/docs/contracts/primitive_contract.md
+++ b/docs/contracts/primitive_contract.md
@@ -28,6 +28,12 @@ These file locations and command roles are part of the public OSS onboarding con
 - `gait trace`: observe-only wrapper for integrations that already emit Gait trace references
 - `gait trace verify`: shipped trace verification command
 
+Canonical migration notes:
+
+- Policy DSL stays on the shipped repo-root contract: `schema_id`, `schema_version`, `default_verdict`, optional `fail_closed`, optional `mcp_trust`, and `rules`.
+- Draft proposal keys such as `version`, `name`, `boundaries`, `defaults`, `trust_sources`, and `unknown_server` are not alternate supported syntax; they return deterministic migration guidance instead.
+- The canonical CLI surface is `gait mcp verify` and `gait capture --out ...`; draft proposal spellings such as `gait mcp-verify` and `gait capture --save-as ...` are not separate commands.
+
 Intent + receipt continuity conformance profile:
 
 - `docs/contracts/intent_receipt_conformance.md`

--- a/docs/external_tool_registry_policy.md
+++ b/docs/external_tool_registry_policy.md
@@ -19,6 +19,8 @@ Use this when an external source such as Snyk or an internal registry produces t
 3. Preflight with `gait mcp verify`.
 4. Enforce the same trust policy through `gait mcp proxy` or `gait mcp serve`.
 
+`gait mcp verify --json` reports that contract explicitly with `trust_model=local_snapshot` and `snapshot_path=<local file>`. The evaluator does not fetch hosted registry data at decision time.
+
 Example policy contract:
 
 ```yaml

--- a/docs/integration_checklist.md
+++ b/docs/integration_checklist.md
@@ -67,6 +67,7 @@ Reference: `docs/agent_integration_boundary.md`.
 ## Boundary Touchpoints To Wire
 
 - Wrapper or sidecar: call `gait gate eval` immediately before the real tool side effect.
+- If you use `gait test`, `gait enforce`, or `gait trace`, the child integration must emit `trace_path=<path>`; wrapper JSON exposes `boundary_contract=explicit_trace_reference` and stable `failure_reason` values when that seam is missing or invalid.
 - Context-required policies: pass `--context-envelope <context_envelope.json>` from the local capture boundary; on `gait mcp serve`, either pin that envelope at server startup or explicitly enable same-host request paths before accepting `call.context.context_envelope_path`. Raw intent context fields are not authoritative by themselves.
 - SDK or CI automation: use `gait demo --json` for machine-readable smoke checks and handoff metadata.
 - CI regression loop: persist the trace or runpack from that same boundary, then wire `gait regress bootstrap --from ... --json --junit ...`.
@@ -92,6 +93,7 @@ Run these first. Stop if expected output is missing.
 5. Wrapper non-allow path:
 - run wrapper block or approval scenario
 - expect `executed=false`
+- if `gait test` / `gait enforce` / `gait trace` are used around that quickstart, expect `boundary_contract=explicit_trace_reference` and a stable `failure_reason` when no trace seam is present
 6. Explicit capture path:
 - `gait capture --from run_demo --json`
 - `gait regress add --from ./gait-out/capture.json --json`

--- a/docs/launch/faq_objections.md
+++ b/docs/launch/faq_objections.md
@@ -14,6 +14,13 @@ Prompt text can be hostile; execution decisions must be structured and determini
 
 For MCP trust, the same rule applies: external scanners or registries produce local evidence, and Gait evaluates that local evidence at the boundary. Gait is not replacing the scanner.
 
+## "Why not just use LangSmith, Langfuse, or AgentOps?"
+
+Those products are valuable for hosted tracing, analytics, and after-the-fact debugging.
+Gait solves a different problem: it decides whether a tool action may execute before side effects happen, then emits signed evidence that can also flow into CI and operational review.
+
+The practical model is camera plus gate, not camera or gate.
+
 ## "Will this add too much latency?"
 
 Runtime budgets are measured and enforced (`make bench-budgets`).

--- a/docs/mcp_capability_matrix.md
+++ b/docs/mcp_capability_matrix.md
@@ -42,6 +42,7 @@ if verdict != allow: do not execute side effects
 - Bound payload size (`--max-request-bytes`) and retention (`--trace-max-*`, `--runpack-max-*`, `--session-max-*`).
 - MCP trust remains offline-first: `mcp_trust.snapshot` points to a local trust snapshot file, and high-risk trust failures fail closed.
 - Trust inputs stay complementary to scanners and registries. Scanner finds; Gait enforces.
+- `gait mcp verify --json` makes the trust model explicit with `trust_model=local_snapshot` and `snapshot_path=<policy snapshot path>` when MCP trust is configured.
 
 ## What MCP Modes Do Not Replace
 
@@ -62,7 +63,7 @@ MCP modes do not replace operator/CI workflows such as:
 
 ### What is gait mcp verify?
 
-One-shot trust preflight for a single MCP server description. Use it to validate a local trust snapshot before wiring the server into `proxy` or `serve`.
+One-shot trust preflight for a single MCP server description. Use it to validate a local trust snapshot before wiring the server into `proxy` or `serve`. It does not call a hosted registry at evaluation time.
 
 ### What is gait mcp proxy?
 

--- a/docs/policy_authoring.md
+++ b/docs/policy_authoring.md
@@ -49,6 +49,19 @@ If you need one rule to win unconditionally, give it a strictly lower numeric `p
 - For context-required policies, runtime enforcement now requires a verified `--context-envelope` on `gait gate eval`; raw intent context claims are not enough to satisfy `require_context_evidence`, `required_context_evidence_mode`, or `max_context_age_seconds`.
 - If a policy review depends on a same-priority rule "winning" by name, change the numeric `priority` instead. Equal-priority names are no longer part of the verdict contract.
 
+## Draft Proposal Migration
+
+If an older draft or pasted spec still uses the proposal keys below, keep the repo-root `.gait.yaml` contract and migrate to the shipped fields instead:
+
+- `version` -> `schema_id` plus `schema_version`
+- `name` -> remove the top-level field; use `rules[].name` only where rule naming matters
+- `boundaries` -> `rules` and optional `mcp_trust`
+- `defaults` -> `default_verdict` and optional `fail_closed`
+- `trust_sources` -> `mcp_trust.snapshot` after rendering a local trust snapshot file
+- `unknown_server` -> `mcp_trust.action` with local snapshot coverage and fail-closed policy
+
+`gait policy validate .gait.yaml --json` now returns deterministic migration guidance when those draft proposal fields are present, rather than silently accepting a second policy DSL.
+
 ## Repo-Root Policy Contract
 
 The default onboarding contract is the repo-root file `.gait.yaml`.
@@ -57,13 +70,18 @@ The default onboarding contract is the repo-root file `.gait.yaml`.
 
 - `policy_path`
 - `template`
+- `detected_signals`
+- `generated_rules`
+- `unknown_signals`
 - `next_commands`
 
 `gait check --json` reads `.gait.yaml` and reports the live contract, including:
 
 - `default_verdict`
 - `rule_count`
+- `findings`
 - `gap_warnings`
+- `next_commands`
 
 Use `gait policy init --out gait.policy.yaml --json` only when you intentionally want a non-default path.
 

--- a/docs/positioning.md
+++ b/docs/positioning.md
@@ -59,6 +59,7 @@ OSS vs Enterprise framing:
 - "Gait integrates with your existing identity, vault, gateway, and SIEM stack."
 - "Guardrails scan content. Gait evaluates structured action intent and enforces policy before execution."
 - "Gait produces the evidence your monitoring stack consumes."
+- "LangSmith, Langfuse, and AgentOps are complementary observability layers; Gait is the execution-boundary gate."
 
 ## Adapter Neutrality Language
 

--- a/examples/integrations/README.md
+++ b/examples/integrations/README.md
@@ -7,6 +7,13 @@ Official lanes:
 - `openai_agents`
 - `langchain` (official middleware with optional callback correlation)
 
+Quick commands:
+
+```bash
+python3 examples/integrations/openai_agents/quickstart.py --scenario allow
+(cd sdk/python && uv run --python 3.13 --extra langchain python ../../examples/integrations/langchain/quickstart.py --scenario allow)
+```
+
 Reference adapters:
 
 - `autogen`

--- a/examples/integrations/mcp_trust/README.md
+++ b/examples/integrations/mcp_trust/README.md
@@ -6,6 +6,7 @@ This example shows the bounded MCP trust path:
 - a deterministic trust snapshot is rendered from that file
 - `gait mcp verify` and `gait mcp proxy` consume the local snapshot
 - Gait enforces; the scanner or registry remains the evidence source
+- `gait mcp verify --json` reports `trust_model=local_snapshot` and the configured `snapshot_path`
 
 ## Files
 


### PR DESCRIPTION
## Problem
- onboarding and wrapper surfaces were still leaving a few public-contract expectations implicit
- legacy command and flag migrations were hard to discover from machine-readable errors
- repo-aware starter guidance for `gait init` and `gait check` needed clearer structured output and docs parity

## Changes
- add migration metadata and guidance for legacy commands, flags, and legacy policy proposal fields
- expand `gait init`, `gait check`, `gait mcp verify`, and wrapper outputs with explicit contract details and starter-rule signals
- refresh tests and docs to cover the updated onboarding, MCP trust, wrapper boundary, and policy authoring contracts

## Validation
- `go run ./cmd/gait doctor --json`
- `make prepush-full`
- `git push -u origin codex/adhoc-public-contract-onboarding`
