### PR TITLE
hotfix: release stabilization v1.3.3 (r1)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,6 +137,9 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
+      - name: Configure repo hooks path
+        run: |
+          git config core.hooksPath .githooks
       - name: Run release hardening gate
         run: |
           bash scripts/test_claude_code_hook_contract.sh


### PR DESCRIPTION
## Problem
The `v1.3.3` release workflow failed in `hardening_gate` on GitHub Actions.

## Root Cause
`make test-hardening-acceptance` enforces `core.hooksPath=.githooks`, but the release workflow did not configure the repo hooks path before running the hardening suite. Regular CI already performs that setup.

## Fix
- add a `Configure repo hooks path` step to `.github/workflows/release.yml`
- set `git config core.hooksPath .githooks` before `make test-hardening-acceptance`

## Validation
- `git config core.hooksPath .githooks && bash scripts/test_claude_code_hook_contract.sh && make test-hardening-acceptance`
- `make prepush-full`
