### PR TITLE
perf: restore release benchmark budgets

### DIFF
--- a/core/mcp/proxy.go
+++ b/core/mcp/proxy.go
@@ -1,6 +1,7 @@
 package mcp
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -252,22 +253,38 @@ func DecodeToolCall(adapter string, payload []byte) (ToolCall, error) {
 }
 
 func decodeOpenAIToolCall(payload []byte) (ToolCall, error) {
-	var envelope struct {
-		Type     string `json:"type"`
+	var stringEnvelope struct {
 		Function struct {
 			Name      string `json:"name"`
-			Arguments any    `json:"arguments"`
+			Arguments string `json:"arguments"`
 		} `json:"function"`
 	}
-	if err := json.Unmarshal(payload, &envelope); err != nil {
+	if err := json.Unmarshal(payload, &stringEnvelope); err == nil {
+		args, decodeErr := decodeJSONStringArguments(stringEnvelope.Function.Arguments)
+		if decodeErr != nil {
+			return ToolCall{}, fmt.Errorf("decode openai arguments: %w", decodeErr)
+		}
+		return ToolCall{
+			Name: stringEnvelope.Function.Name,
+			Args: args,
+		}, nil
+	}
+
+	var rawEnvelope struct {
+		Function struct {
+			Name      string          `json:"name"`
+			Arguments json.RawMessage `json:"arguments"`
+		} `json:"function"`
+	}
+	if err := json.Unmarshal(payload, &rawEnvelope); err != nil {
 		return ToolCall{}, fmt.Errorf("parse openai tool call: %w", err)
 	}
-	args, err := decodeArguments(envelope.Function.Arguments)
+	args, err := decodeRawArguments(rawEnvelope.Function.Arguments)
 	if err != nil {
 		return ToolCall{}, fmt.Errorf("decode openai arguments: %w", err)
 	}
 	return ToolCall{
-		Name: envelope.Function.Name,
+		Name: rawEnvelope.Function.Name,
 		Args: args,
 	}, nil
 }
@@ -560,6 +577,52 @@ func decodeArguments(raw any) (map[string]any, error) {
 			return nil, err
 		}
 		return parsed, nil
+	}
+}
+
+func decodeJSONStringArguments(encoded string) (map[string]any, error) {
+	if strings.TrimSpace(encoded) == "" {
+		return map[string]any{}, nil
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(encoded), &parsed); err != nil {
+		return nil, err
+	}
+	return parsed, nil
+}
+
+func decodeRawArguments(raw json.RawMessage) (map[string]any, error) {
+	raw = bytes.TrimSpace(raw)
+	if len(raw) == 0 || bytes.Equal(raw, []byte("null")) {
+		return map[string]any{}, nil
+	}
+
+	switch raw[0] {
+	case '{':
+		var parsed map[string]any
+		if err := json.Unmarshal(raw, &parsed); err != nil {
+			return nil, err
+		}
+		return parsed, nil
+	case '"':
+		var encoded string
+		if err := json.Unmarshal(raw, &encoded); err != nil {
+			return nil, err
+		}
+		if strings.TrimSpace(encoded) == "" {
+			return map[string]any{}, nil
+		}
+		var parsed map[string]any
+		if err := json.Unmarshal([]byte(encoded), &parsed); err != nil {
+			return nil, err
+		}
+		return parsed, nil
+	default:
+		var decoded any
+		if err := json.Unmarshal(raw, &decoded); err != nil {
+			return nil, err
+		}
+		return decodeArguments(decoded)
 	}
 }
 

--- a/core/mcp/proxy_test.go
+++ b/core/mcp/proxy_test.go
@@ -97,6 +97,38 @@ func TestDecodeToolCallAdapters(t *testing.T) {
 	}
 }
 
+func TestDecodeToolCallOpenAIArgumentShapes(t *testing.T) {
+	objectPayload := []byte(`{
+  "type": "function",
+  "function": {
+    "name": "tool.fetch",
+    "arguments": {"url":"https://example.local/object"}
+  }
+}`)
+	call, err := DecodeToolCall("openai", objectPayload)
+	if err != nil {
+		t.Fatalf("decode openai object arguments: %v", err)
+	}
+	if call.Name != "tool.fetch" || call.Args["url"] != "https://example.local/object" {
+		t.Fatalf("unexpected openai object call: %#v", call)
+	}
+
+	nullPayload := []byte(`{
+  "type": "function",
+  "function": {
+    "name": "tool.noop",
+    "arguments": null
+  }
+}`)
+	call, err = DecodeToolCall("openai", nullPayload)
+	if err != nil {
+		t.Fatalf("decode openai null arguments: %v", err)
+	}
+	if call.Name != "tool.noop" || len(call.Args) != 0 {
+		t.Fatalf("unexpected openai null-args call: %#v", call)
+	}
+}
+
 func TestDecodeToolCallClaudeCodeFallbackNameAndTargets(t *testing.T) {
 	payload := []byte(`{
   "tool_name":"NotebookEdit",

--- a/core/runpack/diff.go
+++ b/core/runpack/diff.go
@@ -3,6 +3,7 @@ package runpack
 import (
 	"encoding/json"
 	"fmt"
+	"reflect"
 	"sort"
 	"time"
 
@@ -58,24 +59,6 @@ func DiffRunpacks(leftPath, rightPath string, privacy DiffPrivacy) (DiffResult, 
 	leftManifest := normalizeManifest(left.Manifest)
 	rightManifest := normalizeManifest(right.Manifest)
 
-	leftManifestJSON, err := json.Marshal(leftManifest)
-	if err != nil {
-		return DiffResult{}, err
-	}
-	rightManifestJSON, err := json.Marshal(rightManifest)
-	if err != nil {
-		return DiffResult{}, err
-	}
-
-	leftManifestDigest, err := digestNormalized(leftManifestJSON)
-	if err != nil {
-		return DiffResult{}, err
-	}
-	rightManifestDigest, err := digestNormalized(rightManifestJSON)
-	if err != nil {
-		return DiffResult{}, err
-	}
-
 	filesChanged := diffManifestFiles(left.Manifest.Files, right.Manifest.Files)
 
 	intentsChanged, leftOnlyIntents, rightOnlyIntents, err := diffRecords(left.Intents, right.Intents, privacy)
@@ -92,19 +75,17 @@ func DiffRunpacks(leftPath, rightPath string, privacy DiffPrivacy) (DiffResult, 
 	leftRefs := normalizeRefs(left.Refs)
 	rightRefs := normalizeRefs(right.Refs)
 	if privacy == DiffPrivacyFull {
-		refsChanged, err = jsonDiff(leftRefs, rightRefs)
-		if err != nil {
-			return DiffResult{}, err
+		if reflect.DeepEqual(leftRefs, rightRefs) {
+			contextDriftClassification = "none"
+		} else {
+			classification, changed, runtimeOnly, classifyErr := contextproof.ClassifyRefsDrift(left.Refs, right.Refs)
+			if classifyErr != nil {
+				return DiffResult{}, classifyErr
+			}
+			refsChanged = changed
+			contextDriftClassification = classification
+			contextRuntimeOnly = runtimeOnly
 		}
-		classification, changed, runtimeOnly, classifyErr := contextproof.ClassifyRefsDrift(left.Refs, right.Refs)
-		if classifyErr != nil {
-			return DiffResult{}, classifyErr
-		}
-		contextDriftClassification = classification
-		if changed {
-			refsChanged = true
-		}
-		contextRuntimeOnly = runtimeOnly
 	} else {
 		refsChanged = len(leftRefs.Receipts) != len(rightRefs.Receipts)
 		contextDriftClassification = "none"
@@ -113,7 +94,7 @@ func DiffRunpacks(leftPath, rightPath string, privacy DiffPrivacy) (DiffResult, 
 	summary := DiffSummary{
 		RunIDLeft:                  left.Run.RunID,
 		RunIDRight:                 right.Run.RunID,
-		ManifestChanged:            leftManifestDigest != rightManifestDigest,
+		ManifestChanged:            !reflect.DeepEqual(leftManifest, rightManifest),
 		FilesChanged:               filesChanged,
 		IntentsChanged:             intentsChanged,
 		ResultsChanged:             resultsChanged,
@@ -227,26 +208,6 @@ func diffKeys(left, right map[string]struct{}) []string {
 
 func digestNormalized(raw []byte) (string, error) {
 	return jcs.DigestJCS(raw)
-}
-
-func jsonDiff(left, right any) (bool, error) {
-	leftRaw, err := json.Marshal(left)
-	if err != nil {
-		return false, err
-	}
-	rightRaw, err := json.Marshal(right)
-	if err != nil {
-		return false, err
-	}
-	leftDigest, err := digestNormalized(leftRaw)
-	if err != nil {
-		return false, err
-	}
-	rightDigest, err := digestNormalized(rightRaw)
-	if err != nil {
-		return false, err
-	}
-	return leftDigest != rightDigest, nil
 }
 
 func recordKey(record any) (string, error) {


### PR DESCRIPTION
Problem
Release preflight for the next cut stopped in Phase 0 because `make bench-check` failed on two benchmark budget regressions.

Changes
- speed up runpack diffing by avoiding redundant manifest and refs hashing work when normalized structures are already equal
- add a faster OpenAI tool-call decode path for the common string-encoded `function.arguments` payload shape while keeping safe fallback handling for object and `null` arguments
- extend MCP tests to cover the added OpenAI argument shapes

Validation
- `./gait doctor --json`
- `make bench-check`
- `make prepush-full`
