### PR TITLE
hotfix: guard UI lockfile integrity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,6 +129,7 @@ jobs:
           cache-dependency-path: ui/local/package-lock.json
       - name: Build local UI source
         run: |
+          bash scripts/check_ui_package_lock_integrity.sh
           cd ui/local
           npm ci
           npm run lint

--- a/Makefile
+++ b/Makefile
@@ -334,4 +334,5 @@ ui-sync:
 	bash scripts/ui_sync_assets.sh
 
 ui-deps-check:
+	bash scripts/check_ui_package_lock_integrity.sh
 	bash scripts/check_ui_deps_freshness.sh

--- a/scripts/check_ui_package_lock_integrity.sh
+++ b/scripts/check_ui_package_lock_integrity.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+LOCKFILE="$REPO_ROOT/ui/local/package-lock.json"
+
+if [[ ! -f "$LOCKFILE" ]]; then
+  echo "ui/local/package-lock.json not found" >&2
+  exit 1
+fi
+
+node - "$LOCKFILE" <<'NODE'
+const fs = require("fs");
+
+const lockfilePath = process.argv[2];
+const lockfile = JSON.parse(fs.readFileSync(lockfilePath, "utf8"));
+const packages = lockfile.packages || {};
+let failed = false;
+
+for (const [packagePath, metadata] of Object.entries(packages)) {
+  if (packagePath === "" || metadata.link === true) {
+    continue;
+  }
+
+  if (typeof metadata.version !== "string" || metadata.version.trim() === "") {
+    console.error(`invalid lockfile package metadata: ${packagePath} is missing a non-empty version`);
+    failed = true;
+  }
+}
+
+if (failed) {
+  process.exit(1);
+}
+NODE
+
+echo "ui package-lock integrity: pass"

--- a/ui/local/package-lock.json
+++ b/ui/local/package-lock.json
@@ -1773,6 +1773,25 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.6.tgz",
+      "integrity": "sha512-HKQ5SP/V/ub73UvF7n/zeJlxk2kLmtL7Wzrg4WfmkjmNos5onJ2tKu7yZOPdL18A6Svfn3max29ym+ry7NkK4g==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@next/swc-win32-arm64-msvc": {
       "version": "16.2.6",
       "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.6.tgz",
@@ -6046,9 +6065,6 @@
         }
       }
     },
-    "node_modules/next/node_modules/@next/swc-linux-x64-musl": {
-      "optional": true
-    },
     "node_modules/node-releases": {
       "version": "2.0.27",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
@@ -8066,21 +8082,6 @@
       },
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
-      }
-    },
-    "node_modules/@next/swc-linux-x64-musl": {
-      "version": "16.2.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.6.tgz",
-      "integrity": "sha512-HKQ5SP/V/ub73UvF7n/zeJlxk2kLmtL7Wzrg4WfmkjmNos5onJ2tKu7yZOPdL18A6Svfn3max29ym+ry7NkK4g==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
       }
     }
   }


### PR DESCRIPTION
## Summary
- Fixes the follow-up `ui-local` failure on `main` after PR #134, where Linux npm failed during `npm ci` with `Invalid Version:`.
- Normalizes the malformed `@next/swc-linux-x64-musl` package-lock entry and removes the versionless nested SWC entry.
- Adds a lightweight UI package-lock integrity guard and runs it before CI executes `npm ci`.

## Validation
- `bash scripts/check_ui_package_lock_integrity.sh`
- `npx --yes -p node@22.22.2 -p npm@10.9.7 npm ci` from `ui/local`
- `npm run lint` from `ui/local`
- `npm run test` from `ui/local`
- `npm run build` from `ui/local`
- `make ui-deps-check`
- `make prepush-full`
- push hook: `make prepush`
