### PR TITLE
gate: harden fail-closed delegation boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ Integration touchpoints:
 
 - Wrapper or sidecar: call `gait gate eval` at the exact tool-dispatch site before side effects execute.
 - Context-required policies: pass `--context-envelope <context_envelope.json>` at that boundary on `gait gate eval`, `gait mcp proxy`, or `gait mcp serve`; raw `intent.context_set_digest`, `intent.context_evidence_mode`, or `context.auth_context.context_age_seconds` claims are treated as non-authoritative until the envelope is verified.
+- Delegated execution: pass signed delegation token evidence to `gait gate eval`; multi-hop delegation only authorizes when each claimed hop is backed by a signed token for that hop, and policy-required delegation scope must be satisfied by the token's signed `scope` or `scope_class`.
 - MCP serve nuance: if the server starts with `--allow-client-artifact-paths`, same-host callers may provide `call.context.context_envelope_path`; otherwise keep context proof fixed at the serve boundary with `--context-envelope`.
 - SDKs and automation: use `gait demo --json` for smoke checks and handoffs; the text form is human-facing only.
 - Policy authors: when same-priority rules overlap, Gait applies the most restrictive verdict for that priority tier. Use a strictly lower numeric `priority` when one rule must win.
@@ -206,6 +207,7 @@ See [`docs/scenarios/simple_agent_tool_boundary.md`](docs/scenarios/simple_agent
 ## What Ships In OSS
 
 **Gate** — evaluate structured tool-call intent against YAML policy with fail-closed enforcement. Non-allow means non-execute. When multiple rules at the same priority match, Gait resolves that priority tier to the most restrictive verdict instead of depending on rule names.
+Approved-script fast-path allow only applies to verified registry entries; missing verification prerequisites disable the fast path in standard low-risk mode and fail closed in high-risk paths.
 
 **Evidence** — signed traces, runpacks, packs, and callpacks you can verify, diff, and attach to tickets, PRs, audits, and incidents.
 
@@ -244,6 +246,7 @@ gait regress bootstrap --from run_demo --json --junit ./gait-out/junit.xml
 Put this copy at the bottom of launch surfaces: Gait produces signed evidence artifacts for operational proof.
 
 - `gait verify`, `gait pack verify`, and `gait trace verify` work offline.
+- If you provide a verify key and signature validation fails, `gait pack verify` returns verification failure instead of a soft success.
 - Packs use Ed25519 signatures plus SHA-256 manifests.
 - Artifacts are versioned, deterministic, and designed for change control, audit trails, PRs, and incident handoff.
 

--- a/cmd/gait/approved_script_test.go
+++ b/cmd/gait/approved_script_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -11,6 +12,7 @@ import (
 	"github.com/Clyra-AI/gait/core/contextproof"
 	schemacontext "github.com/Clyra-AI/gait/core/schema/v1/context"
 	schemagate "github.com/Clyra-AI/gait/core/schema/v1/gate"
+	sign "github.com/Clyra-AI/proof/signing"
 )
 
 func TestApproveScriptAndListScripts(t *testing.T) {
@@ -72,6 +74,7 @@ func TestGateEvalApprovedScriptFastPath(t *testing.T) {
 	intentPath := filepath.Join(workDir, "script_intent.json")
 	registryPath := filepath.Join(workDir, "approved_scripts.json")
 	privateKeyPath := filepath.Join(workDir, "approved_script_private.key")
+	publicKeyPath := filepath.Join(workDir, "approved_script_public.key")
 	tracePath := filepath.Join(workDir, "trace.json")
 
 	mustWriteFile(t, policyPath, `
@@ -83,7 +86,7 @@ rules:
       tool_names: [tool.write]
 `)
 	mustWriteScriptIntentFixture(t, intentPath)
-	writePrivateKey(t, privateKeyPath)
+	writeApprovedScriptKeyPair(t, privateKeyPath, publicKeyPath)
 
 	if code := runGateEval([]string{
 		"--policy", policyPath,
@@ -111,6 +114,7 @@ rules:
 			"--policy", policyPath,
 			"--intent", intentPath,
 			"--approved-script-registry", registryPath,
+			"--approved-script-public-key", publicKeyPath,
 			"--trace-out", tracePath,
 			"--json",
 		}); code != exitOK {
@@ -134,6 +138,7 @@ func TestGateEvalApprovedScriptFastPathDisabledForContextPolicies(t *testing.T) 
 	intentPath := filepath.Join(workDir, "script_intent.json")
 	registryPath := filepath.Join(workDir, "approved_scripts.json")
 	privateKeyPath := filepath.Join(workDir, "approved_script_private.key")
+	publicKeyPath := filepath.Join(workDir, "approved_script_public.key")
 	envelopePath := filepath.Join(workDir, "context_envelope.json")
 
 	mustWriteFile(t, policyPath, `
@@ -147,7 +152,7 @@ rules:
       tool_names: [tool.write]
 `)
 	mustWriteScriptIntentFixture(t, intentPath)
-	writePrivateKey(t, privateKeyPath)
+	writeApprovedScriptKeyPair(t, privateKeyPath, publicKeyPath)
 
 	envelope, err := contextproof.BuildEnvelope([]schemacontext.ReferenceRecord{
 		{
@@ -192,6 +197,7 @@ rules:
 			"--policy", policyPath,
 			"--intent", intentPath,
 			"--approved-script-registry", registryPath,
+			"--approved-script-public-key", publicKeyPath,
 			"--json",
 		}); code != exitPolicyBlocked {
 			t.Fatalf("runGateEval without context envelope expected %d got %d", exitPolicyBlocked, code)
@@ -210,6 +216,7 @@ rules:
 			"--policy", policyPath,
 			"--intent", intentPath,
 			"--approved-script-registry", registryPath,
+			"--approved-script-public-key", publicKeyPath,
 			"--context-envelope", envelopePath,
 			"--json",
 		}); code != exitOK {
@@ -236,6 +243,7 @@ func TestGateEvalApprovedScriptBypassesBlockingRule(t *testing.T) {
 	intentPath := filepath.Join(workDir, "script_intent.json")
 	registryPath := filepath.Join(workDir, "approved_scripts.json")
 	privateKeyPath := filepath.Join(workDir, "approved_script_private.key")
+	publicKeyPath := filepath.Join(workDir, "approved_script_public.key")
 
 	mustWriteFile(t, policyPath, `
 default_verdict: allow
@@ -247,7 +255,7 @@ rules:
       tool_names: [tool.write]
 `)
 	mustWriteScriptIntentFixture(t, intentPath)
-	writePrivateKey(t, privateKeyPath)
+	writeApprovedScriptKeyPair(t, privateKeyPath, publicKeyPath)
 
 	if code := runGateEval([]string{
 		"--policy", policyPath,
@@ -274,6 +282,7 @@ rules:
 			"--policy", policyPath,
 			"--intent", intentPath,
 			"--approved-script-registry", registryPath,
+			"--approved-script-public-key", publicKeyPath,
 			"--json",
 		}); code != exitOK {
 			t.Fatalf("runGateEval with registry expected %d got %d", exitOK, code)
@@ -288,6 +297,116 @@ rules:
 	}
 	if len(evalOut.ReasonCodes) != 1 || evalOut.ReasonCodes[0] != "approved_script_match" {
 		t.Fatalf("expected fast-path reason only, got %#v", evalOut.ReasonCodes)
+	}
+}
+
+func TestGateEvalApprovedScriptRegistryMissingVerifyKeyFailsClosedForHighRisk(t *testing.T) {
+	workDir := t.TempDir()
+	withWorkingDir(t, workDir)
+
+	policyPath := filepath.Join(workDir, "policy_require_approval.yaml")
+	intentPath := filepath.Join(workDir, "script_intent.json")
+	registryPath := filepath.Join(workDir, "approved_scripts.json")
+	privateKeyPath := filepath.Join(workDir, "approved_script_private.key")
+	publicKeyPath := filepath.Join(workDir, "approved_script_public.key")
+
+	mustWriteFile(t, policyPath, `
+default_verdict: allow
+rules:
+  - name: require-approval-write
+    effect: require_approval
+    match:
+      tool_names: [tool.write]
+`)
+	mustWriteScriptIntentFixture(t, intentPath)
+	writeApprovedScriptKeyPair(t, privateKeyPath, publicKeyPath)
+
+	if code := runApproveScript([]string{
+		"--policy", policyPath,
+		"--intent", intentPath,
+		"--registry", registryPath,
+		"--approver", "secops",
+		"--key-mode", "prod",
+		"--private-key", privateKeyPath,
+		"--json",
+	}); code != exitOK {
+		t.Fatalf("runApproveScript expected %d got %d", exitOK, code)
+	}
+
+	rawEval := captureStdout(t, func() {
+		if code := runGateEval([]string{
+			"--policy", policyPath,
+			"--intent", intentPath,
+			"--approved-script-registry", registryPath,
+			"--json",
+		}); code != exitPolicyBlocked {
+			t.Fatalf("runGateEval missing approved-script verify key expected %d got %d", exitPolicyBlocked, code)
+		}
+	})
+	var evalOut gateEvalOutput
+	if err := json.Unmarshal([]byte(rawEval), &evalOut); err != nil {
+		t.Fatalf("decode gate eval output: %v raw=%q", err, rawEval)
+	}
+	if evalOut.OK {
+		t.Fatalf("expected fail-closed output, got %#v", evalOut)
+	}
+	if !strings.Contains(evalOut.Error, "verify key required") {
+		t.Fatalf("expected verify key required error, got %#v", evalOut)
+	}
+}
+
+func TestGateEvalApprovedScriptRegistryMissingVerifyKeyDisablesFastPathForLowRisk(t *testing.T) {
+	workDir := t.TempDir()
+	withWorkingDir(t, workDir)
+
+	policyPath := filepath.Join(workDir, "policy_require_approval.yaml")
+	intentPath := filepath.Join(workDir, "script_intent_low_risk.json")
+	registryPath := filepath.Join(workDir, "approved_scripts.json")
+	privateKeyPath := filepath.Join(workDir, "approved_script_private.key")
+	publicKeyPath := filepath.Join(workDir, "approved_script_public.key")
+
+	mustWriteFile(t, policyPath, `
+default_verdict: allow
+rules:
+  - name: require-approval-write
+    effect: require_approval
+    match:
+      tool_names: [tool.write]
+`)
+	mustWriteLowRiskScriptIntentFixture(t, intentPath)
+	writeApprovedScriptKeyPair(t, privateKeyPath, publicKeyPath)
+
+	if code := runApproveScript([]string{
+		"--policy", policyPath,
+		"--intent", intentPath,
+		"--registry", registryPath,
+		"--approver", "secops",
+		"--key-mode", "prod",
+		"--private-key", privateKeyPath,
+		"--json",
+	}); code != exitOK {
+		t.Fatalf("runApproveScript expected %d got %d", exitOK, code)
+	}
+
+	rawEval := captureStdout(t, func() {
+		if code := runGateEval([]string{
+			"--policy", policyPath,
+			"--intent", intentPath,
+			"--approved-script-registry", registryPath,
+			"--json",
+		}); code != exitApprovalRequired {
+			t.Fatalf("runGateEval missing approved-script verify key expected %d got %d", exitApprovalRequired, code)
+		}
+	})
+	var evalOut gateEvalOutput
+	if err := json.Unmarshal([]byte(rawEval), &evalOut); err != nil {
+		t.Fatalf("decode gate eval output: %v raw=%q", err, rawEval)
+	}
+	if evalOut.PreApproved || evalOut.Verdict != "require_approval" {
+		t.Fatalf("expected fast-path disabled output, got %#v", evalOut)
+	}
+	if !containsString(evalOut.Warnings, "approved script fast-path disabled because registry verify key is not configured") {
+		t.Fatalf("expected missing verify key warning, got %#v", evalOut.Warnings)
 	}
 }
 
@@ -402,7 +521,30 @@ func TestRunApproveAndListScriptsHelpAndValidation(t *testing.T) {
 
 func mustWriteScriptIntentFixture(t *testing.T, path string) {
 	t.Helper()
-	intent := schemagate.IntentRequest{
+	intent := scriptIntentFixture("high")
+	raw, err := json.MarshalIndent(intent, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal script intent: %v", err)
+	}
+	if err := os.WriteFile(path, append(raw, '\n'), 0o600); err != nil {
+		t.Fatalf("write script intent fixture: %v", err)
+	}
+}
+
+func mustWriteLowRiskScriptIntentFixture(t *testing.T, path string) {
+	t.Helper()
+	intent := scriptIntentFixture("low")
+	raw, err := json.MarshalIndent(intent, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal script intent: %v", err)
+	}
+	if err := os.WriteFile(path, append(raw, '\n'), 0o600); err != nil {
+		t.Fatalf("write script intent fixture: %v", err)
+	}
+}
+
+func scriptIntentFixture(riskClass string) schemagate.IntentRequest {
+	return schemagate.IntentRequest{
 		SchemaID:        "gait.gate.intent_request",
 		SchemaVersion:   "1.0.0",
 		CreatedAt:       time.Date(2026, time.February, 5, 0, 0, 0, 0, time.UTC),
@@ -413,7 +555,7 @@ func mustWriteScriptIntentFixture(t *testing.T, path string) {
 		Context: schemagate.IntentContext{
 			Identity:  "alice",
 			Workspace: "/repo/gait",
-			RiskClass: "high",
+			RiskClass: riskClass,
 		},
 		Script: &schemagate.IntentScript{
 			Steps: []schemagate.IntentScriptStep{
@@ -427,11 +569,18 @@ func mustWriteScriptIntentFixture(t *testing.T, path string) {
 			},
 		},
 	}
-	raw, err := json.MarshalIndent(intent, "", "  ")
+}
+
+func writeApprovedScriptKeyPair(t *testing.T, privatePath string, publicPath string) {
+	t.Helper()
+	keyPair, err := sign.GenerateKeyPair()
 	if err != nil {
-		t.Fatalf("marshal script intent: %v", err)
+		t.Fatalf("generate keypair: %v", err)
 	}
-	if err := os.WriteFile(path, append(raw, '\n'), 0o600); err != nil {
-		t.Fatalf("write script intent fixture: %v", err)
+	if err := os.WriteFile(privatePath, []byte(base64.StdEncoding.EncodeToString(keyPair.Private)+"\n"), 0o600); err != nil {
+		t.Fatalf("write private key: %v", err)
+	}
+	if err := os.WriteFile(publicPath, []byte(base64.StdEncoding.EncodeToString(keyPair.Public)+"\n"), 0o600); err != nil {
+		t.Fatalf("write public key: %v", err)
 	}
 }

--- a/cmd/gait/gate.go
+++ b/cmd/gait/gate.go
@@ -314,10 +314,11 @@ func runGateEval(arguments []string) int {
 	approvedRegistryConfigured := strings.TrimSpace(approvedScriptRegistryPath) != ""
 	approvedRegistryEntries := []schemagate.ApprovedScriptEntry{}
 	if approvedRegistryConfigured {
+		riskClass := strings.ToLower(strings.TrimSpace(intent.Context.RiskClass))
+		failClosedApprovedRegistry := resolvedProfile == gateProfileOSSProd || riskClass == "high" || riskClass == "critical"
 		entries, readErr := gate.ReadApprovedScriptRegistry(approvedScriptRegistryPath)
 		if readErr != nil {
-			riskClass := strings.ToLower(strings.TrimSpace(intent.Context.RiskClass))
-			if resolvedProfile == gateProfileOSSProd || riskClass == "high" || riskClass == "critical" {
+			if failClosedApprovedRegistry {
 				return writeGateEvalOutput(jsonOutput, gateEvalOutput{
 					OK:    false,
 					Error: "approved script registry unavailable in fail-closed mode: " + readErr.Error(),
@@ -337,13 +338,16 @@ func runGateEval(arguments []string) int {
 					PrivateKeyEnv:  approvalPrivateKeyEnv,
 				}
 			}
-			if resolvedProfile == gateProfileOSSProd && !hasAnyKeySource(approvedVerifyConfig) {
-				return writeGateEvalOutput(jsonOutput, gateEvalOutput{
-					OK:    false,
-					Error: "oss-prod profile requires approved-script verify key when --approved-script-registry is set",
-				}, exitInvalidInput)
-			}
-			if hasAnyKeySource(approvedVerifyConfig) {
+			if !hasAnyKeySource(approvedVerifyConfig) {
+				if failClosedApprovedRegistry {
+					return writeGateEvalOutput(jsonOutput, gateEvalOutput{
+						OK:    false,
+						Error: "approved script registry verification unavailable in fail-closed mode: verify key required",
+					}, exitPolicyBlocked)
+				}
+				startupWarnings = append(startupWarnings, "approved script fast-path disabled because registry verify key is not configured")
+				entries = []schemagate.ApprovedScriptEntry{}
+			} else {
 				verifyKey, verifyErr := sign.LoadVerifyKey(approvedVerifyConfig)
 				if verifyErr != nil {
 					return writeGateEvalOutput(jsonOutput, gateEvalOutput{OK: false, Error: verifyErr.Error()}, exitCodeForError(verifyErr, exitInvalidInput))
@@ -351,8 +355,7 @@ func runGateEval(arguments []string) int {
 				nowUTC := time.Now().UTC()
 				for index, entry := range entries {
 					if verifyErr := gate.VerifyApprovedScriptEntry(entry, verifyKey, nowUTC); verifyErr != nil {
-						riskClass := strings.ToLower(strings.TrimSpace(intent.Context.RiskClass))
-						if resolvedProfile == gateProfileOSSProd || riskClass == "high" || riskClass == "critical" {
+						if failClosedApprovedRegistry {
 							return writeGateEvalOutput(jsonOutput, gateEvalOutput{
 								OK:    false,
 								Error: fmt.Sprintf("approved script registry verification failed at entry %d: %v", index, verifyErr),
@@ -514,66 +517,39 @@ func runGateEval(arguments []string) int {
 			result.Violations = mergeUniqueSorted(result.Violations, []string{"delegation_not_granted"})
 			exitCode = exitPolicyBlocked
 		} else {
-			expectedDelegator := ""
-			expectedDelegate := ""
-			if preparedIntent.Delegation != nil {
-				expectedDelegate = preparedIntent.Delegation.RequesterIdentity
-				if len(preparedIntent.Delegation.Chain) > 0 {
-					last := preparedIntent.Delegation.Chain[len(preparedIntent.Delegation.Chain)-1]
-					expectedDelegator = last.DelegatorIdentity
-					if expectedDelegate == "" {
-						expectedDelegate = last.DelegateIdentity
-					}
-				}
-			}
-			validTokenRefs := make([]string, 0, len(delegationTokenPaths))
+			tokens := make([]schemagate.DelegationToken, 0, len(delegationTokenPaths))
 			for _, tokenPath := range delegationTokenPaths {
 				token, readErr := gate.ReadDelegationToken(tokenPath)
 				if readErr != nil {
 					return writeGateEvalOutput(jsonOutput, gateEvalOutput{OK: false, Error: readErr.Error()}, exitCodeForError(readErr, exitInvalidInput))
 				}
-				entry := schemagate.DelegationAuditEntry{
-					TokenID:           token.TokenID,
-					DelegatorIdentity: token.DelegatorIdentity,
-					DelegateIdentity:  token.DelegateIdentity,
-					Scope:             mergeUniqueSorted(nil, token.Scope),
-					ExpiresAt:         token.ExpiresAt.UTC(),
-					Valid:             false,
-				}
-				validateErr := gate.ValidateDelegationToken(token, verifyKey, gate.DelegationValidationOptions{
-					Now:                  time.Now().UTC(),
-					ExpectedDelegator:    expectedDelegator,
-					ExpectedDelegate:     expectedDelegate,
-					ExpectedIntentDigest: intentDigestForContext,
-					ExpectedPolicyDigest: policyDigestForContext,
-				})
-				if validateErr != nil {
-					reasonCode := gate.DelegationCodeSchemaInvalid
-					var tokenErr *gate.DelegationTokenError
-					if errors.As(validateErr, &tokenErr) && tokenErr.Code != "" {
-						reasonCode = tokenErr.Code
-					}
-					entry.ErrorCode = reasonCode
-					result.ReasonCodes = mergeUniqueSorted(result.ReasonCodes, []string{reasonCode})
-					delegationEntries = append(delegationEntries, entry)
-					continue
-				}
-				entry.Valid = true
-				delegationEntries = append(delegationEntries, entry)
-				validDelegations++
-				if token.TokenID != "" {
-					validTokenRefs = append(validTokenRefs, token.TokenID)
-				}
+				tokens = append(tokens, token)
 			}
-			if validDelegations == 0 {
+			validation, validateErr := gate.ValidateDelegationChain(preparedIntent.Delegation, tokens, verifyKey, gate.DelegationChainValidationOptions{
+				Now:                  time.Now().UTC(),
+				RequiredScope:        outcome.RequiredDelegationScopes,
+				ExpectedIntentDigest: intentDigestForContext,
+				ExpectedPolicyDigest: policyDigestForContext,
+			})
+			if validateErr != nil {
+				return writeGateEvalOutput(jsonOutput, gateEvalOutput{OK: false, Error: validateErr.Error()}, exitCodeForError(validateErr, exitInvalidInput))
+			}
+			delegationEntries = append(delegationEntries, validation.Entries...)
+			validDelegations = validation.ValidDelegations
+			if !validation.Complete {
+				for _, entry := range validation.Entries {
+					if !entry.Valid && strings.TrimSpace(entry.ErrorCode) != "" {
+						result.ReasonCodes = mergeUniqueSorted(result.ReasonCodes, []string{entry.ErrorCode})
+					}
+				}
 				result.Verdict = "block"
 				result.ReasonCodes = mergeUniqueSorted(result.ReasonCodes, []string{"delegation_chain_insufficient"})
 				result.Violations = mergeUniqueSorted(result.Violations, []string{"delegation_not_granted"})
 				exitCode = exitPolicyBlocked
 			} else {
 				result.ReasonCodes = mergeUniqueSorted(result.ReasonCodes, []string{"delegation_granted"})
-				if len(validTokenRefs) > 0 {
-					resolvedDelegationRef = strings.Join(mergeUniqueSorted(nil, validTokenRefs), ",")
+				if len(validation.ValidTokenIDs) > 0 {
+					resolvedDelegationRef = strings.Join(validation.ValidTokenIDs, ",")
 				}
 			}
 		}

--- a/cmd/gait/gate_delegation_test.go
+++ b/cmd/gait/gate_delegation_test.go
@@ -208,3 +208,67 @@ rules:
 		t.Fatalf("runGateEval with delegation scope mismatch expected %d got %d", exitPolicyBlocked, code)
 	}
 }
+
+func TestRunGateEvalAllowsAnyDelegationScopeMatch(t *testing.T) {
+	workDir := t.TempDir()
+	withWorkingDir(t, workDir)
+
+	privateKeyPath := filepath.Join(workDir, "delegation_private.key")
+	writePrivateKey(t, privateKeyPath)
+
+	policyPath := filepath.Join(workDir, "policy.yaml")
+	mustWriteFile(t, policyPath, `default_verdict: block
+rules:
+  - name: allow-delegated-read-or-write
+    effect: allow
+    match:
+      tool_names: [tool.write]
+      require_delegation: true
+      allowed_delegator_identities: [agent.lead]
+      allowed_delegate_identities: [agent.specialist]
+      delegation_scopes: [read, write]
+`)
+	intentPath := filepath.Join(workDir, "intent.json")
+	mustWriteFile(t, intentPath, `{
+  "schema_id":"gait.gate.intent_request",
+  "schema_version":"1.0.0",
+  "created_at":"2026-02-11T00:00:00Z",
+  "producer_version":"test",
+  "tool_name":"tool.write",
+  "args":{"path":"/tmp/out.txt"},
+  "targets":[{"kind":"path","value":"/tmp/out.txt","operation":"write"}],
+  "delegation":{
+    "requester_identity":"agent.specialist",
+    "scope_class":"write",
+    "token_refs":["delegation_demo"],
+    "chain":[{"delegator_identity":"agent.lead","delegate_identity":"agent.specialist","scope_class":"write","token_ref":"delegation_demo"}]
+  },
+  "context":{"identity":"agent.specialist","workspace":"/repo/gait","risk_class":"high","session_id":"sess-1"}
+}`)
+
+	delegationTokenPath := filepath.Join(workDir, "delegation_token.json")
+	if code := runDelegate([]string{
+		"mint",
+		"--delegator", "agent.lead",
+		"--delegate", "agent.specialist",
+		"--scope", "tool:tool.write",
+		"--scope-class", "write",
+		"--ttl", "1h",
+		"--key-mode", "prod",
+		"--private-key", privateKeyPath,
+		"--out", delegationTokenPath,
+		"--json",
+	}); code != exitOK {
+		t.Fatalf("runDelegate mint expected %d got %d", exitOK, code)
+	}
+
+	if code := runGateEval([]string{
+		"--policy", policyPath,
+		"--intent", intentPath,
+		"--delegation-token", delegationTokenPath,
+		"--delegation-private-key", privateKeyPath,
+		"--json",
+	}); code != exitOK {
+		t.Fatalf("runGateEval with any matching delegation scope expected %d got %d", exitOK, code)
+	}
+}

--- a/cmd/gait/gate_delegation_test.go
+++ b/cmd/gait/gate_delegation_test.go
@@ -76,3 +76,135 @@ rules:
 		t.Fatalf("runGateEval with valid delegation token expected %d got %d", exitOK, code)
 	}
 }
+
+func TestRunGateEvalRejectsIncompleteDelegationChain(t *testing.T) {
+	workDir := t.TempDir()
+	withWorkingDir(t, workDir)
+
+	privateKeyPath := filepath.Join(workDir, "delegation_private.key")
+	writePrivateKey(t, privateKeyPath)
+
+	policyPath := filepath.Join(workDir, "policy.yaml")
+	mustWriteFile(t, policyPath, `default_verdict: block
+rules:
+  - name: allow-delegated-write
+    effect: allow
+    match:
+      tool_names: [tool.write]
+      require_delegation: true
+      allowed_delegator_identities: [agent.lead]
+      allowed_delegate_identities: [agent.manager, agent.specialist]
+      delegation_scopes: [write]
+      max_delegation_depth: 2
+`)
+	intentPath := filepath.Join(workDir, "intent.json")
+	mustWriteFile(t, intentPath, `{
+  "schema_id":"gait.gate.intent_request",
+  "schema_version":"1.0.0",
+  "created_at":"2026-02-11T00:00:00Z",
+  "producer_version":"test",
+  "tool_name":"tool.write",
+  "args":{"path":"/tmp/out.txt"},
+  "targets":[{"kind":"path","value":"/tmp/out.txt","operation":"write"}],
+  "delegation":{
+    "requester_identity":"agent.specialist",
+    "scope_class":"write",
+    "token_refs":["delegation_mid","delegation_leaf"],
+    "chain":[
+      {"delegator_identity":"agent.lead","delegate_identity":"agent.manager","scope_class":"write","token_ref":"delegation_mid"},
+      {"delegator_identity":"agent.manager","delegate_identity":"agent.specialist","scope_class":"write","token_ref":"delegation_leaf"}
+    ]
+  },
+  "context":{"identity":"agent.specialist","workspace":"/repo/gait","risk_class":"high","session_id":"sess-1"}
+}`)
+
+	delegationTokenPath := filepath.Join(workDir, "delegation_token.json")
+	if code := runDelegate([]string{
+		"mint",
+		"--delegator", "agent.manager",
+		"--delegate", "agent.specialist",
+		"--scope", "tool:tool.write",
+		"--scope-class", "write",
+		"--ttl", "1h",
+		"--key-mode", "prod",
+		"--private-key", privateKeyPath,
+		"--out", delegationTokenPath,
+		"--json",
+	}); code != exitOK {
+		t.Fatalf("runDelegate mint expected %d got %d", exitOK, code)
+	}
+
+	if code := runGateEval([]string{
+		"--policy", policyPath,
+		"--intent", intentPath,
+		"--delegation-token", delegationTokenPath,
+		"--delegation-private-key", privateKeyPath,
+		"--json",
+	}); code != exitPolicyBlocked {
+		t.Fatalf("runGateEval with incomplete delegation chain expected %d got %d", exitPolicyBlocked, code)
+	}
+}
+
+func TestRunGateEvalRejectsDelegationScopeMismatch(t *testing.T) {
+	workDir := t.TempDir()
+	withWorkingDir(t, workDir)
+
+	privateKeyPath := filepath.Join(workDir, "delegation_private.key")
+	writePrivateKey(t, privateKeyPath)
+
+	policyPath := filepath.Join(workDir, "policy.yaml")
+	mustWriteFile(t, policyPath, `default_verdict: block
+rules:
+  - name: allow-delegated-write
+    effect: allow
+    match:
+      tool_names: [tool.write]
+      require_delegation: true
+      allowed_delegator_identities: [agent.lead]
+      allowed_delegate_identities: [agent.specialist]
+      delegation_scopes: [write]
+`)
+	intentPath := filepath.Join(workDir, "intent.json")
+	mustWriteFile(t, intentPath, `{
+  "schema_id":"gait.gate.intent_request",
+  "schema_version":"1.0.0",
+  "created_at":"2026-02-11T00:00:00Z",
+  "producer_version":"test",
+  "tool_name":"tool.write",
+  "args":{"path":"/tmp/out.txt"},
+  "targets":[{"kind":"path","value":"/tmp/out.txt","operation":"write"}],
+  "delegation":{
+    "requester_identity":"agent.specialist",
+    "scope_class":"write",
+    "token_refs":["delegation_demo"],
+    "chain":[{"delegator_identity":"agent.lead","delegate_identity":"agent.specialist","scope_class":"write","token_ref":"delegation_demo"}]
+  },
+  "context":{"identity":"agent.specialist","workspace":"/repo/gait","risk_class":"high","session_id":"sess-1"}
+}`)
+
+	delegationTokenPath := filepath.Join(workDir, "delegation_token.json")
+	if code := runDelegate([]string{
+		"mint",
+		"--delegator", "agent.lead",
+		"--delegate", "agent.specialist",
+		"--scope", "tool:tool.read",
+		"--scope-class", "read",
+		"--ttl", "1h",
+		"--key-mode", "prod",
+		"--private-key", privateKeyPath,
+		"--out", delegationTokenPath,
+		"--json",
+	}); code != exitOK {
+		t.Fatalf("runDelegate mint expected %d got %d", exitOK, code)
+	}
+
+	if code := runGateEval([]string{
+		"--policy", policyPath,
+		"--intent", intentPath,
+		"--delegation-token", delegationTokenPath,
+		"--delegation-private-key", privateKeyPath,
+		"--json",
+	}); code != exitPolicyBlocked {
+		t.Fatalf("runGateEval with delegation scope mismatch expected %d got %d", exitPolicyBlocked, code)
+	}
+}

--- a/cmd/gait/pack.go
+++ b/cmd/gait/pack.go
@@ -270,6 +270,8 @@ func runPackVerify(arguments []string) int {
 	ok := len(result.MissingFiles) == 0 && len(result.HashMismatches) == 0 && len(result.UndeclaredFiles) == 0
 	if requireSignature {
 		ok = ok && result.SignatureStatus == "verified"
+	} else {
+		ok = ok && result.SignatureStatus != "failed"
 	}
 	exitCode := exitOK
 	if !ok {

--- a/cmd/gait/pack_cli_test.go
+++ b/cmd/gait/pack_cli_test.go
@@ -4,6 +4,7 @@ import (
 	"archive/zip"
 	"bytes"
 	"crypto/sha256"
+	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	"io"
@@ -15,6 +16,7 @@ import (
 	"time"
 
 	jcs "github.com/Clyra-AI/proof/canon"
+	sign "github.com/Clyra-AI/proof/signing"
 )
 
 func TestRunPackLifecycleCommands(t *testing.T) {
@@ -293,6 +295,57 @@ func TestRunPackVerifySchemaFailureExitCode(t *testing.T) {
 
 	if code := runPack([]string{"verify", mutatedPath, "--json"}); code != exitVerifyFailed {
 		t.Fatalf("pack verify invalid payload expected %d got %d", exitVerifyFailed, code)
+	}
+}
+
+func TestRunPackVerifyWrongKeyFailsInStandardMode(t *testing.T) {
+	workDir := t.TempDir()
+	withWorkingDir(t, workDir)
+
+	if code := runDemo(nil); code != exitOK {
+		t.Fatalf("demo expected %d got %d", exitOK, code)
+	}
+
+	signingPair, err := sign.GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("generate signing key pair: %v", err)
+	}
+	signingPrivateKeyPath := filepath.Join(workDir, "signing_private.key")
+	if err := os.WriteFile(signingPrivateKeyPath, []byte(base64.StdEncoding.EncodeToString(signingPair.Private)+"\n"), 0o600); err != nil {
+		t.Fatalf("write signing private key: %v", err)
+	}
+
+	wrongPair, err := sign.GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("generate wrong key pair: %v", err)
+	}
+	wrongPublicKeyPath := filepath.Join(workDir, "wrong_public.key")
+	if err := os.WriteFile(wrongPublicKeyPath, []byte(base64.StdEncoding.EncodeToString(wrongPair.Public)+"\n"), 0o600); err != nil {
+		t.Fatalf("write wrong public key: %v", err)
+	}
+
+	packPath := filepath.Join(workDir, "signed_pack.zip")
+	if code := runPack([]string{
+		"build",
+		"--type", "run",
+		"--from", "run_demo",
+		"--out", packPath,
+		"--key-mode", "prod",
+		"--private-key", signingPrivateKeyPath,
+		"--json",
+	}); code != exitOK {
+		t.Fatalf("signed pack build expected %d got %d", exitOK, code)
+	}
+
+	verifyCode, verifyOut := runPackJSON(t, []string{"verify", packPath, "--public-key", wrongPublicKeyPath, "--json"})
+	if verifyCode != exitVerifyFailed {
+		t.Fatalf("pack verify wrong-key standard mode expected %d got %d output=%#v", exitVerifyFailed, verifyCode, verifyOut)
+	}
+	if verifyOut.OK {
+		t.Fatalf("expected verify output ok=false, got %#v", verifyOut)
+	}
+	if verifyOut.Verify == nil || verifyOut.Verify.SignatureStatus != "failed" {
+		t.Fatalf("expected signature_status=failed, got %#v", verifyOut)
 	}
 }
 

--- a/core/gate/delegation.go
+++ b/core/gate/delegation.go
@@ -469,11 +469,11 @@ func matchesDelegationScope(requiredScope []string, tokenScope []string, scopeCl
 		return true
 	}
 	for _, scope := range requiredScope {
-		if _, ok := tokenSet[scope]; !ok {
-			return false
+		if _, ok := tokenSet[scope]; ok {
+			return true
 		}
 	}
-	return true
+	return false
 }
 
 func DelegationDigest(delegation schemagate.IntentDelegation) (string, error) {

--- a/core/gate/delegation.go
+++ b/core/gate/delegation.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -30,6 +31,7 @@ const (
 	DelegationCodeScopeMismatch   = "delegation_token_scope_mismatch"
 	DelegationCodeIntentMismatch  = "delegation_token_intent_mismatch"
 	DelegationCodePolicyMismatch  = "delegation_token_policy_mismatch"
+	DelegationCodeChainMismatch   = "delegation_token_chain_mismatch"
 )
 
 type MintDelegationTokenOptions struct {
@@ -63,6 +65,21 @@ type DelegationValidationOptions struct {
 type DelegationTokenError struct {
 	Code string
 	Err  error
+}
+
+type DelegationChainValidationOptions struct {
+	Now                  time.Time
+	RequiredScope        []string
+	ExpectedIntentDigest string
+	ExpectedPolicyDigest string
+}
+
+type DelegationChainValidationResult struct {
+	Complete            bool
+	RequiredDelegations int
+	ValidDelegations    int
+	ValidTokenIDs       []string
+	Entries             []schemagate.DelegationAuditEntry
 }
 
 func (e *DelegationTokenError) Error() string {
@@ -252,10 +269,129 @@ func ValidateDelegationToken(token schemagate.DelegationToken, publicKey ed25519
 	}
 
 	requiredScope := normalizeStringListLower(opts.RequiredScope)
-	if len(requiredScope) > 0 && !matchesApprovalScope(requiredScope, normalized.Scope) {
+	if len(requiredScope) > 0 && !matchesDelegationScope(requiredScope, normalized.Scope, normalized.ScopeClass) {
 		return &DelegationTokenError{Code: DelegationCodeScopeMismatch, Err: fmt.Errorf("scope mismatch")}
 	}
 	return nil
+}
+
+func ValidateDelegationChain(delegation *schemagate.IntentDelegation, tokens []schemagate.DelegationToken, publicKey ed25519.PublicKey, opts DelegationChainValidationOptions) (DelegationChainValidationResult, error) {
+	normalizedDelegation, err := normalizeDelegation(delegation)
+	if err != nil {
+		return DelegationChainValidationResult{}, err
+	}
+	if normalizedDelegation == nil {
+		return DelegationChainValidationResult{}, nil
+	}
+
+	requiredLinks := append([]schemagate.DelegationLink(nil), normalizedDelegation.Chain...)
+	if len(requiredLinks) == 0 {
+		requiredLinks = []schemagate.DelegationLink{{
+			DelegateIdentity: normalizedDelegation.RequesterIdentity,
+			ScopeClass:       normalizedDelegation.ScopeClass,
+		}}
+	}
+
+	used := make([]bool, len(tokens))
+	matchedLinks := make([]bool, len(requiredLinks))
+	entries := make([]schemagate.DelegationAuditEntry, 0, len(tokens)+len(requiredLinks))
+	validTokenIDs := make([]string, 0, len(requiredLinks))
+	validDelegations := 0
+	requiredScope := normalizeStringListLower(opts.RequiredScope)
+
+	for linkIndex, link := range requiredLinks {
+		matched := false
+		for index, token := range tokens {
+			if used[index] {
+				continue
+			}
+			validateErr := ValidateDelegationToken(token, publicKey, DelegationValidationOptions{
+				Now:                  opts.Now,
+				ExpectedDelegator:    strings.TrimSpace(link.DelegatorIdentity),
+				ExpectedDelegate:     strings.TrimSpace(link.DelegateIdentity),
+				RequiredScope:        requiredScope,
+				ExpectedIntentDigest: opts.ExpectedIntentDigest,
+				ExpectedPolicyDigest: opts.ExpectedPolicyDigest,
+			})
+			if validateErr != nil {
+				continue
+			}
+			used[index] = true
+			matchedLinks[linkIndex] = true
+			matched = true
+			validDelegations++
+			if token.TokenID != "" {
+				validTokenIDs = append(validTokenIDs, token.TokenID)
+			}
+			entries = append(entries, schemagate.DelegationAuditEntry{
+				TokenID:           token.TokenID,
+				DelegatorIdentity: token.DelegatorIdentity,
+				DelegateIdentity:  token.DelegateIdentity,
+				Scope:             mergeUniqueSorted(nil, token.Scope),
+				ExpiresAt:         token.ExpiresAt.UTC(),
+				Valid:             true,
+			})
+			break
+		}
+		if matched {
+			continue
+		}
+		entries = append(entries, schemagate.DelegationAuditEntry{
+			DelegatorIdentity: strings.TrimSpace(link.DelegatorIdentity),
+			DelegateIdentity:  strings.TrimSpace(link.DelegateIdentity),
+			Valid:             false,
+			ErrorCode:         "delegation_token_missing",
+		})
+	}
+
+	for index, token := range tokens {
+		if used[index] {
+			continue
+		}
+		errorCode := DelegationCodeChainMismatch
+		for linkIndex, link := range requiredLinks {
+			if matchedLinks[linkIndex] {
+				continue
+			}
+			validateErr := ValidateDelegationToken(token, publicKey, DelegationValidationOptions{
+				Now:                  opts.Now,
+				ExpectedDelegator:    strings.TrimSpace(link.DelegatorIdentity),
+				ExpectedDelegate:     strings.TrimSpace(link.DelegateIdentity),
+				RequiredScope:        requiredScope,
+				ExpectedIntentDigest: opts.ExpectedIntentDigest,
+				ExpectedPolicyDigest: opts.ExpectedPolicyDigest,
+			})
+			if validateErr == nil {
+				errorCode = ""
+				break
+			}
+			var tokenErr *DelegationTokenError
+			if errors.As(validateErr, &tokenErr) && tokenErr.Code != "" {
+				errorCode = tokenErr.Code
+				break
+			}
+		}
+		if errorCode == "" {
+			errorCode = DelegationCodeChainMismatch
+		}
+		entries = append(entries, schemagate.DelegationAuditEntry{
+			TokenID:           token.TokenID,
+			DelegatorIdentity: token.DelegatorIdentity,
+			DelegateIdentity:  token.DelegateIdentity,
+			Scope:             mergeUniqueSorted(nil, token.Scope),
+			ExpiresAt:         token.ExpiresAt.UTC(),
+			Valid:             false,
+			ErrorCode:         errorCode,
+		})
+	}
+
+	return DelegationChainValidationResult{
+		Complete:            validDelegations == len(requiredLinks),
+		RequiredDelegations: len(requiredLinks),
+		ValidDelegations:    validDelegations,
+		ValidTokenIDs:       mergeUniqueSorted(nil, validTokenIDs),
+		Entries:             entries,
+	}, nil
 }
 
 func normalizeDelegationToken(token schemagate.DelegationToken) (schemagate.DelegationToken, error) {
@@ -315,6 +451,29 @@ func computeDelegationTokenID(delegator, delegate string, scope []string, scopeC
 	}, ":")
 	sum := sha256.Sum256([]byte(raw))
 	return hex.EncodeToString(sum[:12])
+}
+
+func matchesDelegationScope(requiredScope []string, tokenScope []string, scopeClass string) bool {
+	if len(requiredScope) == 0 {
+		return true
+	}
+	tokenSet := make(map[string]struct{}, len(tokenScope)+1)
+	for _, scope := range tokenScope {
+		tokenSet[scope] = struct{}{}
+	}
+	normalizedScopeClass := strings.ToLower(strings.TrimSpace(scopeClass))
+	if normalizedScopeClass != "" {
+		tokenSet[normalizedScopeClass] = struct{}{}
+	}
+	if _, ok := tokenSet["*"]; ok {
+		return true
+	}
+	for _, scope := range requiredScope {
+		if _, ok := tokenSet[scope]; !ok {
+			return false
+		}
+	}
+	return true
 }
 
 func DelegationDigest(delegation schemagate.IntentDelegation) (string, error) {

--- a/core/gate/delegation_test.go
+++ b/core/gate/delegation_test.go
@@ -192,6 +192,14 @@ func TestValidateDelegationTokenAdditionalFailureModes(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected signed scope_class to satisfy required scope, got %v", err)
 	}
+
+	err = ValidateDelegationToken(minted.Token, keyPair.Public, DelegationValidationOptions{
+		Now:           time.Date(2026, time.February, 10, 0, 30, 0, 0, time.UTC),
+		RequiredScope: []string{"read", "write"},
+	})
+	if err != nil {
+		t.Fatalf("expected any matching required scope to satisfy validation, got %v", err)
+	}
 }
 
 func TestDelegationBindingDigest(t *testing.T) {

--- a/core/gate/delegation_test.go
+++ b/core/gate/delegation_test.go
@@ -184,6 +184,14 @@ func TestValidateDelegationTokenAdditionalFailureModes(t *testing.T) {
 		ExpectedPolicyDigest: "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
 	})
 	assertDelegationErrorCode(t, err, DelegationCodePolicyMismatch)
+
+	err = ValidateDelegationToken(minted.Token, keyPair.Public, DelegationValidationOptions{
+		Now:           time.Date(2026, time.February, 10, 0, 30, 0, 0, time.UTC),
+		RequiredScope: []string{"write"},
+	})
+	if err != nil {
+		t.Fatalf("expected signed scope_class to satisfy required scope, got %v", err)
+	}
 }
 
 func TestDelegationBindingDigest(t *testing.T) {
@@ -427,5 +435,125 @@ func TestValidateDelegationTokenSchemaFailuresAndSignatureTamper(t *testing.T) {
 	}
 	if err := WriteDelegationToken(filepath.Join(parentFile, "delegation.json"), minted.Token); err == nil {
 		t.Fatalf("expected write delegation token failure when parent is not directory")
+	}
+}
+
+func TestValidateDelegationChainRequiresEveryHop(t *testing.T) {
+	keyPair, err := sign.GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("generate key pair: %v", err)
+	}
+	workDir := t.TempDir()
+
+	midPath := filepath.Join(workDir, "mid.json")
+	leafPath := filepath.Join(workDir, "leaf.json")
+	mid, err := MintDelegationToken(MintDelegationTokenOptions{
+		ProducerVersion:   "test",
+		DelegatorIdentity: "agent.lead",
+		DelegateIdentity:  "agent.manager",
+		Scope:             []string{"tool:tool.write"},
+		ScopeClass:        "write",
+		TTL:               time.Hour,
+		Now:               time.Date(2026, time.February, 10, 0, 0, 0, 0, time.UTC),
+		SigningPrivateKey: keyPair.Private,
+		TokenPath:         midPath,
+	})
+	if err != nil {
+		t.Fatalf("mint mid delegation token: %v", err)
+	}
+	leaf, err := MintDelegationToken(MintDelegationTokenOptions{
+		ProducerVersion:   "test",
+		DelegatorIdentity: "agent.manager",
+		DelegateIdentity:  "agent.specialist",
+		Scope:             []string{"tool:tool.write"},
+		ScopeClass:        "write",
+		TTL:               time.Hour,
+		Now:               time.Date(2026, time.February, 10, 0, 0, 0, 0, time.UTC),
+		SigningPrivateKey: keyPair.Private,
+		TokenPath:         leafPath,
+	})
+	if err != nil {
+		t.Fatalf("mint leaf delegation token: %v", err)
+	}
+
+	delegation := &schemagate.IntentDelegation{
+		RequesterIdentity: "agent.specialist",
+		ScopeClass:        "write",
+		Chain: []schemagate.DelegationLink{
+			{DelegatorIdentity: "agent.lead", DelegateIdentity: "agent.manager", ScopeClass: "write"},
+			{DelegatorIdentity: "agent.manager", DelegateIdentity: "agent.specialist", ScopeClass: "write"},
+		},
+	}
+
+	partial, err := ValidateDelegationChain(delegation, []schemagate.DelegationToken{leaf.Token}, keyPair.Public, DelegationChainValidationOptions{
+		Now: time.Date(2026, time.February, 10, 0, 30, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("validate partial delegation chain: %v", err)
+	}
+	if partial.Complete {
+		t.Fatalf("expected partial delegation chain to be incomplete")
+	}
+	if partial.RequiredDelegations != 2 || partial.ValidDelegations != 1 {
+		t.Fatalf("unexpected partial delegation chain counts: %#v", partial)
+	}
+	if len(partial.Entries) != 2 {
+		t.Fatalf("expected one valid entry and one missing-link entry, got %#v", partial.Entries)
+	}
+
+	complete, err := ValidateDelegationChain(delegation, []schemagate.DelegationToken{mid.Token, leaf.Token}, keyPair.Public, DelegationChainValidationOptions{
+		Now: time.Date(2026, time.February, 10, 0, 30, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("validate complete delegation chain: %v", err)
+	}
+	if !complete.Complete {
+		t.Fatalf("expected complete delegation chain, got %#v", complete)
+	}
+	if complete.RequiredDelegations != 2 || complete.ValidDelegations != 2 {
+		t.Fatalf("unexpected complete delegation chain counts: %#v", complete)
+	}
+	if len(complete.ValidTokenIDs) != 2 {
+		t.Fatalf("expected two valid token ids, got %#v", complete.ValidTokenIDs)
+	}
+}
+
+func TestValidateDelegationChainRequiresSignedScopeMatch(t *testing.T) {
+	keyPair, err := sign.GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("generate key pair: %v", err)
+	}
+	workDir := t.TempDir()
+	tokenPath := filepath.Join(workDir, "delegation_scope_mismatch.json")
+	minted, err := MintDelegationToken(MintDelegationTokenOptions{
+		ProducerVersion:   "test",
+		DelegatorIdentity: "agent.lead",
+		DelegateIdentity:  "agent.specialist",
+		Scope:             []string{"tool:tool.read"},
+		ScopeClass:        "read",
+		TTL:               time.Hour,
+		Now:               time.Date(2026, time.February, 10, 0, 0, 0, 0, time.UTC),
+		SigningPrivateKey: keyPair.Private,
+		TokenPath:         tokenPath,
+	})
+	if err != nil {
+		t.Fatalf("mint delegation token: %v", err)
+	}
+
+	result, err := ValidateDelegationChain(&schemagate.IntentDelegation{
+		RequesterIdentity: "agent.specialist",
+		ScopeClass:        "write",
+		Chain: []schemagate.DelegationLink{
+			{DelegatorIdentity: "agent.lead", DelegateIdentity: "agent.specialist", ScopeClass: "write"},
+		},
+	}, []schemagate.DelegationToken{minted.Token}, keyPair.Public, DelegationChainValidationOptions{
+		Now:           time.Date(2026, time.February, 10, 0, 30, 0, 0, time.UTC),
+		RequiredScope: []string{"write"},
+	})
+	if err != nil {
+		t.Fatalf("validate delegation chain with scope mismatch: %v", err)
+	}
+	if result.Complete || result.ValidDelegations != 0 {
+		t.Fatalf("expected scope mismatch to block delegation chain, got %#v", result)
 	}
 }

--- a/core/gate/intent.go
+++ b/core/gate/intent.go
@@ -732,6 +732,9 @@ func normalizeDelegation(input *schemagate.IntentDelegation) (*schemagate.Intent
 		if delegatorIdentity == "" || delegateIdentity == "" {
 			return nil, fmt.Errorf("delegation.chain[%d] requires delegator_identity and delegate_identity", i)
 		}
+		if i > 0 && normalizedChain[i-1].DelegateIdentity != delegatorIdentity {
+			return nil, fmt.Errorf("delegation.chain[%d] delegator_identity must match delegation.chain[%d].delegate_identity", i, i-1)
+		}
 		issuedAt := link.IssuedAt.UTC()
 		expiresAt := link.ExpiresAt.UTC()
 		if !issuedAt.IsZero() && !expiresAt.IsZero() && !expiresAt.After(issuedAt) {
@@ -751,6 +754,9 @@ func normalizeDelegation(input *schemagate.IntentDelegation) (*schemagate.Intent
 	expiresAt := input.ExpiresAt.UTC()
 	if !issuedAt.IsZero() && !expiresAt.IsZero() && !expiresAt.After(issuedAt) {
 		return nil, fmt.Errorf("delegation.expires_at must be after issued_at")
+	}
+	if len(normalizedChain) > 0 && normalizedChain[len(normalizedChain)-1].DelegateIdentity != requesterIdentity {
+		return nil, fmt.Errorf("delegation.chain last delegate_identity must match delegation.requester_identity")
 	}
 
 	return &schemagate.IntentDelegation{

--- a/core/gate/intent_test.go
+++ b/core/gate/intent_test.go
@@ -527,6 +527,35 @@ func TestNormalizeIntentValidationErrors(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "invalid_delegation_chain_continuity",
+			intent: schemagate.IntentRequest{
+				ToolName: "tool.demo",
+				Args:     map[string]any{},
+				Delegation: &schemagate.IntentDelegation{
+					RequesterIdentity: "agent.worker",
+					Chain: []schemagate.DelegationLink{
+						{DelegatorIdentity: "agent.lead", DelegateIdentity: "agent.manager"},
+						{DelegatorIdentity: "agent.other", DelegateIdentity: "agent.worker"},
+					},
+				},
+				Context: schemagate.IntentContext{Identity: "agent.worker", Workspace: "/tmp", RiskClass: "high"},
+			},
+		},
+		{
+			name: "invalid_delegation_chain_requester_mismatch",
+			intent: schemagate.IntentRequest{
+				ToolName: "tool.demo",
+				Args:     map[string]any{},
+				Delegation: &schemagate.IntentDelegation{
+					RequesterIdentity: "agent.worker",
+					Chain: []schemagate.DelegationLink{
+						{DelegatorIdentity: "agent.lead", DelegateIdentity: "agent.manager"},
+					},
+				},
+				Context: schemagate.IntentContext{Identity: "agent.worker", Workspace: "/tmp", RiskClass: "high"},
+			},
+		},
 	}
 
 	for _, testCase := range tests {

--- a/core/gate/policy.go
+++ b/core/gate/policy.go
@@ -199,6 +199,7 @@ type EvalOutcome struct {
 	RequireDistinctApprovers bool
 	RequireBrokerCredential  bool
 	RequireDelegation        bool
+	RequiredDelegationScopes []string
 	BrokerReference          string
 	BrokerScopes             []string
 	RateLimit                RateLimitPolicy
@@ -225,6 +226,7 @@ type matchedRuleEvaluation struct {
 	RequireDistinctApprovers bool
 	RequireBrokerCredential  bool
 	RequireDelegation        bool
+	RequiredDelegationScopes []string
 	BrokerReference          string
 	BrokerScopes             []string
 	RateLimit                RateLimitPolicy
@@ -382,6 +384,7 @@ func evaluateSingleIntent(policy Policy, intent schemagate.IntentRequest, opts E
 		requireDistinctApprovers := false
 		requireBrokerCredential := false
 		requireDelegation := false
+		requiredDelegationScopes := []string{}
 		brokerReferences := []string{}
 		brokerScopes := []string{}
 		rateLimit := RateLimitPolicy{}
@@ -399,6 +402,7 @@ func evaluateSingleIntent(policy Policy, intent schemagate.IntentRequest, opts E
 			requireDistinctApprovers = requireDistinctApprovers || evaluation.RequireDistinctApprovers
 			requireBrokerCredential = requireBrokerCredential || evaluation.RequireBrokerCredential
 			requireDelegation = requireDelegation || evaluation.RequireDelegation
+			requiredDelegationScopes = mergeUniqueSorted(requiredDelegationScopes, evaluation.RequiredDelegationScopes)
 			brokerReferences = mergeUniqueSorted(brokerReferences, []string{evaluation.BrokerReference})
 			brokerScopes = mergeUniqueSorted(brokerScopes, evaluation.BrokerScopes)
 			rateLimit = mostRestrictiveRateLimitPolicy(rateLimit, evaluation.RateLimit)
@@ -417,6 +421,7 @@ func evaluateSingleIntent(policy Policy, intent schemagate.IntentRequest, opts E
 			RequireDistinctApprovers: requireDistinctApprovers,
 			RequireBrokerCredential:  requireBrokerCredential,
 			RequireDelegation:        requireDelegation,
+			RequiredDelegationScopes: uniqueSorted(requiredDelegationScopes),
 			BrokerReference:          strings.Join(uniqueSorted(brokerReferences), ","),
 			BrokerScopes:             uniqueSorted(brokerScopes),
 			RateLimit:                rateLimit,
@@ -495,6 +500,7 @@ func evaluateMatchedRule(rule PolicyRule, intent schemagate.IntentRequest) match
 		RequireDistinctApprovers: rule.RequireDistinctApprovers,
 		RequireBrokerCredential:  rule.RequireBrokerCredential,
 		RequireDelegation:        rule.Match.RequireDelegation,
+		RequiredDelegationScopes: uniqueSorted(rule.Match.DelegationScopes),
 		BrokerReference:          rule.BrokerReference,
 		BrokerScopes:             uniqueSorted(rule.BrokerScopes),
 		RateLimit:                rule.RateLimit,
@@ -516,6 +522,7 @@ func evaluateScriptPolicyDetailed(policy Policy, intent schemagate.IntentRequest
 	requireDistinctApprovers := false
 	requireBrokerCredential := false
 	requireDelegation := false
+	requiredDelegationScopes := []string{}
 	brokerScopes := []string{}
 	brokerReference := ""
 	dataflowTriggered := false
@@ -570,6 +577,7 @@ func evaluateScriptPolicyDetailed(policy Policy, intent schemagate.IntentRequest
 		if stepOutcome.RequireDelegation {
 			requireDelegation = true
 		}
+		requiredDelegationScopes = mergeUniqueSorted(requiredDelegationScopes, stepOutcome.RequiredDelegationScopes)
 		if brokerReference == "" {
 			brokerReference = stepOutcome.BrokerReference
 		}
@@ -621,6 +629,7 @@ func evaluateScriptPolicyDetailed(policy Policy, intent schemagate.IntentRequest
 		RequireDistinctApprovers: requireDistinctApprovers,
 		RequireBrokerCredential:  requireBrokerCredential,
 		RequireDelegation:        requireDelegation,
+		RequiredDelegationScopes: uniqueSorted(requiredDelegationScopes),
 		BrokerReference:          brokerReference,
 		BrokerScopes:             uniqueSorted(brokerScopes),
 		RateLimit:                aggregatedRateLimit,

--- a/core/gate/trace_test.go
+++ b/core/gate/trace_test.go
@@ -405,7 +405,7 @@ func TestEmitSignedTraceRelationshipEnvelope(t *testing.T) {
 	intent.Delegation = &schemagate.IntentDelegation{
 		RequesterIdentity: "agent.requester",
 		Chain: []schemagate.DelegationLink{
-			{DelegatorIdentity: "agent.lead", DelegateIdentity: "agent.worker"},
+			{DelegatorIdentity: "agent.lead", DelegateIdentity: "agent.requester"},
 		},
 	}
 	result, err := EvaluatePolicy(policy, intent, EvalOptions{ProducerVersion: "test"})

--- a/docs-site/public/llm/contracts.md
+++ b/docs-site/public/llm/contracts.md
@@ -4,6 +4,7 @@ Stable OSS contracts include:
 
 - **PackSpec v1**: Unified portable artifact envelope for run, job, and call evidence with Ed25519 signatures and SHA-256 manifest. Schema: `schemas/v1/pack/manifest.schema.json`.
   - includes first-class export surfaces: `gait pack export --otel-out ...` and `--postgres-sql-out ...` for observability and metadata indexing.
+  - `gait pack verify` remains offline-first, but a supplied verify key that produces `signature_status=failed` is a verification failure, not a soft pass.
 - **ContextSpec v1**: Deterministic context evidence envelopes with privacy-aware modes and fail-closed enforcement. Required context-proof checks are satisfied through a verified `--context-envelope` input on `gait gate eval`, `gait mcp proxy`, or `gait mcp serve`, rather than raw intent claims.
 - **Primitive Contract**: Four deterministic primitives — capture, enforce, regress, diagnose.
 - **CLI Meta Contract**: `gait --help` is text-only and exits `0`; machine-readable version discovery uses `gait version --json` or the `--version` / `-v` aliases.
@@ -16,7 +17,8 @@ Stable OSS contracts include:
   - `mcp_trust.snapshot` must point at a local file; scanners and registries remain complementary inputs.
   - `gait mcp verify --json` reports `trust_model=local_snapshot` and `snapshot_path` when MCP trust is configured.
   - wrapper JSON reports `boundary_contract=explicit_trace_reference`, `trace_reference_required=true`, and stable `failure_reason` values such as `missing_trace_reference` and `invalid_trace_artifact`.
-- **Script Governance Contract**: Script intent steps, deterministic `script_hash`, Wrkr-derived context matching fields, and signed approved-script registry entries.
+- **Script Governance Contract**: Script intent steps, deterministic `script_hash`, Wrkr-derived context matching fields, and signed approved-script registry entries. Fast-path allow requires a verify key; missing verification prerequisites disable fast-path in standard low-risk mode and fail closed in high-risk / `oss-prod` paths.
+- **Delegation Contract**: delegated execution is only authoritative when each claimed delegation hop is backed by signed token evidence; multi-hop chains must stay contiguous and terminate at the requester identity, and policy-required delegation scope must come from the token's signed `scope` or signed `scope_class`.
 - **Intent+Receipt Spec**: Structured tool-call intent with deterministic receipt generation.
 - **Endpoint Action Model**: Maps tool-call intent to policy-evaluated action outcomes.
 - Artifact schemas (`schemas/v1/*`)

--- a/docs-site/public/llm/faq.md
+++ b/docs-site/public/llm/faq.md
@@ -66,7 +66,7 @@ The practical model is camera plus gate, not camera or gate.
 
 ## Can Gait pre-approve known multi-step scripts?
 
-Yes. Use `gait approve-script` to mint signed registry entries bound to policy digest and script hash, then evaluate with `gait gate eval --approved-script-registry ...`. Invalid or tampered registry state fails closed in high-risk paths.
+Yes. Use `gait approve-script` to mint signed registry entries bound to policy digest and script hash, then evaluate with `gait gate eval --approved-script-registry ... --approved-script-public-key ...`. Invalid or tampered registry state fails closed in high-risk paths, and missing verify keys only disable the fast path in standard low-risk mode.
 
 ## How should teams start?
 

--- a/docs/contracts/compatibility_matrix.md
+++ b/docs/contracts/compatibility_matrix.md
@@ -39,6 +39,6 @@ Breaking changes require:
 If you are emitting PackSpec outside Gait runtime:
 - implement RFC 8785 canonicalization for digest/signature inputs
 - keep zip output deterministic
-- validate outputs with `gait pack verify` in CI
+- validate outputs with `gait pack verify` in CI, and treat wrong-key signature failures as hard verification failures even in standard mode when a verify key is supplied
 
 Reference kit: `docs/contracts/pack_producer_kit.md`

--- a/docs/contracts/packspec_tck.md
+++ b/docs/contracts/packspec_tck.md
@@ -26,13 +26,14 @@ The TCK validates these required vectors:
 
 1. Valid run pack (`pack_type=run`) verify pass.
 2. Valid job pack (`pack_type=job`) verify pass.
-3. Tampered hash pack verify fail.
-4. Undeclared file pack verify fail.
-5. Schema-invalid manifest verify fail.
-6. Legacy migration vectors:
+3. Wrong-key signature pack verify fail.
+4. Tampered hash pack verify fail.
+5. Undeclared file pack verify fail.
+6. Schema-invalid manifest verify fail.
+7. Legacy migration vectors:
    - legacy runpack verify through `gait pack verify`
    - legacy guard pack verify through `gait pack verify`
-7. Deterministic `pack diff` output (stable hash across repeated runs).
+8. Deterministic `pack diff` output (stable hash across repeated runs).
 
 ## Exit Contract
 

--- a/docs/contracts/packspec_v1.md
+++ b/docs/contracts/packspec_v1.md
@@ -52,6 +52,7 @@ Producers MUST ensure identical inputs produce identical output bytes:
 - declared file presence and hash integrity
 - undeclared file rejection
 - optional signature requirements (`--profile strict` or `--require-signature`)
+- attempted signature verification failures when a verify key is supplied
 
 Stable exit semantics:
 

--- a/docs/contracts/primitive_contract.md
+++ b/docs/contracts/primitive_contract.md
@@ -110,6 +110,13 @@ Producer obligations:
   - `scope_class`
   - `token_refs`
 
+Delegation obligations:
+
+- Producers MUST keep `delegation.chain[]` contiguous: each link's `delegator_identity` must equal the previous link's `delegate_identity`.
+- Producers MUST terminate `delegation.chain[]` at `delegation.requester_identity`.
+- Consumers MUST require signed token evidence for every claimed delegation hop before treating the chain as authorizing input.
+- Consumers MUST enforce policy-required delegation scope against the delegation token's signed `scope` or signed `scope_class`, not against unsigned intent fields alone.
+
 Consumer obligations:
 
 - MUST fail closed for high-risk paths when intent cannot be evaluated.
@@ -297,6 +304,7 @@ Consumer obligations:
   - supports signed pre-approved fast-path via:
     - `--approved-script-registry <registry.json>`
     - `--approved-script-public-key <path>` or `--approved-script-public-key-env <VAR>`
+  - missing approved-script verify keys disable fast-path in standard low-risk mode and fail closed in high-risk / `oss-prod` paths
 - `gait approve-script`:
   - creates signed approved-script entries bound to policy digest + script hash
 - `gait list-scripts`:

--- a/docs/policy_rollout.md
+++ b/docs/policy_rollout.md
@@ -145,6 +145,7 @@ Rollout gate:
 
 - approved-script entries must be policy-digest bound and signature verified.
 - missing/invalid registry state must fail closed in high-risk/oss-prod paths.
+- missing approved-script verify keys disable fast-path in standard low-risk mode; they do not create an implicit allow path.
 - monitor `pre_approved`, `pattern_id`, and `registry_reason` in gate JSON and trace artifacts.
 
 ## Stage 3B: Skill Trust Guardrails
@@ -188,6 +189,8 @@ Rollout gate:
 Identity boundary note:
 
 - Gait validates signed delegation evidence (identity/scope/digest bindings) presented at eval time.
+- For multi-hop delegation, every claimed `delegation.chain[]` hop must be backed by a signed delegation token for that hop; partial chains remain blocked.
+- Policy `delegation_scopes` must be satisfied by the delegation token's signed `scope` or signed `scope_class`; unsigned intent-only scope claims do not authorize execution.
 - Enterprise IdP/OIDC token exchange and identity lifecycle remain external to Gait.
 - Integration teams should map IdP-issued identities/claims into delegation token issuance before `gait gate eval`.
 

--- a/internal/e2e/cli_test.go
+++ b/internal/e2e/cli_test.go
@@ -706,6 +706,281 @@ rules:
 	}
 }
 
+func TestCLIGateRejectsPartialDelegationChain(t *testing.T) {
+	root := repoRoot(t)
+	binPath := buildGaitBinary(t, root)
+	workDir := t.TempDir()
+
+	intentPath := filepath.Join(workDir, "intent_delegation_partial.json")
+	intentContent := []byte(`{
+  "schema_id": "gait.gate.intent_request",
+  "schema_version": "1.0.0",
+  "created_at": "2026-02-11T00:00:00Z",
+  "producer_version": "0.0.0-dev",
+  "tool_name": "tool.write",
+  "args": {"path": "/tmp/out.txt"},
+  "targets": [{"kind":"path","value":"/tmp/out.txt","operation":"write","endpoint_class":"fs.write"}],
+  "arg_provenance": [{"arg_path":"$.path","source":"user"}],
+  "delegation": {
+    "requester_identity":"agent.specialist",
+    "scope_class":"write",
+    "token_refs":["delegation_mid","delegation_leaf"],
+    "chain":[
+      {"delegator_identity":"agent.lead","delegate_identity":"agent.manager","scope_class":"write","token_ref":"delegation_mid"},
+      {"delegator_identity":"agent.manager","delegate_identity":"agent.specialist","scope_class":"write","token_ref":"delegation_leaf"}
+    ]
+  },
+  "context": {"identity":"agent.specialist","workspace":"/repo/gait","risk_class":"high","session_id":"sess-e2e"}
+}`)
+	if err := os.WriteFile(intentPath, intentContent, 0o600); err != nil {
+		t.Fatalf("write partial delegation intent file: %v", err)
+	}
+
+	policyPath := filepath.Join(workDir, "delegation_policy.yaml")
+	policyContent := []byte(`default_verdict: block
+rules:
+  - name: allow-delegated-write
+    effect: allow
+    match:
+      tool_names: [tool.write]
+      require_delegation: true
+      allowed_delegator_identities: [agent.lead]
+      allowed_delegate_identities: [agent.manager, agent.specialist]
+      delegation_scopes: [write]
+      max_delegation_depth: 2
+`)
+	if err := os.WriteFile(policyPath, policyContent, 0o600); err != nil {
+		t.Fatalf("write partial delegation policy file: %v", err)
+	}
+
+	traceKeyPair, err := sign.GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("generate trace key pair: %v", err)
+	}
+	tracePrivateKeyPath := filepath.Join(workDir, "trace_private.key")
+	if err := os.WriteFile(tracePrivateKeyPath, []byte(base64.StdEncoding.EncodeToString(traceKeyPair.Private)), 0o600); err != nil {
+		t.Fatalf("write trace private key: %v", err)
+	}
+
+	delegationKeyPair, err := sign.GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("generate delegation key pair: %v", err)
+	}
+	delegationPrivateKeyPath := filepath.Join(workDir, "delegation_private.key")
+	if err := os.WriteFile(delegationPrivateKeyPath, []byte(base64.StdEncoding.EncodeToString(delegationKeyPair.Private)), 0o600); err != nil {
+		t.Fatalf("write delegation private key: %v", err)
+	}
+	delegationPublicKeyPath := filepath.Join(workDir, "delegation_public.key")
+	if err := os.WriteFile(delegationPublicKeyPath, []byte(base64.StdEncoding.EncodeToString(delegationKeyPair.Public)), 0o600); err != nil {
+		t.Fatalf("write delegation public key: %v", err)
+	}
+
+	delegateMint := exec.Command(
+		binPath,
+		"delegate",
+		"mint",
+		"--delegator", "agent.manager",
+		"--delegate", "agent.specialist",
+		"--scope", "tool:tool.write",
+		"--scope-class", "write",
+		"--ttl", "1h",
+		"--key-mode", "prod",
+		"--private-key", delegationPrivateKeyPath,
+		"--out", filepath.Join(workDir, "delegation_token.json"),
+		"--json",
+	)
+	delegateMint.Dir = workDir
+	delegateOut, err := delegateMint.CombinedOutput()
+	if err != nil {
+		t.Fatalf("delegate mint failed: %v\n%s", err, string(delegateOut))
+	}
+	var delegateResult struct {
+		OK        bool   `json:"ok"`
+		TokenPath string `json:"token_path"`
+	}
+	if err := json.Unmarshal(delegateOut, &delegateResult); err != nil {
+		t.Fatalf("parse delegate output: %v\n%s", err, string(delegateOut))
+	}
+	if !delegateResult.OK || delegateResult.TokenPath == "" {
+		t.Fatalf("unexpected delegate output: %s", string(delegateOut))
+	}
+
+	evalDelegated := exec.Command(
+		binPath,
+		"gate", "eval",
+		"--policy", policyPath,
+		"--intent", intentPath,
+		"--delegation-token", delegateResult.TokenPath,
+		"--delegation-public-key", delegationPublicKeyPath,
+		"--key-mode", "prod",
+		"--private-key", tracePrivateKeyPath,
+		"--json",
+	)
+	evalDelegated.Dir = workDir
+	delegatedOut, err := evalDelegated.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected gate eval to reject incomplete delegation chain\n%s", string(delegatedOut))
+	}
+	if code := commandExitCode(t, err); code != 3 {
+		t.Fatalf("unexpected partial delegation exit code: got=%d want=3 output=%s", code, string(delegatedOut))
+	}
+	var delegatedResult struct {
+		OK               bool     `json:"ok"`
+		Verdict          string   `json:"verdict"`
+		ReasonCodes      []string `json:"reason_codes"`
+		ValidDelegations int      `json:"valid_delegations"`
+	}
+	if err := json.Unmarshal(delegatedOut, &delegatedResult); err != nil {
+		t.Fatalf("parse partial delegated gate output: %v\n%s", err, string(delegatedOut))
+	}
+	if !delegatedResult.OK || delegatedResult.Verdict != "block" {
+		t.Fatalf("unexpected partial delegated gate output: %s", string(delegatedOut))
+	}
+	if delegatedResult.ValidDelegations != 1 {
+		t.Fatalf("expected one valid hop in partial delegation chain, got %#v", delegatedResult)
+	}
+	if !containsString(delegatedResult.ReasonCodes, "delegation_chain_insufficient") {
+		t.Fatalf("expected delegation_chain_insufficient reason, got: %#v", delegatedResult.ReasonCodes)
+	}
+	if !containsString(delegatedResult.ReasonCodes, "delegation_token_missing") {
+		t.Fatalf("expected delegation_token_missing reason, got: %#v", delegatedResult.ReasonCodes)
+	}
+}
+
+func TestCLIGateRejectsDelegationScopeMismatch(t *testing.T) {
+	root := repoRoot(t)
+	binPath := buildGaitBinary(t, root)
+	workDir := t.TempDir()
+
+	intentPath := filepath.Join(workDir, "intent_delegation_scope.json")
+	intentContent := []byte(`{
+  "schema_id": "gait.gate.intent_request",
+  "schema_version": "1.0.0",
+  "created_at": "2026-02-11T00:00:00Z",
+  "producer_version": "0.0.0-dev",
+  "tool_name": "tool.write",
+  "args": {"path": "/tmp/out.txt"},
+  "targets": [{"kind":"path","value":"/tmp/out.txt","operation":"write","endpoint_class":"fs.write"}],
+  "arg_provenance": [{"arg_path":"$.path","source":"user"}],
+  "delegation": {
+    "requester_identity":"agent.specialist",
+    "scope_class":"write",
+    "token_refs":["delegation_e2e"],
+    "chain":[{"delegator_identity":"agent.lead","delegate_identity":"agent.specialist","scope_class":"write","token_ref":"delegation_e2e"}]
+  },
+  "context": {"identity":"agent.specialist","workspace":"/repo/gait","risk_class":"high","session_id":"sess-e2e"}
+}`)
+	if err := os.WriteFile(intentPath, intentContent, 0o600); err != nil {
+		t.Fatalf("write delegation scope intent file: %v", err)
+	}
+
+	policyPath := filepath.Join(workDir, "delegation_policy.yaml")
+	policyContent := []byte(`default_verdict: block
+rules:
+  - name: allow-delegated-write
+    effect: allow
+    match:
+      tool_names: [tool.write]
+      require_delegation: true
+      allowed_delegator_identities: [agent.lead]
+      allowed_delegate_identities: [agent.specialist]
+      delegation_scopes: [write]
+`)
+	if err := os.WriteFile(policyPath, policyContent, 0o600); err != nil {
+		t.Fatalf("write delegation scope policy file: %v", err)
+	}
+
+	traceKeyPair, err := sign.GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("generate trace key pair: %v", err)
+	}
+	tracePrivateKeyPath := filepath.Join(workDir, "trace_private.key")
+	if err := os.WriteFile(tracePrivateKeyPath, []byte(base64.StdEncoding.EncodeToString(traceKeyPair.Private)), 0o600); err != nil {
+		t.Fatalf("write trace private key: %v", err)
+	}
+
+	delegationKeyPair, err := sign.GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("generate delegation key pair: %v", err)
+	}
+	delegationPrivateKeyPath := filepath.Join(workDir, "delegation_private.key")
+	if err := os.WriteFile(delegationPrivateKeyPath, []byte(base64.StdEncoding.EncodeToString(delegationKeyPair.Private)), 0o600); err != nil {
+		t.Fatalf("write delegation private key: %v", err)
+	}
+	delegationPublicKeyPath := filepath.Join(workDir, "delegation_public.key")
+	if err := os.WriteFile(delegationPublicKeyPath, []byte(base64.StdEncoding.EncodeToString(delegationKeyPair.Public)), 0o600); err != nil {
+		t.Fatalf("write delegation public key: %v", err)
+	}
+
+	delegateMint := exec.Command(
+		binPath,
+		"delegate",
+		"mint",
+		"--delegator", "agent.lead",
+		"--delegate", "agent.specialist",
+		"--scope", "tool:tool.read",
+		"--scope-class", "read",
+		"--ttl", "1h",
+		"--key-mode", "prod",
+		"--private-key", delegationPrivateKeyPath,
+		"--out", filepath.Join(workDir, "delegation_token.json"),
+		"--json",
+	)
+	delegateMint.Dir = workDir
+	delegateOut, err := delegateMint.CombinedOutput()
+	if err != nil {
+		t.Fatalf("delegate mint failed: %v\n%s", err, string(delegateOut))
+	}
+	var delegateResult struct {
+		OK        bool   `json:"ok"`
+		TokenPath string `json:"token_path"`
+	}
+	if err := json.Unmarshal(delegateOut, &delegateResult); err != nil {
+		t.Fatalf("parse delegate output: %v\n%s", err, string(delegateOut))
+	}
+	if !delegateResult.OK || delegateResult.TokenPath == "" {
+		t.Fatalf("unexpected delegate output: %s", string(delegateOut))
+	}
+
+	evalDelegated := exec.Command(
+		binPath,
+		"gate", "eval",
+		"--policy", policyPath,
+		"--intent", intentPath,
+		"--delegation-token", delegateResult.TokenPath,
+		"--delegation-public-key", delegationPublicKeyPath,
+		"--key-mode", "prod",
+		"--private-key", tracePrivateKeyPath,
+		"--json",
+	)
+	evalDelegated.Dir = workDir
+	delegatedOut, err := evalDelegated.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected gate eval to reject delegation scope mismatch\n%s", string(delegatedOut))
+	}
+	if code := commandExitCode(t, err); code != 3 {
+		t.Fatalf("unexpected delegation scope mismatch exit code: got=%d want=3 output=%s", code, string(delegatedOut))
+	}
+	var delegatedResult struct {
+		OK               bool     `json:"ok"`
+		Verdict          string   `json:"verdict"`
+		ReasonCodes      []string `json:"reason_codes"`
+		ValidDelegations int      `json:"valid_delegations"`
+	}
+	if err := json.Unmarshal(delegatedOut, &delegatedResult); err != nil {
+		t.Fatalf("parse delegation scope mismatch output: %v\n%s", err, string(delegatedOut))
+	}
+	if !delegatedResult.OK || delegatedResult.Verdict != "block" {
+		t.Fatalf("unexpected delegation scope mismatch output: %s", string(delegatedOut))
+	}
+	if delegatedResult.ValidDelegations != 0 {
+		t.Fatalf("expected zero valid delegations for scope mismatch, got %#v", delegatedResult)
+	}
+	if !containsString(delegatedResult.ReasonCodes, "delegation_token_scope_mismatch") {
+		t.Fatalf("expected delegation_token_scope_mismatch reason, got: %#v", delegatedResult.ReasonCodes)
+	}
+}
+
 func TestCLIPolicyTestExitCodes(t *testing.T) {
 	root := repoRoot(t)
 	binPath := buildGaitBinary(t, root)

--- a/internal/scenarios/scenario_test.go
+++ b/internal/scenarios/scenario_test.go
@@ -345,7 +345,7 @@ func runDelegationScenario(t *testing.T, repoRoot string, binaryPath string, sce
 	if got.Verdict != expected.Verdict {
 		t.Fatalf("unexpected delegation verdict: got=%s want=%s output=%s", got.Verdict, expected.Verdict, output)
 	}
-	if expected.ValidDelegations > 0 && got.ValidDelegations != expected.ValidDelegations {
+	if got.ValidDelegations != expected.ValidDelegations {
 		t.Fatalf("unexpected valid_delegations: got=%d want=%d", got.ValidDelegations, expected.ValidDelegations)
 	}
 	for _, required := range expected.ReasonCodesMustInclude {

--- a/scenarios/gait/delegation-chain-depth-3/expected.yaml
+++ b/scenarios/gait/delegation-chain-depth-3/expected.yaml
@@ -1,5 +1,5 @@
 exit_code: 0
 verdict: allow
-valid_delegations: 1
+valid_delegations: 3
 reason_codes_must_include:
   - delegation_granted

--- a/scripts/test_hardening_acceptance.sh
+++ b/scripts/test_hardening_acceptance.sh
@@ -42,4 +42,4 @@ bash scripts/test_chaos_trace_uniqueness.sh
 
 echo "[hardening-acceptance] hardening integration and e2e checks"
 go test ./internal/integration -run 'TestConcurrentGateRateLimitStateIsDeterministic|TestConcurrentSessionAppendStateIsDeterministic|TestSessionSwarmContentionBudget|TestStopLatencySLOForEmergencyStopAcknowledgment|TestEmergencyStopBackpressureHasZeroPostStopSideEffects' -count=1
-go test ./internal/e2e -run 'TestCLIRegressExitCodes|TestCLIPolicyTestExitCodes|TestCLIDoctor|TestCLIDelegateAndGateRequireDelegationFlow|TestCLIStopLatencyAndEmergencyStopPreemption' -count=1
+go test ./internal/e2e -run 'TestCLIRegressExitCodes|TestCLIPolicyTestExitCodes|TestCLIDoctor|TestCLIDelegateAndGateRequireDelegationFlow|TestCLIGateRejectsPartialDelegationChain|TestCLIGateRejectsDelegationScopeMismatch|TestCLIStopLatencyAndEmergencyStopPreemption' -count=1

--- a/scripts/test_packspec_tck.sh
+++ b/scripts/test_packspec_tck.sh
@@ -37,6 +37,19 @@ echo "==> tck: valid run pack"
 "$BIN_PATH" pack build --type run --from "$WORK_DIR/gait-out/runpack_run_tck.zip" --out "$WORK_DIR/pack_run.zip" --json > "$WORK_DIR/pack_run_build.json"
 "$BIN_PATH" pack verify "$WORK_DIR/pack_run.zip" --json > "$WORK_DIR/pack_run_verify.json"
 
+echo "==> tck: wrong-key signature vector"
+"$BIN_PATH" keys init --out-dir "$WORK_DIR/keys_a" --prefix tck_a --json > "$WORK_DIR/keys_a.json"
+"$BIN_PATH" keys init --out-dir "$WORK_DIR/keys_b" --prefix tck_b --json > "$WORK_DIR/keys_b.json"
+"$BIN_PATH" pack build --type run --from "$WORK_DIR/gait-out/runpack_run_tck.zip" --out "$WORK_DIR/pack_run_signed.zip" --key-mode prod --private-key "$WORK_DIR/keys_a/tck_a_private.key" --json > "$WORK_DIR/pack_run_signed_build.json"
+set +e
+"$BIN_PATH" pack verify "$WORK_DIR/pack_run_signed.zip" --public-key "$WORK_DIR/keys_b/tck_b_public.key" --json > "$WORK_DIR/pack_run_wrong_key_verify.json"
+WRONG_KEY_CODE=$?
+set -e
+if [[ $WRONG_KEY_CODE -eq 0 ]]; then
+  echo "expected wrong-key pack verify to fail" >&2
+  exit 1
+fi
+
 echo "==> tck: valid job pack"
 "$BIN_PATH" job submit --id job_tck --root "$WORK_DIR/jobs" --json > "$WORK_DIR/job_submit.json"
 "$BIN_PATH" job checkpoint add --id job_tck --root "$WORK_DIR/jobs" --type decision-needed --summary "approval required" --required-action "approve" --json > "$WORK_DIR/job_checkpoint.json"
@@ -185,6 +198,11 @@ if legacy_run.get("verify", {}).get("legacy_type") != "runpack":
     raise SystemExit("legacy run verify did not report legacy_type=runpack")
 if legacy_guard.get("verify", {}).get("legacy_type") != "guard":
     raise SystemExit("legacy guard verify did not report legacy_type=guard")
+wrong_key = json.loads((work / "pack_run_wrong_key_verify.json").read_text(encoding="utf-8"))
+if wrong_key.get("ok") is not False:
+    raise SystemExit(f"wrong-key verify expected ok=false, got {wrong_key}")
+if wrong_key.get("verify", {}).get("signature_status") != "failed":
+    raise SystemExit(f"wrong-key verify expected signature_status=failed, got {wrong_key}")
 PY
 
 echo "packspec tck: pass"

--- a/scripts/test_script_intent_acceptance.sh
+++ b/scripts/test_script_intent_acceptance.sh
@@ -31,6 +31,7 @@ trap 'rm -rf "${TMP_DIR}"' EXIT
 WRKR_POLICY_PATH="${TMP_DIR}/policy_wrkr.yaml"
 APPROVAL_POLICY_PATH="${TMP_DIR}/policy_approval.yaml"
 SCRIPT_INTENT_PATH="${TMP_DIR}/intent_script.json"
+SCRIPT_INTENT_LOW_RISK_PATH="${TMP_DIR}/intent_script_low_risk.json"
 WRKR_INVENTORY_PATH="${TMP_DIR}/wrkr_inventory.json"
 REGISTRY_PATH="${TMP_DIR}/approved_scripts.json"
 TAMPERED_REGISTRY_PATH="${TMP_DIR}/approved_scripts_tampered.json"
@@ -130,6 +131,18 @@ cat >"${SCRIPT_INTENT_PATH}" <<'JSON'
   }
 }
 JSON
+
+python3 - <<'PY' "${SCRIPT_INTENT_PATH}" "${SCRIPT_INTENT_LOW_RISK_PATH}"
+from __future__ import annotations
+
+import json
+import pathlib
+import sys
+
+payload = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+payload["context"]["risk_class"] = "low"
+pathlib.Path(sys.argv[2]).write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+PY
 
 cat >"${WRKR_INVENTORY_PATH}" <<'JSON'
 [
@@ -257,6 +270,45 @@ assert payload.get("verdict") == "allow", payload
 assert payload.get("pre_approved") is True, payload
 assert payload.get("pattern_id"), payload
 assert payload.get("registry_reason") == "approved_script_match", payload
+PY
+
+echo "==> approved-script fast-path fail-closed when verify key is missing in high-risk mode"
+EVAL_MISSING_KEY_HIGH_EXIT="$(run_eval "${TMP_DIR}/eval_missing_key_high.json" --policy "${APPROVAL_POLICY_PATH}" --intent "${SCRIPT_INTENT_PATH}" --approved-script-registry "${REGISTRY_PATH}")"
+if [[ "${EVAL_MISSING_KEY_HIGH_EXIT}" -ne 3 ]]; then
+  echo "expected missing verify key fail-closed exit (3), got ${EVAL_MISSING_KEY_HIGH_EXIT}" >&2
+  exit 1
+fi
+python3 - <<'PY' "${TMP_DIR}/eval_missing_key_high.json"
+from __future__ import annotations
+
+import json
+import pathlib
+import sys
+
+payload = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+assert payload.get("ok") is False, payload
+assert "verify key required" in str(payload.get("error", "")), payload
+PY
+
+echo "==> approved-script fast-path disables without key in standard low-risk mode"
+EVAL_MISSING_KEY_LOW_EXIT="$(run_eval "${TMP_DIR}/eval_missing_key_low.json" --policy "${APPROVAL_POLICY_PATH}" --intent "${SCRIPT_INTENT_LOW_RISK_PATH}" --approved-script-registry "${REGISTRY_PATH}")"
+if [[ "${EVAL_MISSING_KEY_LOW_EXIT}" -ne 4 ]]; then
+  echo "expected missing verify key low-risk exit (4), got ${EVAL_MISSING_KEY_LOW_EXIT}" >&2
+  exit 1
+fi
+python3 - <<'PY' "${TMP_DIR}/eval_missing_key_low.json"
+from __future__ import annotations
+
+import json
+import pathlib
+import sys
+
+payload = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+assert payload.get("ok") is True, payload
+assert payload.get("verdict") == "require_approval", payload
+assert payload.get("pre_approved") is not True, payload
+warnings = payload.get("warnings") or []
+assert any("registry verify key is not configured" in str(item) for item in warnings), payload
 PY
 
 echo "==> approved-script fail-closed on signature mismatch"


### PR DESCRIPTION
## Problem
- delegation intent and boundary enforcement needed stronger fail-closed behavior so indirect execution paths cannot silently bypass policy checks
- pack and script intent surfaces needed regression coverage to keep the boundary deterministic across CLI, e2e, and acceptance flows
- docs and compatibility references needed to match the tightened contract

## Changes
- harden delegation intent normalization and boundary evaluation in the gate path
- add CLI, core, scenario, acceptance, and e2e coverage for delegation-chain and script-intent fail-closed behavior
- update README and contract docs to reflect the stricter boundary behavior and test coverage expectations

## Validation
- `./gait doctor --json`
- `make prepush-full`
- repo pre-push hook on `git push -u origin codex/adhoc-fail-closed-boundary-hardening`
