### PR TITLE
Add plan implement skill wrapper

### DIFF
--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -12,6 +12,7 @@ Shared wrapper and maintenance skills kept in this project:
 - `commit-push`
 - `cut-release`
 - `factory-sync`
+- `plan-implement`
 
 Project-local skills kept in this project:
 

--- a/.agents/skills/plan-implement/SKILL.md
+++ b/.agents/skills/plan-implement/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: plan-implement
+description: Implement any valid Factory execution plan story-by-story using the active repo profile, planned changelog/versioning fields, and required validation lanes.
+disable-model-invocation: true
+---
+
+# Plan Implement
+
+This is a local discovery wrapper for the shared Factory skill at `factory/skills/plan-implement/SKILL.md`.
+
+Before using this skill:
+
+1. Verify `factory/skills/plan-implement/SKILL.md` exists.
+2. If it is missing, stop and ask the user to run:
+
+```bash
+git submodule update --init factory
+```
+
+Then read `factory/skills/plan-implement/SKILL.md` and follow that Factory skill exactly, using the active `gait` repo profile unless the user provides another explicit profile.
+
+Do not treat this wrapper as the source of truth. The Factory skill is authoritative.
+
+Gait repository skill contract:
+
+- When command evidence is needed, prefer `gait doctor --json` or another active-profile `gait ... --json` command from `factory/profiles/gait.yaml`.
+- Require `--json` output for machine-readable command evidence.

--- a/.agents/skills/plan-implement/agents/openai.yaml
+++ b/.agents/skills/plan-implement/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Plan Implement"
+  short_description: "Execute plan stories with required gates"
+  default_prompt: "Use $plan-implement to implement a provided plan path story-by-story with profile validation and evidence."


### PR DESCRIPTION
## Summary
- add the local plan-implement wrapper that delegates to the shared Factory skill
- list plan-implement in the gait skill README

## Validation
- python3 scripts/validate_repo_skills.py
- make prepush via pre-push hook