### PR TITLE
fix: bump Go toolchain for nightly scans

### DIFF
--- a/cmd/gait/main_test.go
+++ b/cmd/gait/main_test.go
@@ -2958,6 +2958,7 @@ func TestRunDoctorJSONReportsInvokedBinaryPathWhenPATHDiffers(t *testing.T) {
 	}
 	if onboardingCheck == nil {
 		t.Fatalf("expected onboarding_binary check in output")
+		return
 	}
 	if !strings.Contains(onboardingCheck.Message, "invoked_path="+invokedBinary) {
 		t.Fatalf("expected invoked path in onboarding message, got %q", onboardingCheck.Message)

--- a/core/doctor/doctor_test.go
+++ b/core/doctor/doctor_test.go
@@ -202,6 +202,7 @@ func TestRunPrefersInvokedBinaryAndReportsPATHCollision(t *testing.T) {
 	check := findCheck(result.Checks, "onboarding_binary")
 	if check == nil {
 		t.Fatalf("expected onboarding_binary check")
+		return
 	}
 	if check.Status != statusPass {
 		t.Fatalf("expected onboarding_binary pass, got %#v", check)
@@ -246,6 +247,7 @@ func TestRunFallsBackToWorkDirBinaryWhenPATHMissing(t *testing.T) {
 	check := findCheck(result.Checks, "onboarding_binary")
 	if check == nil {
 		t.Fatalf("expected onboarding_binary check")
+		return
 	}
 	if check.Status != statusPass {
 		t.Fatalf("expected onboarding_binary pass, got %#v", check)

--- a/core/runpack/session_test.go
+++ b/core/runpack/session_test.go
@@ -1048,6 +1048,7 @@ func TestSessionRelationshipBuildersNormalizeAndSort(t *testing.T) {
 	)
 	if eventRelationship == nil {
 		t.Fatalf("expected session event relationship")
+		return
 	}
 	if eventRelationship.ParentRef == nil || eventRelationship.ParentRef.Kind != "session" || eventRelationship.ParentRef.ID != "sess_demo" {
 		t.Fatalf("unexpected session parent_ref: %#v", eventRelationship.ParentRef)
@@ -1084,6 +1085,7 @@ func TestSessionRelationshipBuildersNormalizeAndSort(t *testing.T) {
 	)
 	if checkpointRelationship == nil {
 		t.Fatalf("expected checkpoint relationship")
+		return
 	}
 	if checkpointRelationship.ParentRef == nil || checkpointRelationship.ParentRef.Kind != "session" {
 		t.Fatalf("unexpected checkpoint parent_ref: %#v", checkpointRelationship.ParentRef)
@@ -1102,6 +1104,7 @@ func TestSessionRelationshipBuildersNormalizeAndSort(t *testing.T) {
 	)
 	if timelineRelationship == nil {
 		t.Fatalf("expected timeline relationship")
+		return
 	}
 	if timelineRelationship.ParentRef == nil || timelineRelationship.ParentRef.Kind != "run" {
 		t.Fatalf("unexpected timeline parent_ref: %#v", timelineRelationship.ParentRef)
@@ -1120,6 +1123,7 @@ func TestSessionRelationshipBuildersNormalizeAndSort(t *testing.T) {
 	)
 	if checkpointTimelineRelationship == nil {
 		t.Fatalf("expected checkpoint timeline relationship")
+		return
 	}
 	foundEvidenceEmission := false
 	for _, edge := range checkpointTimelineRelationship.Edges {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Clyra-AI/gait
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/Clyra-AI/proof v0.4.6


### PR DESCRIPTION
## Problem

Two scheduled nightly runs failed on main at `430c8d2e60e31cfe2ad0a2203ecfef9263905cbe`:

- nightly-full-windows lint job: https://github.com/Clyra-AI/gait/actions/runs/25538338105/job/74958751189
- adoption-nightly validation run: https://github.com/Clyra-AI/gait/actions/runs/25539492136

Both failures reached `govulncheck` after building with Go `1.26.2`; the scanner reported standard-library vulnerabilities fixed in Go `1.26.3`.

## Changes

- Bumped the repo Go directive from `1.26.2` to `1.26.3`, which is the authoritative `actions/setup-go` source for the affected workflows.
- Added explicit returns after fatal nil assertions in tests so `golangci-lint`/staticcheck can prove subsequent dereferences are safe under Go `1.26.3`.

## Validation

- `make lint` passed, including `govulncheck`: `No vulnerabilities found.`
- `make prepush-full` passed.
- Pre-push hook `make prepush` passed while pushing this branch.
- `./gait doctor --json` returned `ok: true` with one non-blocking registry cache warning.

## Risk

Low. This is a patch-level Go toolchain update plus test-only staticcheck annotations. No runtime behavior or artifact schema changes.

## Submodules

No submodule pointer changes.
