### PR TITLE
ci: fix windows go coverage package parsing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,6 +188,8 @@ jobs:
           set +e
           go_test_packages=()
           while IFS= read -r package; do
+            package=${package%$'\r'}
+            [[ -n "${package}" ]] || continue
             go_test_packages+=("$package")
           done < <(python scripts/list_go_test_packages.py)
           go test "${go_test_packages[@]}" -cover > coverage-go-packages.out 2>&1

--- a/.github/workflows/nightly-full-windows.yml
+++ b/.github/workflows/nightly-full-windows.yml
@@ -51,6 +51,8 @@ jobs:
           set +e
           go_test_packages=()
           while IFS= read -r package; do
+            package=${package%$'\r'}
+            [[ -n "${package}" ]] || continue
             go_test_packages+=("$package")
           done < <(python scripts/list_go_test_packages.py)
           go test "${go_test_packages[@]}" -cover > coverage-go-packages.out 2>&1

--- a/scripts/list_go_test_packages.py
+++ b/scripts/list_go_test_packages.py
@@ -7,6 +7,14 @@ import subprocess
 import sys
 
 
+def write_packages(packages: list[str]) -> None:
+    payload = ("\n".join(packages) + "\n").encode("utf-8")
+    if hasattr(sys.stdout, "buffer"):
+        sys.stdout.buffer.write(payload)
+        return
+    sys.stdout.write(payload.decode("utf-8"))
+
+
 def main() -> int:
     go_bin = os.environ.get("GO", "go")
     result = subprocess.run(
@@ -25,8 +33,7 @@ def main() -> int:
         print("no Go packages matched after filtering", file=sys.stderr)
         return 1
 
-    sys.stdout.write("\n".join(packages))
-    sys.stdout.write("\n")
+    write_packages(packages)
     return 0
 
 


### PR DESCRIPTION
## Problem
The `nightly-full-windows` workflow was failing in the `Go tests with coverage` step because Windows carriage returns were reaching `go test` package arguments and producing malformed import paths like `github.com/Clyra-AI/gait/cmd/gait\r`.

## Changes
- emit LF-only bytes from `scripts/list_go_test_packages.py` so package output is stable across platforms
- defensively strip trailing `\r` values in the bash package-loading loops used by CI and the Windows nightly workflow
- preserve existing non-Windows behavior while hardening the Windows path

## Validation
- `./gait doctor --json`
- `make prepush-full`
- repo pre-push hook via `git push` (`make prepush`)
