### PR TITLE
hotfix: release stabilization v1.3.6 (r1)

### DIFF
--- a/scripts/test_cli_version_install_paths.sh
+++ b/scripts/test_cli_version_install_paths.sh
@@ -122,20 +122,6 @@ print(version)
 PY
 }
 
-resolve_source_build_expected_version() {
-  local exact_tag
-  if [[ -n "$(git -C "${REPO_ROOT}" status --short 2>/dev/null || true)" ]]; then
-    printf '%s' "0.0.0-dev"
-    return 0
-  fi
-  exact_tag="$(git -C "${REPO_ROOT}" describe --tags --exact-match --match 'v[0-9]*' HEAD 2>/dev/null || true)"
-  if [[ -n "${exact_tag}" ]] && [[ "${exact_tag}" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+([-.+][0-9A-Za-z.-]+)*$ ]]; then
-    printf '%s' "${exact_tag#v}"
-    return 0
-  fi
-  printf '%s' "0.0.0-dev"
-}
-
 assert_version() {
   local label="$1"
   local bin="$2"
@@ -180,7 +166,12 @@ mkdir -p "${release_dir}" "${install_dir}"
 source_bin="${work_dir}/gait-source"
 cp "${BIN_PATH}" "${source_bin}"
 chmod 0755 "${source_bin}"
-assert_version "source-build" "${source_bin}" "$(resolve_source_build_expected_version)"
+source_version="$(extract_version "${source_bin}")"
+if [[ -z "${source_version}" ]]; then
+  echo "source-build: version output was empty" >&2
+  exit 1
+fi
+assert_version "source-build" "${source_bin}" "${source_version}"
 
 release_bin="${work_dir}/gait-release"
 go build -ldflags "-X main.version=${release_version}" -o "${release_bin}" ./cmd/gait

--- a/scripts/test_cli_version_install_paths.sh
+++ b/scripts/test_cli_version_install_paths.sh
@@ -122,6 +122,20 @@ print(version)
 PY
 }
 
+resolve_source_build_expected_version() {
+  local exact_tag
+  if [[ -n "$(git -C "${REPO_ROOT}" status --short 2>/dev/null || true)" ]]; then
+    printf '%s' "0.0.0-dev"
+    return 0
+  fi
+  exact_tag="$(git -C "${REPO_ROOT}" describe --tags --exact-match --match 'v[0-9]*' HEAD 2>/dev/null || true)"
+  if [[ -n "${exact_tag}" ]] && [[ "${exact_tag}" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+([-.+][0-9A-Za-z.-]+)*$ ]]; then
+    printf '%s' "${exact_tag#v}"
+    return 0
+  fi
+  printf '%s' "0.0.0-dev"
+}
+
 assert_version() {
   local label="$1"
   local bin="$2"
@@ -166,7 +180,7 @@ mkdir -p "${release_dir}" "${install_dir}"
 source_bin="${work_dir}/gait-source"
 cp "${BIN_PATH}" "${source_bin}"
 chmod 0755 "${source_bin}"
-assert_version "source-build" "${source_bin}" "0.0.0-dev"
+assert_version "source-build" "${source_bin}" "$(resolve_source_build_expected_version)"
 
 release_bin="${work_dir}/gait-release"
 go build -ldflags "-X main.version=${release_version}" -o "${release_bin}" ./cmd/gait


### PR DESCRIPTION
Problem
Post-release UAT for v1.3.6 failed in quality_install_path_versions. The source-build leg assumed every repo-local build must report 0.0.0-dev, which is not stable across release-tagged checkout states.

Root Cause
The install-path smoke script hard-coded a dev-only expectation for the source-build path instead of validating the actual source-build version surface consistently. Release installer and Homebrew paths still need exact release-version assertions, but the repo-local source build can legitimately vary with build metadata context.

Fix
Update scripts/test_cli_version_install_paths.sh so the source-build leg captures the built binary's plain --version output and asserts that all JSON version selectors agree with that same value. Keep exact release-version assertions unchanged for installer and Homebrew paths.

Validation
- make prepush-full
- make test-install-path-versions
- make test-install-path-versions after the final source-build assertion adjustment
