### PR TITLE
hotfix: support ci package list on mac bash (r1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,7 +186,10 @@ jobs:
         shell: bash
         run: |
           set +e
-          mapfile -t go_test_packages < <(python scripts/list_go_test_packages.py)
+          go_test_packages=()
+          while IFS= read -r package; do
+            go_test_packages+=("$package")
+          done < <(python scripts/list_go_test_packages.py)
           go test "${go_test_packages[@]}" -cover > coverage-go-packages.out 2>&1
           package_test_status=$?
           set -e

--- a/.github/workflows/nightly-full-windows.yml
+++ b/.github/workflows/nightly-full-windows.yml
@@ -49,7 +49,10 @@ jobs:
         shell: bash
         run: |
           set +e
-          mapfile -t go_test_packages < <(python scripts/list_go_test_packages.py)
+          go_test_packages=()
+          while IFS= read -r package; do
+            go_test_packages+=("$package")
+          done < <(python scripts/list_go_test_packages.py)
           go test "${go_test_packages[@]}" -cover > coverage-go-packages.out 2>&1
           package_test_status=$?
           set -e


### PR DESCRIPTION
## Problem
- post-merge `main` CI failed in the `ci` workflow on `macos-latest`
- the new Go coverage package-list step used `mapfile`, which is unavailable in the Bash version on GitHub's macOS runners
- that caused the package array to stay empty and `go test` to run against `.` instead of the filtered package set

## Changes
- replace `mapfile` with a Bash 3.2-compatible `while read` array population loop in the `ci` workflow
- apply the same package-loading pattern to the matching nightly Windows workflow step so the coverage logic stays consistent

## Validation
- `make prepush-full`
- `git push -u origin codex/hotfix-ci-package-list-r1` (pre-push hook ran `make prepush`)
