### PR TITLE
fix: unblock release guard pack benchmarks

### DIFF
--- a/core/guard/incident.go
+++ b/core/guard/incident.go
@@ -84,7 +84,7 @@ func BuildIncidentPack(options IncidentPackOptions) (IncidentPackResult, error) 
 		return IncidentPackResult{}, fmt.Errorf("encode policy digests: %w", err)
 	}
 
-	buildResult, err := BuildPack(BuildOptions{
+	buildResult, err := buildPackWithRunpack(BuildOptions{
 		RunpackPath:             runpackPath,
 		OutputPath:              options.OutputPath,
 		CaseID:                  options.CaseID,
@@ -105,7 +105,7 @@ func BuildIncidentPack(options IncidentPackOptions) (IncidentPackResult, error) 
 		},
 		AutoDiscoverV12: false,
 		ProducerVersion: options.ProducerVersion,
-	})
+	}, data)
 	if err != nil {
 		return IncidentPackResult{}, err
 	}

--- a/core/guard/pack.go
+++ b/core/guard/pack.go
@@ -97,7 +97,10 @@ func BuildPack(options BuildOptions) (BuildResult, error) {
 	if err != nil {
 		return BuildResult{}, fmt.Errorf("read runpack: %w", err)
 	}
+	return buildPackWithRunpack(options, runpackData)
+}
 
+func buildPackWithRunpack(options BuildOptions, runpackData runpack.Runpack) (BuildResult, error) {
 	evidenceFiles := map[string][]byte{}
 	runpackSummary, err := buildRunpackSummary(runpackData)
 	if err != nil {
@@ -320,16 +323,18 @@ func VerifyPack(path string) (VerifyResult, error) {
 }
 
 func VerifyPackWithOptions(path string, opts VerifyOptions) (VerifyResult, error) {
-	zipReader, err := zip.OpenReader(path)
+	zipReader, zipCloser, err := openPackZip(path)
 	if err != nil {
 		return VerifyResult{}, fmt.Errorf("open evidence pack zip: %w", err)
 	}
-	defer func() {
-		_ = zipReader.Close()
-	}()
+	if zipCloser != nil {
+		defer func() {
+			_ = zipCloser.Close()
+		}()
+	}
 
 	var files map[string]*zip.File
-	if len(zipReader.File) > 16 {
+	if len(zipReader.File) > 4 {
 		files = make(map[string]*zip.File, len(zipReader.File))
 		for _, zipFile := range zipReader.File {
 			files[zipFile.Name] = zipFile
@@ -423,6 +428,28 @@ func VerifyPackWithOptions(path string, opts VerifyOptions) (VerifyResult, error
 	}
 	sort.Strings(result.SignatureErrors)
 	return result, nil
+}
+
+const maxInMemoryPackVerifyBytes = 1 << 20
+
+func openPackZip(path string) (*zip.Reader, io.Closer, error) {
+	info, err := os.Stat(path)
+	if err == nil && info.Size() > 0 && info.Size() <= maxInMemoryPackVerifyBytes {
+		// #nosec G304 -- verify path is an explicit local artifact selected by the caller.
+		packBytes, readErr := os.ReadFile(path)
+		if readErr == nil {
+			zipReader, zipErr := zip.NewReader(bytes.NewReader(packBytes), int64(len(packBytes)))
+			if zipErr == nil {
+				return zipReader, nil, nil
+			}
+		}
+	}
+
+	zipReader, err := zip.OpenReader(path)
+	if err != nil {
+		return nil, nil, err
+	}
+	return &zipReader.Reader, zipReader, nil
 }
 
 func findZipFile(all []*zip.File, indexed map[string]*zip.File, name string) *zip.File {


### PR DESCRIPTION
Problem
The release hotfix branch was blocked in pre-tag validation because the guard pack benchmarks regressed past the `make bench-check` envelope, specifically `BenchmarkVerifyPackTypical` and `BenchmarkBuildIncidentPackTypical`.

Changes
- reuse the already-loaded runpack when building incident packs so the incident path does not reread the same artifact
- add a small-pack verify fast path that opens tiny evidence zips in memory
- index small pack entries earlier in verification to cut repeated lookup cost
- annotate the new local artifact read for the existing gosec policy

Validation
- `gait doctor --json`
- `make prepush-full`
- targeted benchmark reruns during remediation
- `make bench-check`
- `make test-v2-4-acceptance`
- `make test-release-smoke`
