### PR TITLE
hotfix: refresh ui dependency freshness

### DIFF
--- a/.agents/skills/commit-push/SKILL.md
+++ b/.agents/skills/commit-push/SKILL.md
@@ -15,6 +15,7 @@ Execute this workflow for: "commit/push/open PR", "ship this branch", "merge aft
 - No GitHub issue creation.
 - PR text must use heredoc EOF bodies (no inline `--body` strings).
 - Default posture: when a blocker is actionable from the repo, branch, or CI logs, fix it in-loop and continue instead of stopping at first failure.
+- Do not stop merely because PR CI, passive review, merge propagation, or post-merge `main` CI is still in progress within the configured wait windows.
 
 ## Preconditions
 
@@ -61,6 +62,7 @@ If preconditions fail, stop and report.
 - Watch required checks/run(s) with timeout `25 minutes`.
 - Use polling/watch (for example every 10s).
 - If green, continue.
+- If still pending, keep polling until terminal or timeout; async wait alone is not a blocker.
 - If failed, classify failure:
 - actionable product/test failure
 - flaky/infra/transient
@@ -86,6 +88,7 @@ If preconditions fail, stop and report.
 - Stage A: for the first `15 minutes`, look for latest-head Codex terminal signals or an `eyes` in-progress signal
 - Stage B: if `eyes` was observed during Stage A or later, continue polling every `30s` for up to `15 minutes` from the first observed `eyes` on the current review cycle
 - If no terminal Codex signal appears within that `15 minute` Stage B window, stop and report a blocked Codex review gate
+- While inside Stage A or Stage B, keep waiting and polling; an in-progress review signal is not a blocker by itself
 - If no latest-head terminal signal appears and no `eyes` in-progress signal is seen during Stage A, fall back to PR-wide Codex review inventory:
 - collect prior Codex reviews, inline comments, issue comments, and Codex-authored `+1` / thumbs-up reactions on the PR
 - require at least one prior Codex review artifact before permitting `carry_forward`
@@ -124,6 +127,7 @@ If preconditions fail, stop and report.
 - Codex review settle gate is satisfied (`approved`, `thumbs_up`, `actionable` resolved, or `carry_forward`)
 - no unresolved `P0/P1` review items remain
 - Merge non-interactively (repo-default merge strategy or explicitly chosen one).
+- If a merge attempt fails only because the repository disallows the chosen strategy, retry immediately with a repo-allowed non-interactive strategy instead of stopping.
 - Record merged PR URL and merge commit SHA.
 
 11. Switch to main and sync:
@@ -132,6 +136,7 @@ If preconditions fail, stop and report.
 
 12. Monitor post-merge CI on `main`:
 - Watch the latest `main` CI run with timeout `25 minutes`.
+- If the run is still pending, keep polling until terminal or timeout; async wait alone is not a blocker.
 
 13. Hotfix loop on post-merge red:
 - Run only for actionable or repo-fixable failures.
@@ -150,7 +155,16 @@ If preconditions fail, stop and report.
 - Continue hotfixing while failures remain actionable and each cycle makes progress.
 - Stop only for external/non-actionable blockers, safety blockers, or 2 consecutive no-progress hotfix cycles.
 
-14. Stop conditions:
+15. Global wait rule:
+- Pending CI, pending passive review, pending merge propagation, and pending post-merge checks are not blockers by themselves.
+- While inside the configured timeout windows, keep polling and continue the loop.
+- Only stop for:
+- explicit non-actionable or unsafe failure
+- timeout expiry for the current wait window
+- exhausted no-progress budget
+- unexpected repo state that cannot be reconciled safely
+
+16. Stop conditions:
 - CI green on main: success.
 - Codex gate unresolved after passive latest-head poll plus PR-wide carry-forward triage, without any Codex `eyes` in-progress signal: stop and report blocker.
 - Codex gate remains pending with Codex `eyes` in-progress signal: continue waiting up to the `15 minute` Stage B window; only then stop and report blocker if no terminal signal appears.
@@ -208,3 +222,4 @@ Never use inline `--body "..."` for multi-line PR text.
 - Merge commit SHA(s)
 - Post-merge CI status on `main`
 - If stopped: blocker reason and last failing check
+- Never report a mere in-progress async gate as the final stop reason; report only the hard blocker, timeout, or last terminal failing gate

--- a/.agents/skills/cut-release/SKILL.md
+++ b/.agents/skills/cut-release/SKILL.md
@@ -39,6 +39,8 @@ Execute this workflow for: "cut release", "ship vX.Y.Z", "push tag and monitor r
 - No commit amend unless explicitly requested
 - No changelog modifications
 - PR bodies/comments must use EOF heredoc (`--body-file - <<'EOF' ... EOF`)
+- Do not stop at an external async gate merely because CI, review, merge, or post-merge monitoring is still in progress
+- Continue waiting, polling, merging, retagging, rerunning UAT, and re-monitoring until a success condition or an explicit hard stop condition is reached
 
 ## Workflow
 
@@ -65,6 +67,7 @@ Execute this workflow for: "cut release", "ship vX.Y.Z", "push tag and monitor r
 - `make test-release-smoke`
 
 If any step fails, stop and report blocker.
+Do not stop merely because a release run is still pending; continue polling until completion or timeout.
 
 ### Phase 1: Tag and Release Monitor
 
@@ -78,6 +81,7 @@ If any step fails, stop and report blocker.
 - transient/infra: rerun workflow once, re-monitor
 - actionable: go to hotfix loop
 - non-actionable: stop with blocker report
+5. If release is still running, keep polling until it reaches a terminal state or the timeout is hit.
 
 ### Phase 2: Post-Release UAT
 
@@ -88,6 +92,7 @@ If any step fails, stop and report blocker.
 - classify actionable vs non-actionable
 - actionable: go to hotfix loop
 - non-actionable: stop with blocker report
+4. If UAT-related async validation is still in progress, continue waiting; async wait alone is not a blocker.
 
 ### Phase 3: Hotfix Loop (Only if Needed, Max 2)
 
@@ -118,29 +123,43 @@ For loop `r1..r2`:
 - `EOF`
 
 7. Monitor PR CI (`ci` and `codeql`) to green (`CI_TIMEOUT_MIN`).
+8. If PR CI is red and actionable, fix the full known actionable set on the same hotfix branch, rerun local validation, push again, and continue monitoring.
 
-8. Merge PR after green.
+9. After PR CI is green, wait for required passive review/release gates as applicable; do not stop merely because those checks are still pending inside their timeout windows.
 
-9. Sync and monitor post-merge main CI:
+10. Merge PR after green and satisfied review gates.
+
+11. Sync and monitor post-merge main CI:
 - `git checkout main`
 - `git pull --ff-only origin main`
 - monitor `ci` and `codeql` on `main` (`CI_TIMEOUT_MIN`)
 - if post-merge main CI is red and actionable, continue same loop (counts against max)
+- if post-merge main CI is still running, continue polling until terminal or timeout; async wait alone is not a blocker
 
-10. Bump patch version:
+12. Bump patch version:
 - `vX.Y.Z -> vX.Y.(Z+1)`
 
-11. Create/push new tag from `main` and monitor `release` workflow again:
+13. Create/push new tag from `main` and monitor `release` workflow again:
 - tag from `main` only
 - monitor until green (`RELEASE_TIMEOUT_MIN`)
 
-12. Rerun full UAT for the new tag:
+14. Rerun full UAT for the new tag:
 - `GAIT_UAT_RELEASE_VERSION=<new-version> bash scripts/test_uat_local.sh`
 
-13. Exit conditions:
+15. Exit conditions:
 - if release + UAT green: success
 - if loop count exceeds 2: stop with blocker report
 - if non-actionable failure appears: stop with blocker report
+
+### Global Wait Rule
+
+- Pending GitHub Actions runs, pending passive review signals, pending merge propagation, and pending post-merge `main` checks are not blockers by themselves.
+- While within the configured timeout windows, keep polling and continue the workflow.
+- Only stop for:
+- explicit failure classified as non-actionable or unsafe
+- timeout expiry for the current wait window
+- exhausted hotfix loop budget
+- unexpected repo state that cannot be reconciled safely
 
 ## Command Contract (JSON Required)
 
@@ -163,3 +182,4 @@ No inline multi-line `--body` strings.
 - Hotfix branch/PR URLs and commit SHAs (if any)
 - Loop count used
 - Final status: success or blocker with last failing gate
+- If blocked, distinguish `hard blocker` from `async gate still in progress`; never report a mere in-progress async wait as the final blocker

--- a/ui/local/package-lock.json
+++ b/ui/local/package-lock.json
@@ -8,7 +8,7 @@
       "name": "gait-local-ui",
       "version": "0.1.0",
       "dependencies": {
-        "next": "16.1.7",
+        "next": "^16.2.0",
         "react": "19.2.4",
         "react-dom": "19.2.4"
       },
@@ -18,7 +18,7 @@
         "@types/react-dom": "19.2.3",
         "@vitest/coverage-v8": "4.0.7",
         "eslint": "9.39.1",
-        "eslint-config-next": "16.1.7",
+        "eslint-config-next": "^16.2.0",
         "jsdom": "27.2.0",
         "typescript": "5.9.3",
         "vitest": "4.0.7"
@@ -1669,15 +1669,15 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "16.1.7",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.1.7.tgz",
-      "integrity": "sha512-rJJbIdJB/RQr2F1nylZr/PJzamvNNhfr3brdKP6s/GW850jbtR70QlSfFselvIBbcPUOlQwBakexjFzqLzF6pg==",
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.0.tgz",
+      "integrity": "sha512-OZIbODWWAi0epQRCRjNe1VO45LOFBzgiyqmTLzIqWq6u1wrxKnAyz1HH6tgY/Mc81YzIjRPoYsPAEr4QV4l9TA==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
-      "version": "16.1.7",
-      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-16.1.7.tgz",
-      "integrity": "sha512-v/bRGOJlfRCO+NDKt0bZlIIWjhMKU8xbgEQBo+rV9C8S6czZvs96LZ/v24/GvpEnovZlL4QDpku/RzWHVbmPpA==",
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-16.2.0.tgz",
+      "integrity": "sha512-3D3pEMcGKfENC9Pzlkr67GOm+205+5hRdYPZvHuNIy5sr9k0ybSU8g+sxOO/R/RLEh/gWZ3UlY+5LmEyZ1xgXQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1685,9 +1685,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "16.1.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.1.7.tgz",
-      "integrity": "sha512-b2wWIE8sABdyafc4IM8r5Y/dS6kD80JRtOGrUiKTsACFQfWWgUQ2NwoUX1yjFMXVsAwcQeNpnucF2ZrujsBBPg==",
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.0.tgz",
+      "integrity": "sha512-/JZsqKzKt01IFoiLLAzlNqys7qk2F3JkcUhj50zuRhKDQkZNOz9E5N6wAQWprXdsvjRP4lTFj+/+36NSv5AwhQ==",
       "cpu": [
         "arm64"
       ],
@@ -1701,9 +1701,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "16.1.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.1.7.tgz",
-      "integrity": "sha512-zcnVaaZulS1WL0Ss38R5Q6D2gz7MtBu8GZLPfK+73D/hp4GFMrC2sudLky1QibfV7h6RJBJs/gOFvYP0X7UVlQ==",
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.0.tgz",
+      "integrity": "sha512-/hV8erWq4SNlVgglUiW5UmQ5Hwy5EW/AbbXlJCn6zkfKxTy/E/U3V8U1Ocm2YCTUoFgQdoMxRyRMOW5jYy4ygg==",
       "cpu": [
         "x64"
       ],
@@ -1717,9 +1717,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "16.1.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.1.7.tgz",
-      "integrity": "sha512-2ant89Lux/Q3VyC8vNVg7uBaFVP9SwoK2jJOOR0L8TQnX8CAYnh4uctAScy2Hwj2dgjVHqHLORQZJ2wH6VxhSQ==",
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.0.tgz",
+      "integrity": "sha512-GkjL/Q7MWOwqWR9zoxu1TIHzkOI2l2BHCf7FzeQG87zPgs+6WDh+oC9Sw9ARuuL/FUk6JNCgKRkA6rEQYadUaw==",
       "cpu": [
         "arm64"
       ],
@@ -1733,9 +1733,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "16.1.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.1.7.tgz",
-      "integrity": "sha512-uufcze7LYv0FQg9GnNeZ3/whYfo+1Q3HnQpm16o6Uyi0OVzLlk2ZWoY7j07KADZFY8qwDbsmFnMQP3p3+Ftprw==",
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.0.tgz",
+      "integrity": "sha512-1ffhC6KY5qWLg5miMlKJp3dZbXelEfjuXt1qcp5WzSCQy36CV3y+JT7OC1WSFKizGQCDOcQbfkH/IjZP3cdRNA==",
       "cpu": [
         "arm64"
       ],
@@ -1749,9 +1749,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "16.1.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.1.7.tgz",
-      "integrity": "sha512-KWVf2gxYvHtvuT+c4MBOGxuse5TD7DsMFYSxVxRBnOzok/xryNeQSjXgxSv9QpIVlaGzEn/pIuI6Koosx8CGWA==",
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.0.tgz",
+      "integrity": "sha512-FmbDcZQ8yJRq93EJSL6xaE0KK/Rslraf8fj1uViGxg7K4CKBCRYSubILJPEhjSgZurpcPQq12QNOJQ0DRJl6Hg==",
       "cpu": [
         "x64"
       ],
@@ -1765,9 +1765,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "16.1.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.1.7.tgz",
-      "integrity": "sha512-HguhaGwsGr1YAGs68uRKc4aGWxLET+NevJskOcCAwXbwj0fYX0RgZW2gsOCzr9S11CSQPIkxmoSbuVaBp4Z3dA==",
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.0.tgz",
+      "integrity": "sha512-HzjIHVkmGAwRbh/vzvoBWWEbb8BBZPxBvVbDQDvzHSf3D8RP/4vjw7MNLDXFF9Q1WEzeQyEj2zdxBtVAHu5Oyw==",
       "cpu": [
         "x64"
       ],
@@ -1781,9 +1781,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "16.1.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.1.7.tgz",
-      "integrity": "sha512-S0n3KrDJokKTeFyM/vGGGR8+pCmXYrjNTk2ZozOL1C/JFdfUIL9O1ATaJOl5r2POe56iRChbsszrjMAdWSv7kQ==",
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.0.tgz",
+      "integrity": "sha512-UMiFNQf5H7+1ZsZPxEsA064WEuFbRNq/kEXyepbCnSErp4f5iut75dBA8UeerFIG3vDaQNOfCpevnERPp2V+nA==",
       "cpu": [
         "arm64"
       ],
@@ -1797,9 +1797,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "16.1.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.1.7.tgz",
-      "integrity": "sha512-mwgtg8CNZGYm06LeEd+bNnOUfwOyNem/rOiP14Lsz+AnUY92Zq/LXwtebtUiaeVkhbroRCQ0c8GlR4UT1U+0yg==",
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.0.tgz",
+      "integrity": "sha512-DRrNJKW+/eimrZgdhVN1uvkN1OI4j6Lpefwr44jKQ0YQzztlmOBUUzHuV5GxOMPK3nmodAYElUVCY8ZXo/IWeA==",
       "cpu": [
         "x64"
       ],
@@ -4140,13 +4140,13 @@
       }
     },
     "node_modules/eslint-config-next": {
-      "version": "16.1.7",
-      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-16.1.7.tgz",
-      "integrity": "sha512-FTq1i/QDltzq+zf9aB/cKWAiZ77baG0V7h8dRQh3thVx7I4dwr6ZXQrWKAaTB7x5VwVXlzoUTyMLIVQPLj2gJg==",
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-16.2.0.tgz",
+      "integrity": "sha512-LlVJrWnjIkgQRECjIOELyAtrWFqzn326ARS5ap7swc1YKL4wkry6/gszn6wi5ZDWKxKe7fanxArvhqMoAzbL7w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@next/eslint-plugin-next": "16.1.7",
+        "@next/eslint-plugin-next": "16.2.0",
         "eslint-import-resolver-node": "^0.3.6",
         "eslint-import-resolver-typescript": "^3.5.2",
         "eslint-plugin-import": "^2.32.0",
@@ -5975,12 +5975,12 @@
       "license": "MIT"
     },
     "node_modules/next": {
-      "version": "16.1.7",
-      "resolved": "https://registry.npmjs.org/next/-/next-16.1.7.tgz",
-      "integrity": "sha512-WM0L7WrSvKwoLegLYr6V+mz+RIofqQgVAfHhMp9a88ms0cFX8iX9ew+snpWlSBwpkURJOUdvCEt3uLl3NNzvWg==",
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.2.0.tgz",
+      "integrity": "sha512-NLBVrJy1pbV1Yn00L5sU4vFyAHt5XuSjzrNyFnxo6Com0M0KrL6hHM5B99dbqXb2bE9pm4Ow3Zl1xp6HVY9edQ==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "16.1.7",
+        "@next/env": "16.2.0",
         "@swc/helpers": "0.5.15",
         "baseline-browser-mapping": "^2.9.19",
         "caniuse-lite": "^1.0.30001579",
@@ -5994,15 +5994,15 @@
         "node": ">=20.9.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "16.1.7",
-        "@next/swc-darwin-x64": "16.1.7",
-        "@next/swc-linux-arm64-gnu": "16.1.7",
-        "@next/swc-linux-arm64-musl": "16.1.7",
-        "@next/swc-linux-x64-gnu": "16.1.7",
-        "@next/swc-linux-x64-musl": "16.1.7",
-        "@next/swc-win32-arm64-msvc": "16.1.7",
-        "@next/swc-win32-x64-msvc": "16.1.7",
-        "sharp": "^0.34.4"
+        "@next/swc-darwin-arm64": "16.2.0",
+        "@next/swc-darwin-x64": "16.2.0",
+        "@next/swc-linux-arm64-gnu": "16.2.0",
+        "@next/swc-linux-arm64-musl": "16.2.0",
+        "@next/swc-linux-x64-gnu": "16.2.0",
+        "@next/swc-linux-x64-musl": "16.2.0",
+        "@next/swc-win32-arm64-msvc": "16.2.0",
+        "@next/swc-win32-x64-msvc": "16.2.0",
+        "sharp": "^0.34.5"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.1.0",

--- a/ui/local/package.json
+++ b/ui/local/package.json
@@ -10,7 +10,7 @@
     "test": "vitest run --coverage"
   },
   "dependencies": {
-    "next": "16.1.7",
+    "next": "16.2.0",
     "react": "19.2.4",
     "react-dom": "19.2.4"
   },
@@ -20,7 +20,7 @@
     "@types/react-dom": "19.2.3",
     "@vitest/coverage-v8": "4.0.7",
     "eslint": "9.39.1",
-    "eslint-config-next": "16.1.7",
+    "eslint-config-next": "16.2.0",
     "jsdom": "27.2.0",
     "typescript": "5.9.3",
     "vitest": "4.0.7"


### PR DESCRIPTION
## Problem
- Post-merge `main` CI failed in `ui-local` because `scripts/check_ui_deps_freshness.sh` detected stale `next` and `eslint-config-next` versions.

## Changes
- Updated `ui/local/package.json` and `ui/local/package-lock.json` so `next` and `eslint-config-next` are pinned to `16.2.0`.

## Validation
- `bash scripts/check_ui_deps_freshness.sh`
- `make prepush-full`
