### PR TITLE
fix: bump Go toolchain to 1.26.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Clyra-AI/gait
 
-go 1.26.1
+go 1.26.2
 
 require (
 	github.com/Clyra-AI/proof v0.4.6


### PR DESCRIPTION
## Problem
Scheduled runs `24327241035` (`nightly-full-windows`) and `24328213033` (`adoption-nightly`) were failing in their lint/validation stages on `main`.

Root cause from both run logs:
- `govulncheck` was scanning binaries built with Go `1.26.1`
- it reported stdlib vulnerabilities in `crypto/x509` and `crypto/tls`
- the logs explicitly note those findings are fixed in Go `1.26.2`

## Change
- bump the repo Go toolchain pin in `go.mod` from `1.26.1` to `1.26.2`
- workflows already inherit the Go version through `go-version-file: go.mod`, so no workflow file changes were needed

## Validation
- `gait doctor --json`
- `GOTOOLCHAIN=go1.26.2 go build -o ./gait ./cmd/gait`
- `GOTOOLCHAIN=go1.26.2 go run golang.org/x/vuln/cmd/govulncheck@v1.1.4 -mode=binary ./gait`
- `make prepush-full`
