### PR TITLE
ci: migrate workflow runtime baseline and update codeowners

### DIFF
--- a/.github/workflows/adoption-nightly.yml
+++ b/.github/workflows/adoption-nightly.yml
@@ -13,11 +13,11 @@ jobs:
   nightly-validation:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.13"
       - uses: astral-sh/setup-uv@v5

--- a/.github/workflows/adoption-regress-template.yml
+++ b/.github/workflows/adoption-regress-template.yml
@@ -65,9 +65,9 @@ jobs:
       SOURCE_RUN: ${{ inputs.source_run || github.event.inputs.source_run || 'run_demo' }}
       ARTIFACT_ROOT: gait-out/adoption_regress
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     outputs:
       adoption_critical: ${{ steps.filter.outputs.adoption_critical }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dorny/paths-filter@v3
         id: filter
         with:
@@ -51,11 +51,11 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
       - name: Install uv
@@ -88,7 +88,7 @@ jobs:
     needs: changes
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
         with:
           node-version: "22"
@@ -121,7 +121,7 @@ jobs:
     needs: changes
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
         with:
           node-version: "22"
@@ -142,8 +142,8 @@ jobs:
     needs: changes
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
       - name: Run UI e2e smoke
@@ -155,8 +155,8 @@ jobs:
     needs: changes
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
       - name: Run local UI acceptance gate
@@ -172,11 +172,11 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
       - name: Install uv
@@ -219,11 +219,11 @@ jobs:
       matrix:
         python-version: ["3.11", "3.13"]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install uv
@@ -247,8 +247,8 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
       - name: E2E tests
@@ -259,11 +259,11 @@ jobs:
     needs: changes
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
       - name: V1 acceptance checks
@@ -274,11 +274,11 @@ jobs:
     needs: changes
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
       - name: V1.6 wedge acceptance checks
@@ -289,11 +289,11 @@ jobs:
     needs: changes
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
       - name: V1.7 wedge acceptance checks
@@ -304,11 +304,11 @@ jobs:
     needs: changes
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
       - name: V1.8 wedge acceptance checks
@@ -319,11 +319,11 @@ jobs:
     needs: changes
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
       - name: Script intent governance acceptance checks
@@ -334,11 +334,11 @@ jobs:
     needs: changes
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
       - name: Release smoke checks
@@ -353,8 +353,8 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
       - name: Install script smoke checks
@@ -378,11 +378,11 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
       - name: Contract and compatibility checks
@@ -396,8 +396,8 @@ jobs:
     needs: changes
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
       - name: Run policy compliance fixture suite
@@ -417,11 +417,11 @@ jobs:
     needs: changes
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
       - name: Install uv
@@ -445,11 +445,11 @@ jobs:
     if: github.event_name != 'pull_request' || needs.changes.outputs.adoption_critical == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
       - name: Run v2.3 acceptance gate
@@ -471,11 +471,11 @@ jobs:
     if: github.event_name != 'pull_request' || needs.changes.outputs.adoption_critical == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
       - name: Run v2.4 acceptance gate
@@ -488,11 +488,11 @@ jobs:
     if: github.event_name != 'pull_request' || needs.changes.outputs.adoption_critical == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
       - name: Run v2.5 acceptance gate
@@ -504,11 +504,11 @@ jobs:
     needs: changes
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
       - name: Run v2.6 acceptance gate
@@ -521,11 +521,11 @@ jobs:
     if: github.event_name != 'pull_request' || needs.changes.outputs.adoption_critical == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
       - name: Run voice acceptance gate
@@ -538,11 +538,11 @@ jobs:
     if: github.event_name != 'pull_request' || needs.changes.outputs.adoption_critical == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
       - name: Run context conformance gate
@@ -555,11 +555,11 @@ jobs:
     if: github.event_name != 'pull_request' || needs.changes.outputs.adoption_critical == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
       - name: Run context chaos gate
@@ -571,11 +571,11 @@ jobs:
     needs: changes
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
       - name: Run PackSpec TCK lane
@@ -587,11 +587,11 @@ jobs:
     needs: changes
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
       - name: Install uv
@@ -605,8 +605,8 @@ jobs:
     needs: changes
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
       - name: Run ecosystem contribution/release automation checks
@@ -624,11 +624,11 @@ jobs:
     needs: changes
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
       - name: Run skill supply-chain suite
@@ -640,8 +640,8 @@ jobs:
     needs: changes
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
       - name: Run hardening suite
@@ -654,8 +654,8 @@ jobs:
     needs: changes
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
       - name: Run chaos suite
@@ -668,11 +668,11 @@ jobs:
     needs: changes
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
       - name: Run runtime SLO budget suite
@@ -685,8 +685,8 @@ jobs:
     needs: changes
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
       - name: Build

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,20 +25,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.13"
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: go,python
           queries: security-and-quality
@@ -48,4 +48,4 @@ jobs:
           go build ./...
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/hardening-nightly.yml
+++ b/.github/workflows/hardening-nightly.yml
@@ -15,8 +15,8 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
       - name: Run hardening suite

--- a/.github/workflows/intent-receipt-conformance.yml
+++ b/.github/workflows/intent-receipt-conformance.yml
@@ -28,8 +28,8 @@ jobs:
   conformance:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
       - name: Build gait

--- a/.github/workflows/live-connectors.yml
+++ b/.github/workflows/live-connectors.yml
@@ -13,11 +13,11 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.13"
       - uses: astral-sh/setup-uv@v5

--- a/.github/workflows/nightly-full-windows.yml
+++ b/.github/workflows/nightly-full-windows.yml
@@ -13,11 +13,11 @@ jobs:
     name: nightly-full-windows-lint
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.13"
       - name: Install uv
@@ -34,11 +34,11 @@ jobs:
     name: nightly-full-windows-test
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.13"
       - name: Install uv
@@ -72,8 +72,8 @@ jobs:
     name: nightly-full-windows-e2e
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
       - name: E2E tests
@@ -85,11 +85,11 @@ jobs:
     name: nightly-full-windows-contracts
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.13"
       - name: Contract and compatibility checks

--- a/.github/workflows/perf-nightly.yml
+++ b/.github/workflows/perf-nightly.yml
@@ -13,11 +13,11 @@ jobs:
   perf:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.13"
       - name: Run benchmarks

--- a/.github/workflows/pr-fast.yml
+++ b/.github/workflows/pr-fast.yml
@@ -18,11 +18,11 @@ jobs:
     name: pr-fast-lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
       - name: Install uv
@@ -39,11 +39,11 @@ jobs:
     name: pr-fast-test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
       - name: Install uv
@@ -71,11 +71,11 @@ jobs:
       matrix:
         python-version: ["3.11", "3.13"]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install uv
@@ -97,11 +97,11 @@ jobs:
     runs-on: windows-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
       - name: Install uv

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,11 +17,11 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
       - name: Run v2.3 acceptance gate
@@ -42,11 +42,11 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
       - name: Run v2.4 release contract gate
@@ -64,11 +64,11 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
       - name: Run v2.5 release contract gate
@@ -86,11 +86,11 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
       - name: Run v2.6 release contract gate
@@ -105,11 +105,11 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install uv
@@ -130,11 +130,11 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
       - name: Configure repo hooks path
@@ -152,16 +152,16 @@ jobs:
       contents: write
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
       - name: Add Go bin to PATH
         run: |
           echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
       - name: Install goreleaser
@@ -207,8 +207,8 @@ jobs:
       contents: write
       id-token: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
       - name: Add Go bin to PATH

--- a/.github/workflows/ui-nightly.yml
+++ b/.github/workflows/ui-nightly.yml
@@ -13,8 +13,8 @@ jobs:
   ui-e2e-smoke:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
       - name: Run UI e2e smoke
@@ -24,11 +24,11 @@ jobs:
   ui-perf-budgets:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.13"
       - name: Run UI performance budgets

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,13 +1,13 @@
 # Default owner for all paths.
-* @davidahmann
+* @davidahmann @ryshman
 
 # Core CLI/policy/artifact enforcement paths.
-/cmd/gait/** @davidahmann
-/core/** @davidahmann
-/schemas/** @davidahmann
+/cmd/gait/** @davidahmann @ryshman
+/core/** @davidahmann @ryshman
+/schemas/** @davidahmann @ryshman
 
 # Scenario fixtures are contract artifacts and require explicit owner review.
 # Changes under /scenarios/ should be reviewed for expected behavior drift.
-/scenarios/ @davidahmann
+/scenarios/ @davidahmann @ryshman
 
-/.github/workflows/** @davidahmann
+/.github/workflows/** @davidahmann @ryshman

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,6 +48,24 @@ make hooks
 Install guide: <https://codeql.github.com/docs/codeql-cli/getting-started-with-the-codeql-cli/>.
 Emergency bypass (not recommended for normal flow): `GAIT_SKIP_CODEQL=1 git push`.
 
+## GitHub Actions runtime policy
+
+Keep monitored GitHub Actions references on the repo's Node 24-safe baseline:
+
+- `actions/checkout@v5` or newer
+- `actions/setup-go@v6` or newer
+- `actions/setup-python@v6` or newer
+- `github/codeql-action/init@v4` and `github/codeql-action/analyze@v4` or newer
+
+Validate that baseline locally before opening a PR:
+
+```
+python3 scripts/check_github_action_runtime_versions.py .github/workflows docs/adopt_in_one_pr.md
+```
+
+`make lint-fast` and `make lint` run the same guard through `scripts/check_repo_hygiene.sh`, so runtime deprecations fail before longer suites.
+Do not rely on `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` or `ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true` as the default fix path; keep those as emergency-only compatibility levers while the action pin is being updated.
+
 ## Branch protection and required checks
 
 `main` is expected to be PR-only with required checks. Apply/update the repository defaults with:
@@ -63,6 +81,8 @@ This config enforces:
 - strict required status checks (`pr-fast-lint`, `pr-fast-test`, `codeql-scan`)
 - PR flow with `0` required approvals (solo-maintainer-safe)
 
+Treat those required status check names as part of the repo contract when modernizing workflows. Action-major upgrades should preserve them unless the same change intentionally updates branch-protection expectations.
+
 When at least two maintainers are active, raise governance to require approval plus CODEOWNERS review:
 
 ```
@@ -75,6 +95,7 @@ make github-guardrails-strict
 
 - required planning docs under `product/` stay tracked in Git
 - generated artifacts (for example `gait-out/*`, coverage files, local binaries) are not committed
+- monitored GitHub Actions references stay on the supported runtime baseline
 
 If it fails, remove tracked generated files with `git rm --cached <path>` and re-run lint.
 

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ BENCH_REGEX := Benchmark(EvaluatePolicyTypical|VerifyZipTypical|DiffRunpacksTypi
 BENCH_OUTPUT ?= perf/bench_output.txt
 BENCH_BASELINE ?= perf/bench_baseline.json
 
-.PHONY: fmt lint lint-fast codeql test test-fast test-scenarios prepush prepush-full github-guardrails github-guardrails-strict test-hardening test-hardening-acceptance test-chaos test-e2e test-acceptance test-v1-6-acceptance test-v1-7-acceptance test-v1-8-acceptance test-v2-3-acceptance test-v2-4-acceptance test-v2-5-acceptance test-v2-6-acceptance test-voice-acceptance test-context-conformance test-context-chaos test-packspec-tck test-script-intent-acceptance test-ui-acceptance test-ui-unit test-ui-e2e-smoke test-ui-perf test-claude-code-hook-contract test-adoption test-adapter-parity test-ecosystem-automation test-release-smoke test-install test-install-path-versions test-contracts test-intent-receipt-conformance test-ci-regress-template test-ci-portability-templates test-live-connectors test-skill-supply-chain test-runtime-slo test-ent-consumer-contract test-uat-local test-openclaw-skill-install test-beads-bridge test-docs-storyline test-docs-consistency test-demo-recording openclaw-skill-install build bench bench-check bench-budgets context-budgets skills-validate ecosystem-validate ecosystem-release-notes demo-90s demo-hero-gif homebrew-formula wiki-publish tool-allowlist-policy ui-build ui-sync ui-deps-check
+.PHONY: fmt lint lint-fast codeql test test-fast test-scenarios prepush prepush-full github-guardrails github-guardrails-strict test-hardening test-hardening-acceptance test-chaos test-e2e test-acceptance test-v1-6-acceptance test-v1-7-acceptance test-v1-8-acceptance test-v2-3-acceptance test-v2-4-acceptance test-v2-5-acceptance test-v2-6-acceptance test-voice-acceptance test-context-conformance test-context-chaos test-packspec-tck test-script-intent-acceptance test-ui-acceptance test-ui-unit test-ui-e2e-smoke test-ui-perf test-claude-code-hook-contract test-adoption test-adapter-parity test-ecosystem-automation test-release-smoke test-install test-install-path-versions test-contracts test-intent-receipt-conformance test-ci-regress-template test-ci-portability-templates test-live-connectors test-skill-supply-chain test-runtime-slo test-ent-consumer-contract test-uat-local test-openclaw-skill-install test-beads-bridge test-docs-storyline test-docs-consistency test-demo-recording test-github-action-runtime-guard openclaw-skill-install build bench bench-check bench-budgets context-budgets skills-validate ecosystem-validate ecosystem-release-notes demo-90s demo-hero-gif homebrew-formula wiki-publish tool-allowlist-policy ui-build ui-sync ui-deps-check
 .PHONY: hooks
 .PHONY: docs-site-install docs-site-build docs-site-lint docs-site-check
 
@@ -61,10 +61,12 @@ test:
 	$(GO) test $(GO_COVERAGE_PACKAGES) -coverprofile=coverage-go.out
 	$(PYTHON) scripts/check_go_coverage.py coverage-go.out $(GO_COVERAGE_THRESHOLD)
 	(cd $(SDK_DIR) && PYTHONPATH=. uv run --python $(UV_PY) --extra dev pytest --cov=gait --cov-report=term-missing --cov-fail-under=$(PYTHON_COVERAGE_THRESHOLD))
+	bash scripts/test_github_action_runtime_versions.sh
 
 test-fast:
 	$(GO) test ./...
 	(cd $(SDK_DIR) && PYTHONPATH=. uv run --python $(UV_PY) --extra dev pytest)
+	bash scripts/test_github_action_runtime_versions.sh
 
 test-scenarios:
 	$(GO) test ./internal/scenarios -count=1 -tags=scenario -v
@@ -210,6 +212,9 @@ test-ci-regress-template: build
 
 test-ci-portability-templates: build
 	bash scripts/test_ci_portability_templates.sh
+
+test-github-action-runtime-guard:
+	bash scripts/test_github_action_runtime_versions.sh
 
 test-ent-consumer-contract: build
 	bash scripts/test_ent_consumer_contract.sh ./gait

--- a/docs/README.md
+++ b/docs/README.md
@@ -72,6 +72,7 @@ Extended first-class surfaces:
 - Prime-time runbook: `docs/hardening/prime_time_runbook.md`
 - Runtime SLOs: `docs/slo/runtime_slo.md`
 - Retention profiles: `docs/slo/retention_profiles.md`
+- Maintainer CI/runtime policy and local workflow guard: `CONTRIBUTING.md`
 - CI regress runbook: `docs/ci_regress_kit.md`
 - One-PR adoption page: `docs/adopt_in_one_pr.md`
 - Threat model: `docs/threat_model.md`
@@ -108,4 +109,5 @@ Extended first-class surfaces:
 
 - Docs site source: `docs-site/`
 - Docs deployment workflow: `.github/workflows/docs.yml`
+- Local workflow runtime guard: `python3 scripts/check_github_action_runtime_versions.py .github/workflows docs/adopt_in_one_pr.md`
 - Wiki publish script: `scripts/publish_wiki.sh`

--- a/docs/adopt_in_one_pr.md
+++ b/docs/adopt_in_one_pr.md
@@ -30,7 +30,7 @@ jobs:
   regress-gate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install gait
         shell: bash
@@ -151,6 +151,12 @@ Expected PR behavior:
   - `junit.xml`
 
 If you want a passing lane after validating setup, remove the forced-drift step.
+
+Maintainer runtime policy:
+
+- Keep published GitHub Actions examples on the repo's Node 24-safe baseline, including `actions/checkout@v5` or newer.
+- Run `python3 scripts/check_github_action_runtime_versions.py .github/workflows docs/adopt_in_one_pr.md` before opening a PR that changes workflow YAML or this example.
+- Treat `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` and `ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true` as emergency-only compatibility toggles, not the normal remediation path.
 
 Local hook reminder:
 

--- a/scripts/check_github_action_runtime_versions.py
+++ b/scripts/check_github_action_runtime_versions.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+
+@dataclass(frozen=True)
+class Rule:
+    minimum_major: int
+
+
+@dataclass(frozen=True)
+class Violation:
+    path: str
+    line: int
+    reference: str
+    message: str
+
+
+RULES: dict[str, Rule] = {
+    "actions/checkout": Rule(minimum_major=5),
+    "actions/setup-go": Rule(minimum_major=6),
+    "actions/setup-python": Rule(minimum_major=6),
+    "github/codeql-action/init": Rule(minimum_major=4),
+    "github/codeql-action/analyze": Rule(minimum_major=4),
+}
+
+USES_PATTERN = re.compile(
+    r"uses:\s*['\"]?([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+(?:/[A-Za-z0-9_.-]+)?@[^ \t\r\n#'\"]+)"
+)
+MAJOR_PATTERN = re.compile(r"^v(?P<major>[0-9]+)(?:[._-].*)?$")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Fail deterministically when monitored GitHub Actions references use deprecated "
+            "runtime-backed major versions."
+        )
+    )
+    parser.add_argument(
+        "paths",
+        nargs="+",
+        help="Workflow directories or files to scan for monitored GitHub Actions references.",
+    )
+    return parser.parse_args()
+
+
+def iter_files(paths: Iterable[str]) -> list[Path]:
+    expanded: set[Path] = set()
+    for raw_path in paths:
+        path = Path(raw_path)
+        if not path.exists():
+            raise SystemExit(f"workflow runtime guard: path does not exist: {raw_path}")
+        if path.is_dir():
+            for candidate in sorted(child for child in path.rglob("*") if child.is_file()):
+                expanded.add(candidate)
+            continue
+        expanded.add(path)
+    return sorted(expanded)
+
+
+def parse_major(reference: str) -> int | None:
+    match = MAJOR_PATTERN.match(reference)
+    if match is None:
+        return None
+    return int(match.group("major"))
+
+
+def scan_file(path: Path) -> list[Violation]:
+    violations: list[Violation] = []
+    for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        for match in USES_PATTERN.finditer(line):
+            reference = match.group(1)
+            action_name, version_ref = reference.split("@", 1)
+            rule = RULES.get(action_name)
+            if rule is None:
+                continue
+            major = parse_major(version_ref)
+            if major is None:
+                violations.append(
+                    Violation(
+                        path=str(path),
+                        line=line_number,
+                        reference=reference,
+                        message=(
+                            f"unsupported monitored ref format; require {action_name}@v"
+                            f"{rule.minimum_major}+"
+                        ),
+                    )
+                )
+                continue
+            if major < rule.minimum_major:
+                violations.append(
+                    Violation(
+                        path=str(path),
+                        line=line_number,
+                        reference=reference,
+                        message=(
+                            f"deprecated major v{major}; require {action_name}@v"
+                            f"{rule.minimum_major}+"
+                        ),
+                    )
+                )
+    return violations
+
+
+def main() -> int:
+    args = parse_args()
+    files = iter_files(args.paths)
+    violations: list[Violation] = []
+    for path in files:
+        violations.extend(scan_file(path))
+
+    if violations:
+        print("workflow runtime guard: fail")
+        for violation in sorted(violations, key=lambda item: (item.path, item.line, item.reference)):
+            print(
+                f"{violation.path}:{violation.line}: {violation.reference}: {violation.message}"
+            )
+        return 1
+
+    print(f"workflow runtime guard: pass ({len(files)} files scanned)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_repo_hygiene.sh
+++ b/scripts/check_repo_hygiene.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+REPO_ROOT="${GAIT_REPO_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+cd "${REPO_ROOT}"
+
 if ! command -v git >/dev/null 2>&1; then
   echo "[repo-hygiene] git is required"
   exit 1
@@ -61,3 +64,5 @@ if [[ "${#tracked_generated[@]}" -gt 0 ]]; then
   echo "  git rm --cached <path>"
   exit 1
 fi
+
+python3 scripts/check_github_action_runtime_versions.py .github/workflows docs/adopt_in_one_pr.md

--- a/scripts/test_github_action_runtime_versions.sh
+++ b/scripts/test_github_action_runtime_versions.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT_PATH="${REPO_ROOT}/scripts/check_github_action_runtime_versions.py"
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "${WORK_DIR}"' EXIT
+
+assert_eq() {
+  local actual="$1"
+  local expected="$2"
+  local message="$3"
+  if [[ "${actual}" != "${expected}" ]]; then
+    echo "${message}" >&2
+    echo "expected:" >&2
+    printf '%s\n' "${expected}" >&2
+    echo "actual:" >&2
+    printf '%s\n' "${actual}" >&2
+    exit 1
+  fi
+}
+
+assert_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local message="$3"
+  if [[ "${haystack}" != *"${needle}"* ]]; then
+    echo "${message}" >&2
+    echo "missing fragment: ${needle}" >&2
+    exit 1
+  fi
+}
+
+mkdir -p "${WORK_DIR}/pass/.github/workflows" "${WORK_DIR}/pass/docs"
+cat > "${WORK_DIR}/pass/.github/workflows/core.yml" <<'EOF'
+name: core
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
+      - uses: actions/setup-python@v6
+      - uses: github/codeql-action/init@v4
+      - uses: github/codeql-action/analyze@v4
+EOF
+cat > "${WORK_DIR}/pass/docs/adopt_in_one_pr.md" <<'EOF'
+```yaml
+- uses: actions/checkout@v5
+```
+EOF
+
+pass_output="$(
+  python3 "${SCRIPT_PATH}" \
+    "${WORK_DIR}/pass/.github/workflows" \
+    "${WORK_DIR}/pass/docs/adopt_in_one_pr.md"
+)"
+assert_eq \
+  "${pass_output}" \
+  "workflow runtime guard: pass (2 files scanned)" \
+  "guard should pass deterministically for allowed action majors"
+
+mkdir -p "${WORK_DIR}/fail/.github/workflows" "${WORK_DIR}/fail/docs"
+cat > "${WORK_DIR}/fail/.github/workflows/core.yml" <<'EOF'
+name: core
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v4
+      - uses: github/codeql-action/analyze@v3
+      - uses: actions/setup-go@v5
+EOF
+cat > "${WORK_DIR}/fail/docs/adopt_in_one_pr.md" <<'EOF'
+```yaml
+- uses: actions/checkout@v4
+```
+EOF
+
+set +e
+fail_output="$(
+  python3 "${SCRIPT_PATH}" \
+    "${WORK_DIR}/fail/.github/workflows" \
+    "${WORK_DIR}/fail/docs/adopt_in_one_pr.md" \
+    2>&1
+)"
+fail_status=$?
+set -e
+assert_eq "${fail_status}" "1" "guard should exit 1 on deprecated action majors"
+
+expected_fail_output="$(cat <<EOF
+workflow runtime guard: fail
+${WORK_DIR}/fail/.github/workflows/core.yml:6: actions/setup-python@v5: deprecated major v5; require actions/setup-python@v6+
+${WORK_DIR}/fail/.github/workflows/core.yml:7: actions/checkout@v4: deprecated major v4; require actions/checkout@v5+
+${WORK_DIR}/fail/.github/workflows/core.yml:8: github/codeql-action/analyze@v3: deprecated major v3; require github/codeql-action/analyze@v4+
+${WORK_DIR}/fail/.github/workflows/core.yml:9: actions/setup-go@v5: deprecated major v5; require actions/setup-go@v6+
+${WORK_DIR}/fail/docs/adopt_in_one_pr.md:2: actions/checkout@v4: deprecated major v4; require actions/checkout@v5+
+EOF
+)"
+assert_eq \
+  "${fail_output}" \
+  "${expected_fail_output}" \
+  "guard should report deterministic sorted failures"
+
+set +e
+usage_output="$(python3 "${SCRIPT_PATH}" 2>&1)"
+usage_status=$?
+set -e
+assert_eq "${usage_status}" "2" "guard should exit 2 on missing arguments"
+assert_contains "${usage_output}" "usage:" "guard should print argparse usage on missing arguments"
+
+INTEGRATION_REPO="${WORK_DIR}/integration"
+mkdir -p "${INTEGRATION_REPO}/scripts" "${INTEGRATION_REPO}/product" "${INTEGRATION_REPO}/docs" "${INTEGRATION_REPO}/.github/workflows"
+cp "${REPO_ROOT}/scripts/check_repo_hygiene.sh" "${INTEGRATION_REPO}/scripts/check_repo_hygiene.sh"
+cp "${REPO_ROOT}/scripts/check_github_action_runtime_versions.py" "${INTEGRATION_REPO}/scripts/check_github_action_runtime_versions.py"
+
+cat > "${INTEGRATION_REPO}/Makefile" <<'EOF'
+lint-fast:
+	bash scripts/check_repo_hygiene.sh
+
+lint:
+	bash scripts/check_repo_hygiene.sh
+EOF
+
+for path in \
+  "product/PRD.md" \
+  "product/ROADMAP.md" \
+  "product/PLAN_v1.md" \
+  "product/PLAN_v1.7.md" \
+  "product/PLAN_ADOPTION.md" \
+  "product/PLAN_HARDENING.md"; do
+  mkdir -p "${INTEGRATION_REPO}/$(dirname "${path}")"
+  printf '# placeholder\n' > "${INTEGRATION_REPO}/${path}"
+done
+
+cat > "${INTEGRATION_REPO}/docs/adopt_in_one_pr.md" <<'EOF'
+```yaml
+- uses: actions/checkout@v5
+```
+EOF
+cat > "${INTEGRATION_REPO}/.github/workflows/ci.yml" <<'EOF'
+name: ci
+jobs:
+  lint:
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
+EOF
+
+(
+  cd "${INTEGRATION_REPO}"
+  git init -q
+  git add .
+  make lint-fast >/dev/null
+  make lint >/dev/null
+)
+
+cat > "${INTEGRATION_REPO}/.github/workflows/ci.yml" <<'EOF'
+name: ci
+jobs:
+  lint:
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+EOF
+
+(
+  cd "${INTEGRATION_REPO}"
+  git add .github/workflows/ci.yml
+  set +e
+  lint_fast_output="$(make lint-fast 2>&1)"
+  lint_fast_status=$?
+  lint_output="$(make lint 2>&1)"
+  lint_status=$?
+  set -e
+  assert_eq "${lint_fast_status}" "2" "lint-fast should fail when deprecated action majors are reintroduced"
+  assert_eq "${lint_status}" "2" "lint should fail when deprecated action majors are reintroduced"
+  assert_contains "${lint_fast_output}" "workflow runtime guard: fail" "lint-fast should surface guard failure output"
+  assert_contains "${lint_output}" "workflow runtime guard: fail" "lint should surface guard failure output"
+)
+
+echo "github action runtime guard: pass"


### PR DESCRIPTION
## Problem
- Core and secondary GitHub Actions workflows still used deprecated Node 20-backed action majors.
- The repo had no deterministic local guard to prevent those pins from reappearing.
- `CODEOWNERS` still needed `@ryshman` added alongside the existing owner set.

## Changes
- Added a deterministic local GitHub Actions runtime guard and wired it into repo hygiene and test coverage.
- Upgraded monitored workflow pins across core and secondary workflows to the Node 24-safe baseline, including CodeQL v4.
- Updated maintainer docs for the runtime policy and local guard command.
- Added `@ryshman` to `CODEOWNERS` across the current ownership rules.

## Validation
- `gait doctor --json`
- `make prepush-full`
