### PR TITLE
hotfix: restore broker receipt compatibility

### DIFF
--- a/core/credential/broker.go
+++ b/core/credential/broker.go
@@ -82,6 +82,18 @@ func Issue(broker Broker, request Request) (Response, error) {
 	if response.Source == "" {
 		response.Source = broker.Name()
 	}
+	if len(response.Scope) == 0 && len(normalized.Scope) > 0 {
+		response.Scope = append([]string(nil), normalized.Scope...)
+	}
+	if response.TargetBinding == "" {
+		response.TargetBinding = normalized.TargetBinding
+	}
+	if response.RunBinding == "" {
+		response.RunBinding = normalized.RunID
+	}
+	if response.JobBinding == "" {
+		response.JobBinding = normalized.JobID
+	}
 	if response.CredentialRef == "" {
 		return Response{}, fmt.Errorf("broker returned empty credential reference")
 	}

--- a/core/credential/broker.go
+++ b/core/credential/broker.go
@@ -82,18 +82,6 @@ func Issue(broker Broker, request Request) (Response, error) {
 	if response.Source == "" {
 		response.Source = broker.Name()
 	}
-	if len(response.Scope) == 0 && len(normalized.Scope) > 0 {
-		response.Scope = append([]string(nil), normalized.Scope...)
-	}
-	if response.TargetBinding == "" {
-		response.TargetBinding = normalized.TargetBinding
-	}
-	if response.RunBinding == "" {
-		response.RunBinding = normalized.RunID
-	}
-	if response.JobBinding == "" {
-		response.JobBinding = normalized.JobID
-	}
 	if response.CredentialRef == "" {
 		return Response{}, fmt.Errorf("broker returned empty credential reference")
 	}

--- a/core/credential/providers.go
+++ b/core/credential/providers.go
@@ -207,6 +207,20 @@ func (b CommandBroker) Issue(request Request) (Response, error) {
 	if err := json.Unmarshal(output, &response); err != nil {
 		return Response{}, fmt.Errorf("%w: command broker must return JSON response", ErrCredentialUnavailable)
 	}
+	// Preserve compatibility with legacy command brokers that only returned a
+	// credential_ref while keeping stricter receipt enforcement for other modes.
+	if len(response.Scope) == 0 && len(request.Scope) > 0 {
+		response.Scope = append([]string(nil), request.Scope...)
+	}
+	if response.TargetBinding == "" {
+		response.TargetBinding = request.TargetBinding
+	}
+	if response.RunBinding == "" {
+		response.RunBinding = request.RunID
+	}
+	if response.JobBinding == "" {
+		response.JobBinding = request.JobID
+	}
 	response.IssuedBy = strings.TrimSpace(response.IssuedBy)
 	response.CredentialRef = strings.TrimSpace(response.CredentialRef)
 	if response.IssuedBy == "" {

--- a/core/credential/providers_test.go
+++ b/core/credential/providers_test.go
@@ -10,6 +10,23 @@ import (
 	"time"
 )
 
+type staticTestBroker struct {
+	name     string
+	response Response
+	err      error
+}
+
+func (b staticTestBroker) Name() string {
+	if b.name == "" {
+		return "static"
+	}
+	return b.name
+}
+
+func (b staticTestBroker) Issue(Request) (Response, error) {
+	return b.response, b.err
+}
+
 func TestStubBrokerIssueDeterministic(t *testing.T) {
 	request := Request{
 		ToolName:  "tool.write",
@@ -85,6 +102,35 @@ func TestCommandBrokerIssue(t *testing.T) {
 	}
 	if response.CredentialRef != "cmd:test-credential" {
 		t.Fatalf("unexpected command broker credential ref: %#v", response)
+	}
+}
+
+func TestIssueDefaultsCompatibilityFieldsFromRequest(t *testing.T) {
+	response, err := Issue(staticTestBroker{
+		name: "command",
+		response: Response{
+			IssuedBy:      "command",
+			CredentialRef: "cmd:no-ttl",
+		},
+	}, Request{
+		ToolName:      "tool.write",
+		Identity:      "alice",
+		RunID:         "run-1",
+		JobID:         "job-1",
+		Scope:         []string{"execute"},
+		TargetBinding: "binding-1",
+	})
+	if err != nil {
+		t.Fatalf("issue with compatibility broker: %v", err)
+	}
+	if strings.Join(response.Scope, ",") != "execute" {
+		t.Fatalf("expected scope to default from request, got %#v", response.Scope)
+	}
+	if response.TargetBinding != "binding-1" {
+		t.Fatalf("expected target binding to default from request, got %#v", response)
+	}
+	if response.RunBinding != "run-1" || response.JobBinding != "job-1" {
+		t.Fatalf("expected run/job binding to default from request, got %#v", response)
 	}
 }
 

--- a/core/credential/providers_test.go
+++ b/core/credential/providers_test.go
@@ -10,23 +10,6 @@ import (
 	"time"
 )
 
-type staticTestBroker struct {
-	name     string
-	response Response
-	err      error
-}
-
-func (b staticTestBroker) Name() string {
-	if b.name == "" {
-		return "static"
-	}
-	return b.name
-}
-
-func (b staticTestBroker) Issue(Request) (Response, error) {
-	return b.response, b.err
-}
-
 func TestStubBrokerIssueDeterministic(t *testing.T) {
 	request := Request{
 		ToolName:  "tool.write",
@@ -105,13 +88,16 @@ func TestCommandBrokerIssue(t *testing.T) {
 	}
 }
 
-func TestIssueDefaultsCompatibilityFieldsFromRequest(t *testing.T) {
-	response, err := Issue(staticTestBroker{
-		name: "command",
-		response: Response{
-			IssuedBy:      "command",
-			CredentialRef: "cmd:no-ttl",
-		},
+func TestCommandBrokerIssueDefaultsCompatibilityFieldsFromRequest(t *testing.T) {
+	executable, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable: %v", err)
+	}
+	t.Setenv("GAIT_TEST_COMMAND_BROKER_HELPER", "1")
+	t.Setenv("GAIT_TEST_COMMAND_BROKER_OMIT_COMPAT", "1")
+	response, err := Issue(CommandBroker{
+		Command: executable,
+		Args:    []string{"-test.run", "TestCommandBrokerHelperProcess", "--"},
 	}, Request{
 		ToolName:      "tool.write",
 		Identity:      "alice",
@@ -434,6 +420,10 @@ func TestCommandBrokerHelperProcess(t *testing.T) {
 	}
 	if os.Getenv("GAIT_TEST_COMMAND_BROKER_PLAIN") == "1" {
 		fmt.Print("cmd:plain-ref")
+		os.Exit(0)
+	}
+	if os.Getenv("GAIT_TEST_COMMAND_BROKER_OMIT_COMPAT") == "1" {
+		fmt.Print(`{"issued_by":"command","credential_ref":"cmd:test-credential"}`)
 		os.Exit(0)
 	}
 	request := Request{}


### PR DESCRIPTION
## Problem

Post-merge `main` CI for `100b427759766810153229649ebcf131704d2ee6` failed in the `v2-4-acceptance` compatibility wedge. The new broker receipt enforcement correctly catches explicit scope/binding mismatches, but legacy command-broker responses that omit compatibility fields were no longer inheriting the requested scope and target/run/job bindings.

## Changes

- default omitted broker `scope` from the normalized request scope during credential issuance
- default omitted broker `target_binding`, `run_binding`, and `job_binding` from the normalized request values
- add focused unit coverage for the compatibility fallback path

## Validation

- `go test ./core/credential`
- `make test-v2-4-acceptance`
- `make prepush-full`
- pre-push hook `make prepush` during `git push`

## Risks

- this restores compatibility by filling omitted broker metadata from the request, so explicit broker mismatches still rely on the broker returning non-empty conflicting values to trigger blocking
- scope/binding defaults are limited to omitted fields only; explicit broker responses still win and are validated as before

## Notes

- post-merge failure source: `ci` workflow on `main` for landed SHA `100b427759766810153229649ebcf131704d2ee6`
- hotfix branch: `codex/hotfix-broker-receipt-compat-r1`
