### PR TITLE
[codex] add factory sync skill

### DIFF
--- a/.agents/skills/factory-sync/SKILL.md
+++ b/.agents/skills/factory-sync/SKILL.md
@@ -19,7 +19,9 @@ latest shared skill behavior.
    - `git fetch origin main`
    - `git checkout main`
    - `git pull --ff-only origin main`
-3. Create or switch to `codex/update-factory-submodule`.
+3. Reset the dedicated sync branch from current `main`:
+   - `git checkout -B codex/update-factory-submodule main`
+   - do not reuse prior `codex/update-factory-submodule` history
 4. Update Factory:
    - `git submodule update --init factory`
    - `git submodule update --remote factory`
@@ -31,7 +33,7 @@ latest shared skill behavior.
    - ensure only `factory` and optionally `.gitmodules` changed
    - `git add factory .gitmodules`
    - `git commit -m "chore: update factory submodule"`
-   - `git push -u origin codex/update-factory-submodule`
+   - `git push --force-with-lease -u origin codex/update-factory-submodule`
    - create a PR against `main`
    - wait for required checks
    - merge without deleting the branch
@@ -42,7 +44,8 @@ latest shared skill behavior.
 - Do not edit files inside `factory`.
 - Do not run product implementation work in this skill.
 - Do not hide unrelated dirty files; stop and report them.
-- Do not force-push unless explicitly required by a stale branch and clearly reported.
+- Use `--force-with-lease` only for the dedicated sync branch after resetting it
+  from current `main`; stop if the lease fails.
 - Use machine-readable command output when useful, for example `wrkr scan --json`,
   `axym collect --dry-run --json`, or `gait doctor --json` depending on the active repo.
 

--- a/.agents/skills/factory-sync/SKILL.md
+++ b/.agents/skills/factory-sync/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: factory-sync
+description: Update the local Factory submodule pointer to latest factory/main through a small PR before running Factory-backed skills.
+disable-model-invocation: true
+---
+
+# Factory Sync
+
+Update this repository's `factory` submodule to the latest `factory/main` commit
+through an auditable PR.
+
+Use this skill before a Factory-backed wrapper skill when the user wants the
+latest shared skill behavior.
+
+## Workflow
+
+1. Verify the current repo has a clean worktree.
+2. Sync the default branch:
+   - `git fetch origin main`
+   - `git checkout main`
+   - `git pull --ff-only origin main`
+3. Create or switch to `codex/update-factory-submodule`.
+4. Update Factory:
+   - `git submodule update --init factory`
+   - `git submodule update --remote factory`
+5. If `git status --short factory .gitmodules` is empty:
+   - report `factory already at latest main`
+   - return the current `git -C factory rev-parse HEAD`
+   - do not create a PR
+6. If the submodule pointer changed:
+   - ensure only `factory` and optionally `.gitmodules` changed
+   - `git add factory .gitmodules`
+   - `git commit -m "chore: update factory submodule"`
+   - `git push -u origin codex/update-factory-submodule`
+   - create a PR against `main`
+   - wait for required checks
+   - merge without deleting the branch
+7. Sync local `main` after merge and return the merged Factory commit.
+
+## Safety Rules
+
+- Do not edit files inside `factory`.
+- Do not run product implementation work in this skill.
+- Do not hide unrelated dirty files; stop and report them.
+- Do not force-push unless explicitly required by a stale branch and clearly reported.
+- Use machine-readable command output when useful, for example `wrkr scan --json`,
+  `axym collect --dry-run --json`, or `gait doctor --json` depending on the active repo.
+
+## Output
+
+- synced Factory commit SHA
+- PR URL or `already up to date`
+- merge SHA when a PR was merged
+- next suggested command, such as `Use $adhoc-plan ...`

--- a/.agents/skills/factory-sync/agents/openai.yaml
+++ b/.agents/skills/factory-sync/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Factory Sync"
+  short_description: "Sync Factory submodule before skill use"
+  default_prompt: "Use $factory-sync to update the Factory submodule to latest main through a small PR before running Factory-backed skills."


### PR DESCRIPTION
## Summary

- Add a local $factory-sync skill that updates the Factory submodule through an auditable PR.
- Update the factory submodule pointer to Factory main with publish-by-default adhoc-plan.
- Keep factory-sync separate from normal wrapper skills so latest Factory pulls are explicit.

## Validation
- python3 scripts/validate_repo_skills.py
- make lint-fast
- pre-push make prepush








