### PR TITLE
fix: harden oss-prod gate and reference capture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - [semver:minor] Added sandbox metadata policy enforcement for high-risk `proc.exec` and generated-code actions.
 - [semver:minor] Added credential provenance policy controls that block standing or static credentials for high-risk actions and record privacy-safe credential evidence.
 - [semver:minor] Strengthened brokered JIT access validation with typed broker receipts, scope and TTL checks, and proof-ready credential evidence.
+- [semver:patch] Fixed `oss-prod` policy evaluation so permissive default policies cannot allow unmatched tool calls at the Gate or MCP boundary.
+- [semver:patch] Fixed reference-mode runpack recording so raw intent arguments and raw result payloads are stripped after digesting unless raw capture is explicitly selected.
+
+### Fixed
+
+- [semver:patch] Aligned policy and runpack documentation with strict `oss-prod` defaults and reference-mode privacy behavior.
 
 ### Upgrade Notes
 

--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ gait check --json
 gait doctor --production-readiness --json
 ```
 
+In `oss-prod`, policies that set `default_verdict: allow` are rejected. Keep strict profiles on `block` or `require_approval`, then grant allow paths with explicit rules.
+
 Do not describe a deployment as hardened `oss-prod` until that readiness check returns `ok=true`.
 
 ## Why Gait
@@ -210,6 +212,8 @@ See [`examples/integrations/openai_agents/`](examples/integrations/openai_agents
 The official LangChain surface is middleware with optional callback correlation. Enforcement happens in `wrap_tool_call`; callbacks are additive only.
 
 `run_session(...)` and other Python run-capture helpers delegate digest completion to `gait run record` in Go rather than hashing artifact fields in Python. Normalize `set` values to JSON lists before calling the SDK; unsupported non-JSON values now fail deterministically instead of being coerced into digest-affecting output.
+
+`gait run record` defaults to `capture_mode=reference`: it computes `args_digest` and `result_digest`, keeps refs and receipts deterministic, and strips raw `intents[].args` and `results[].result` from the serialized runpack. Use `--capture-mode raw` only when you explicitly want sensitive payload retention; JSON output warns when raw capture is selected.
 
 ```bash
 (cd sdk/python && uv sync --extra langchain --extra dev)

--- a/cmd/gait/gate.go
+++ b/cmd/gait/gate.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/Clyra-AI/gait/core/contextproof"
 	"github.com/Clyra-AI/gait/core/credential"
+	coreerrors "github.com/Clyra-AI/gait/core/errors"
 	"github.com/Clyra-AI/gait/core/gate"
 	"github.com/Clyra-AI/gait/core/projectconfig"
 	schemacontext "github.com/Clyra-AI/gait/core/schema/v1/context"
@@ -81,8 +82,9 @@ type gateEvalOutput struct {
 type gateEvalProfile string
 
 const (
-	gateProfileStandard gateEvalProfile = "standard"
-	gateProfileOSSProd  gateEvalProfile = "oss-prod"
+	gateProfileStandard            gateEvalProfile = "standard"
+	gateProfileOSSProd             gateEvalProfile = "oss-prod"
+	ossProdRejectDefaultAllowError                 = "oss-prod profile rejects policy default_verdict=allow; use default_verdict: block or require_approval"
 )
 
 func runGate(arguments []string) int {
@@ -266,6 +268,9 @@ func runGateEval(arguments []string) int {
 	policy, err := gate.LoadPolicyFile(policyPath)
 	if err != nil {
 		return writeGateEvalOutput(jsonOutput, gateEvalOutput{OK: false, Error: err.Error()}, exitCodeForError(err, exitInvalidInput))
+	}
+	if err := validatePolicyForGateProfile(policy, resolvedProfile); err != nil {
+		return writeGateEvalOutput(jsonOutput, gateEvalOutput{OK: false, Error: err.Error()}, exitInvalidInput)
 	}
 
 	intent, err := readIntentRequest(intentPath)
@@ -1353,6 +1358,22 @@ func parseGateEvalProfile(value string) (gateEvalProfile, error) {
 	default:
 		return "", fmt.Errorf("unsupported --profile value %q (expected standard or oss-prod)", value)
 	}
+}
+
+func validatePolicyForGateProfile(policy gate.Policy, profile gateEvalProfile) error {
+	if profile != gateProfileOSSProd {
+		return nil
+	}
+	if strings.EqualFold(strings.TrimSpace(policy.DefaultVerdict), "allow") {
+		return coreerrors.Wrap(
+			errors.New(ossProdRejectDefaultAllowError),
+			coreerrors.CategoryInvalidInput,
+			"invalid_input",
+			"check command usage and input schema",
+			false,
+		)
+	}
+	return nil
 }
 
 func joinCSV(values []string) string {

--- a/cmd/gait/kill_switch_test.go
+++ b/cmd/gait/kill_switch_test.go
@@ -164,7 +164,7 @@ func TestRunGateEvalKillSwitchUnavailableFailClosedInOSSProd(t *testing.T) {
 
 	policyPath := filepath.Join(workDir, "policy.yaml")
 	mustWriteFile(t, policyPath, strings.Join([]string{
-		"default_verdict: allow",
+		"default_verdict: block",
 		"rules:",
 		"  - name: allow-exec",
 		"    effect: allow",

--- a/cmd/gait/main_test.go
+++ b/cmd/gait/main_test.go
@@ -3551,20 +3551,39 @@ func TestGateEvalOSSProdProfile(t *testing.T) {
 		t.Fatalf("runGateEval oss-prod dev key mode: expected %d got %d", exitInvalidInput, code)
 	}
 
-	if code := runGateEval([]string{
-		"--policy", allowPolicyPath,
-		"--intent", intentPath,
-		"--profile", "oss-prod",
-		"--key-mode", "prod",
-		"--private-key", privateKeyPath,
-		"--json",
-	}); code != exitOK {
-		t.Fatalf("runGateEval oss-prod allow: expected %d got %d", exitOK, code)
+	tracePath := filepath.Join(workDir, "trace_should_not_exist.json")
+	var allowCode int
+	allowRaw := captureStdout(t, func() {
+		allowCode = runGateEval([]string{
+			"--policy", allowPolicyPath,
+			"--intent", intentPath,
+			"--profile", "oss-prod",
+			"--trace-out", tracePath,
+			"--key-mode", "prod",
+			"--private-key", privateKeyPath,
+			"--json",
+		})
+	})
+	if allowCode != exitInvalidInput {
+		t.Fatalf("runGateEval oss-prod permissive default: expected %d got %d", exitInvalidInput, allowCode)
+	}
+	var allowOut gateEvalOutput
+	if err := json.Unmarshal([]byte(allowRaw), &allowOut); err != nil {
+		t.Fatalf("decode gate eval output: %v raw=%q", err, allowRaw)
+	}
+	if allowOut.OK || allowOut.Error != ossProdRejectDefaultAllowError {
+		t.Fatalf("unexpected gate eval output for permissive default: %#v", allowOut)
+	}
+	if allowOut.TracePath != "" {
+		t.Fatalf("expected no trace path for rejected permissive default, got %q", allowOut.TracePath)
+	}
+	if _, err := os.Stat(tracePath); !os.IsNotExist(err) {
+		t.Fatalf("expected no trace artifact for rejected permissive default, stat err=%v", err)
 	}
 
 	highRiskNoBrokerPolicyPath := filepath.Join(workDir, "policy_high_risk_no_broker.yaml")
 	mustWriteFile(t, highRiskNoBrokerPolicyPath, strings.Join([]string{
-		"default_verdict: allow",
+		"default_verdict: block",
 		"rules:",
 		"  - name: high-risk-allow",
 		"    effect: allow",
@@ -3584,7 +3603,7 @@ func TestGateEvalOSSProdProfile(t *testing.T) {
 
 	highRiskWithBrokerPolicyPath := filepath.Join(workDir, "policy_high_risk_with_broker.yaml")
 	mustWriteFile(t, highRiskWithBrokerPolicyPath, strings.Join([]string{
-		"default_verdict: allow",
+		"default_verdict: block",
 		"rules:",
 		"  - name: high-risk-allow",
 		"    effect: allow",
@@ -3616,7 +3635,7 @@ func TestGateEvalOSSProdProfile(t *testing.T) {
 
 	approvalPolicyPath := filepath.Join(workDir, "policy_approval.yaml")
 	mustWriteFile(t, approvalPolicyPath, strings.Join([]string{
-		"default_verdict: allow",
+		"default_verdict: block",
 		"rules:",
 		"  - name: needs-approval",
 		"    effect: require_approval",
@@ -3657,7 +3676,16 @@ func TestGateEvalProjectConfigDefaults(t *testing.T) {
 	privateKeyPath := filepath.Join(workDir, "private.key")
 	writePrivateKey(t, privateKeyPath)
 	policyPath := filepath.Join(workDir, "policy_allow.yaml")
-	mustWriteFile(t, policyPath, "default_verdict: allow\n")
+	mustWriteFile(t, policyPath, strings.Join([]string{
+		"default_verdict: block",
+		"rules:",
+		"  - name: allow-write",
+		"    effect: allow",
+		"    require_broker_credential: true",
+		"    match:",
+		"      tool_names: [tool.write]",
+		"      risk_classes: [high]",
+	}, "\n")+"\n")
 
 	if err := os.MkdirAll(filepath.Join(workDir, ".gait"), 0o750); err != nil {
 		t.Fatalf("mkdir .gait: %v", err)
@@ -3950,7 +3978,7 @@ func TestGateEvalOSSProdMissingHighRiskContextFieldBlocks(t *testing.T) {
 
 	policyPath := filepath.Join(workDir, "policy_highrisk_context.yaml")
 	mustWriteFile(t, policyPath, strings.Join([]string{
-		"default_verdict: allow",
+		"default_verdict: block",
 		"fail_closed:",
 		"  enabled: true",
 		"  risk_classes: [high]",

--- a/cmd/gait/main_test.go
+++ b/cmd/gait/main_test.go
@@ -3840,8 +3840,26 @@ func TestRunReplayUnsafeRequiresAllowToolsAndEnv(t *testing.T) {
 	}
 
 	t.Setenv("GAIT_ALLOW_REAL_REPLAY", "1")
-	if code := runReplay([]string{"--json", "--real-tools", "--unsafe-real-tools", "--allow-tools", "tool.write", "run_demo"}); code != exitOK {
-		t.Fatalf("runReplay with env interlock: expected %d got %d", exitOK, code)
+	if code := runReplay([]string{"--json", "--real-tools", "--unsafe-real-tools", "--allow-tools", "tool.write", "run_demo"}); code != exitInvalidInput {
+		t.Fatalf("runReplay reference-mode guard: expected %d got %d", exitInvalidInput, code)
+	}
+
+	run, intents, results, refs, err := buildDemoRunpack()
+	if err != nil {
+		t.Fatalf("buildDemoRunpack: %v", err)
+	}
+	rawPath := filepath.Join(workDir, "runpack_run_demo_raw.zip")
+	if _, err := runpack.WriteRunpack(rawPath, runpack.RecordOptions{
+		Run:         run,
+		Intents:     intents,
+		Results:     results,
+		Refs:        refs,
+		CaptureMode: "raw",
+	}); err != nil {
+		t.Fatalf("write raw replay runpack: %v", err)
+	}
+	if code := runReplay([]string{"--json", "--real-tools", "--unsafe-real-tools", "--allow-tools", "tool.write", rawPath}); code != exitOK {
+		t.Fatalf("runReplay raw capture success: expected %d got %d", exitOK, code)
 	}
 }
 

--- a/cmd/gait/mcp.go
+++ b/cmd/gait/mcp.go
@@ -435,6 +435,9 @@ func evaluateMCPProxyPayload(policyPath string, payload []byte, options mcpProxy
 	if err != nil {
 		return mcpProxyOutput{}, exitInvalidInput, err
 	}
+	if err := validatePolicyForGateProfile(policy, resolvedProfile); err != nil {
+		return mcpProxyOutput{}, exitInvalidInput, err
+	}
 
 	evalResult, err := mcp.EvaluateToolCallWithIntentOptions(policy, call, evalOptions, mcp.IntentOptions{
 		RequireExplicitContext: resolvedProfile == gateProfileOSSProd,

--- a/cmd/gait/mcp_server_test.go
+++ b/cmd/gait/mcp_server_test.go
@@ -336,6 +336,73 @@ func TestMCPServeHandlerRejectsMissingOAuthEvidenceInOSSProd(t *testing.T) {
 	}
 }
 
+func TestMCPServeHandlerRejectsPermissiveDefaultPolicyInOSSProd(t *testing.T) {
+	workDir := t.TempDir()
+	policyPath := filepath.Join(workDir, "policy.yaml")
+	mustWriteFile(t, policyPath, "default_verdict: allow\n")
+
+	privateKeyPath := filepath.Join(workDir, "trace_private.key")
+	writePrivateKey(t, privateKeyPath)
+
+	traceDir := filepath.Join(workDir, "traces")
+	runpackDir := filepath.Join(workDir, "runpacks")
+	packDir := filepath.Join(workDir, "packs")
+	handler, err := newMCPServeHandler(mcpServeConfig{
+		PolicyPath:     policyPath,
+		DefaultAdapter: "mcp",
+		Profile:        "oss-prod",
+		TraceDir:       traceDir,
+		RunpackDir:     runpackDir,
+		PackDir:        packDir,
+		KeyMode:        "prod",
+		PrivateKey:     privateKeyPath,
+	})
+	if err != nil {
+		t.Fatalf("newMCPServeHandler: %v", err)
+	}
+
+	requestBody := []byte(`{
+	  "run_id":"run_mcp_server_reject",
+	  "emit_runpack":true,
+	  "emit_pack":true,
+	  "call":{
+	    "name":"tool.write",
+	    "args":{"path":"/tmp/out.txt"},
+	    "targets":[{"kind":"path","value":"/tmp/out.txt","operation":"write"}],
+	    "context":{
+	      "identity":"alice",
+	      "workspace":"/repo/gait",
+	      "risk_class":"high",
+	      "session_id":"sess-1"
+	    }
+	  }
+	}`)
+	request := httptest.NewRequest(http.MethodPost, "/v1/evaluate", bytes.NewReader(requestBody))
+	request.Header.Set("content-type", "application/json")
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, request)
+
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("expected status %d got %d body=%s", http.StatusBadRequest, recorder.Code, recorder.Body.String())
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(recorder.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("decode error response: %v", err)
+	}
+	if payload["error"] != ossProdRejectDefaultAllowError {
+		t.Fatalf("unexpected error payload: %#v", payload)
+	}
+	for _, dir := range []string{traceDir, runpackDir, packDir} {
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			t.Fatalf("read dir %s: %v", dir, err)
+		}
+		if len(entries) != 0 {
+			t.Fatalf("expected no emitted artifacts in %s, found %d", dir, len(entries))
+		}
+	}
+}
+
 func TestMCPServeHandlerEvaluateBlockVerdict(t *testing.T) {
 	workDir := t.TempDir()
 	policyPath := filepath.Join(workDir, "policy.yaml")

--- a/cmd/gait/mcp_test.go
+++ b/cmd/gait/mcp_test.go
@@ -610,7 +610,15 @@ func TestRunMCPProxyOSSProdRequiresExplicitContext(t *testing.T) {
 	writePrivateKey(t, privateKeyPath)
 
 	policyPath := filepath.Join(workDir, "policy.yaml")
-	mustWriteFile(t, policyPath, "default_verdict: allow\n")
+	mustWriteFile(t, policyPath, strings.Join([]string{
+		"default_verdict: block",
+		"rules:",
+		"  - name: allow-search",
+		"    effect: allow",
+		"    match:",
+		"      tool_names: [tool.search]",
+		"      risk_classes: [high]",
+	}, "\n")+"\n")
 
 	missingContextPath := filepath.Join(workDir, "missing_context.json")
 	mustWriteFile(t, missingContextPath, `{
@@ -647,7 +655,7 @@ func TestRunMCPProxyOSSProdRequiresExplicitContext(t *testing.T) {
 	}
 }
 
-func TestRunMCPProxyOSSProdOAuthEvidenceValidation(t *testing.T) {
+func TestRunMCPProxyOSSProdRejectsPermissiveDefaultPolicy(t *testing.T) {
 	workDir := t.TempDir()
 	withWorkingDir(t, workDir)
 
@@ -656,6 +664,69 @@ func TestRunMCPProxyOSSProdOAuthEvidenceValidation(t *testing.T) {
 
 	policyPath := filepath.Join(workDir, "policy.yaml")
 	mustWriteFile(t, policyPath, "default_verdict: allow\n")
+
+	callPath := filepath.Join(workDir, "call.json")
+	mustWriteFile(t, callPath, `{
+  "name":"tool.write",
+  "args":{"path":"/tmp/out.txt"},
+  "targets":[{"kind":"path","value":"/tmp/out.txt","operation":"write"}],
+  "context":{"identity":"alice","workspace":"/repo/gait","risk_class":"high","session_id":"sess-1"}
+}`)
+
+	tracePath := filepath.Join(workDir, "trace.json")
+	runpackPath := filepath.Join(workDir, "runpack.zip")
+	packPath := filepath.Join(workDir, "pack.zip")
+	var code int
+	raw := captureStdout(t, func() {
+		code = runMCPProxy([]string{
+			"--policy", policyPath,
+			"--call", callPath,
+			"--profile", "oss-prod",
+			"--trace-out", tracePath,
+			"--runpack-out", runpackPath,
+			"--pack-out", packPath,
+			"--key-mode", "prod",
+			"--private-key", privateKeyPath,
+			"--json",
+		})
+	})
+	if code != exitInvalidInput {
+		t.Fatalf("runMCPProxy oss-prod permissive default expected %d got %d raw=%s", exitInvalidInput, code, raw)
+	}
+	var output mcpProxyOutput
+	if err := json.Unmarshal([]byte(raw), &output); err != nil {
+		t.Fatalf("decode mcp proxy output: %v raw=%q", err, raw)
+	}
+	if output.OK || output.Error != ossProdRejectDefaultAllowError {
+		t.Fatalf("unexpected mcp proxy output for permissive default: %#v", output)
+	}
+	if output.TracePath != "" || output.RunpackPath != "" || output.PackPath != "" {
+		t.Fatalf("expected no artifact paths for rejected permissive default, got %#v", output)
+	}
+	for _, path := range []string{tracePath, runpackPath, packPath} {
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Fatalf("expected no artifact at %s, stat err=%v", path, err)
+		}
+	}
+}
+
+func TestRunMCPProxyOSSProdOAuthEvidenceValidation(t *testing.T) {
+	workDir := t.TempDir()
+	withWorkingDir(t, workDir)
+
+	privateKeyPath := filepath.Join(workDir, "trace_private.key")
+	writePrivateKey(t, privateKeyPath)
+
+	policyPath := filepath.Join(workDir, "policy.yaml")
+	mustWriteFile(t, policyPath, strings.Join([]string{
+		"default_verdict: block",
+		"rules:",
+		"  - name: allow-search",
+		"    effect: allow",
+		"    match:",
+		"      tool_names: [tool.search]",
+		"      risk_classes: [high]",
+	}, "\n")+"\n")
 
 	missingEvidencePath := filepath.Join(workDir, "oauth_missing_evidence.json")
 	mustWriteFile(t, missingEvidencePath, `{

--- a/cmd/gait/run.go
+++ b/cmd/gait/run.go
@@ -312,7 +312,7 @@ func printRunUsage() {
 func printReplayUsage() {
 	fmt.Println("Usage:")
 	fmt.Println("  gait run replay <run_id|path> [--json] [--real-tools --unsafe-real-tools --allow-tools <csv> --unsafe-real-tools-env <VAR>] [--explain]")
-	fmt.Println("  note: default mode replays recorded/stubbed results; real execution requires explicit unsafe controls.")
+	fmt.Println("  note: default mode replays recorded/stubbed results; real execution requires explicit unsafe controls and a raw-capture runpack.")
 }
 
 func runReduce(arguments []string) int {

--- a/cmd/gait/run_record.go
+++ b/cmd/gait/run_record.go
@@ -42,6 +42,11 @@ type runRecordOutput struct {
 	Error           string   `json:"error,omitempty"`
 }
 
+const (
+	runRecordRawCaptureWarning     = "raw capture retains raw intent arguments and raw result payloads; handle runpack as sensitive evidence"
+	runRecordReferenceStripWarning = "reference capture stripped raw intent arguments and raw result payloads after digesting"
+)
+
 func runRecord(arguments []string) int {
 	if hasExplainFlag(arguments) {
 		return writeExplain("Create a signed and verifiable runpack zip from normalized run, intent, result, and reference receipt records.")
@@ -221,6 +226,7 @@ func runRecord(arguments []string) int {
 			Error: "context evidence mode required but context_set_digest is missing",
 		}, exitInvalidInput)
 	}
+	captureWarnings := captureModeWarnings(recordInput, resolvedCaptureMode)
 	if signingRequested {
 		resolvedMode := strings.ToLower(strings.TrimSpace(keyMode))
 		if resolvedMode == "" {
@@ -279,7 +285,7 @@ func runRecord(arguments []string) int {
 		ManifestDigest:  result.Manifest.ManifestDigest,
 		SignatureStatus: signatureStatus,
 		SignatureKeyID:  signatureKeyID,
-		Warnings:        signingWarnings,
+		Warnings:        append(captureWarnings, signingWarnings...),
 		TicketFooter:    ticketFooter,
 	}, exitOK)
 }
@@ -347,4 +353,30 @@ func hasRawContextReceipts(receipts []schemarunpack.RefReceipt) bool {
 		}
 	}
 	return false
+}
+
+func captureModeWarnings(input runRecordInput, captureMode string) []string {
+	switch strings.ToLower(strings.TrimSpace(captureMode)) {
+	case "raw":
+		return []string{runRecordRawCaptureWarning}
+	case "reference":
+		if runRecordHasRawPayloads(input) {
+			return []string{runRecordReferenceStripWarning}
+		}
+	}
+	return nil
+}
+
+func runRecordHasRawPayloads(input runRecordInput) bool {
+	for _, intent := range input.Intents {
+		if len(intent.Args) > 0 {
+			return true
+		}
+	}
+	for _, result := range input.Results {
+		if len(result.Result) > 0 {
+			return true
+		}
+	}
+	return len(input.Normalization.IntentArgs) > 0 || len(input.Normalization.ResultPayloads) > 0
 }

--- a/cmd/gait/run_record_test.go
+++ b/cmd/gait/run_record_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	runpackcore "github.com/Clyra-AI/gait/core/runpack"
 	schemacontext "github.com/Clyra-AI/gait/core/schema/v1/context"
 	schemarunpack "github.com/Clyra-AI/gait/core/schema/v1/runpack"
 )
@@ -93,6 +94,84 @@ func TestRunRecordUnsafeContextRawGate(t *testing.T) {
 	}
 	if !withUnsafeOut.OK || withUnsafeOut.Bundle == "" {
 		t.Fatalf("expected successful run record output with bundle path, got %#v", withUnsafeOut)
+	}
+}
+
+func TestRunRecordCaptureModeWarningsAndArtifactPrivacy(t *testing.T) {
+	workDir := t.TempDir()
+	withWorkingDir(t, workDir)
+
+	input := runRecordInput{
+		Run: schemarunpack.Run{
+			RunID: "run_record_capture_privacy",
+		},
+		Intents: []schemarunpack.IntentRecord{{
+			IntentID: "intent_1",
+			ToolName: "tool.demo",
+			Args: map[string]any{
+				"path":   "/tmp/out.txt",
+				"secret": "reference-secret-arg",
+			},
+		}},
+		Results: []schemarunpack.ResultRecord{{
+			IntentID: "intent_1",
+			Status:   "ok",
+			Result: map[string]any{
+				"ok":     true,
+				"secret": "reference-secret-result",
+			},
+		}},
+		Refs: schemarunpack.Refs{
+			RunID: "run_record_capture_privacy",
+		},
+	}
+	inputPath := filepath.Join(workDir, "run_record_capture_privacy.json")
+	rawInput, err := json.Marshal(input)
+	if err != nil {
+		t.Fatalf("marshal run record input: %v", err)
+	}
+	if err := os.WriteFile(inputPath, rawInput, 0o600); err != nil {
+		t.Fatalf("write run record input: %v", err)
+	}
+
+	referenceCode, referenceOut := runRecordJSON(t, []string{
+		"--input", inputPath,
+		"--out-dir", filepath.Join(workDir, "reference-out"),
+		"--capture-mode", "reference",
+		"--json",
+	})
+	if referenceCode != exitOK {
+		t.Fatalf("expected reference capture success, got %d output=%#v", referenceCode, referenceOut)
+	}
+	if !containsString(referenceOut.Warnings, runRecordReferenceStripWarning) {
+		t.Fatalf("expected reference strip warning, got %#v", referenceOut.Warnings)
+	}
+	referencePack, err := runpackcore.ReadRunpack(referenceOut.Bundle)
+	if err != nil {
+		t.Fatalf("read reference runpack: %v", err)
+	}
+	if referencePack.Intents[0].Args != nil || referencePack.Results[0].Result != nil {
+		t.Fatalf("expected stripped reference-mode payloads, got %#v %#v", referencePack.Intents[0].Args, referencePack.Results[0].Result)
+	}
+
+	rawCode, rawOut := runRecordJSON(t, []string{
+		"--input", inputPath,
+		"--out-dir", filepath.Join(workDir, "raw-out"),
+		"--capture-mode", "raw",
+		"--json",
+	})
+	if rawCode != exitOK {
+		t.Fatalf("expected raw capture success, got %d output=%#v", rawCode, rawOut)
+	}
+	if !containsString(rawOut.Warnings, runRecordRawCaptureWarning) {
+		t.Fatalf("expected raw capture warning, got %#v", rawOut.Warnings)
+	}
+	rawPack, err := runpackcore.ReadRunpack(rawOut.Bundle)
+	if err != nil {
+		t.Fatalf("read raw runpack: %v", err)
+	}
+	if rawPack.Intents[0].Args == nil || rawPack.Results[0].Result == nil {
+		t.Fatalf("expected retained raw-mode payloads, got %#v %#v", rawPack.Intents[0].Args, rawPack.Results[0].Result)
 	}
 }
 

--- a/core/pack/exporters_test.go
+++ b/core/pack/exporters_test.go
@@ -548,6 +548,7 @@ func createRunpackFixtureWithTelemetrySignals(t *testing.T, dir string) string {
 		Refs: schemarunpack.Refs{
 			RunID: "run_export_metrics",
 		},
+		CaptureMode: "raw",
 	})
 	if err != nil {
 		t.Fatalf("write runpack fixture: %v", err)

--- a/core/regress/init_test.go
+++ b/core/regress/init_test.go
@@ -491,6 +491,7 @@ func createRunpack(t *testing.T, dir, runID string) string {
 		Refs: schemarunpack.Refs{
 			RunID: runID,
 		},
+		CaptureMode: "raw",
 	})
 	if err != nil {
 		t.Fatalf("write runpack: %v", err)

--- a/core/regress/run_test.go
+++ b/core/regress/run_test.go
@@ -950,6 +950,7 @@ func createVariantRunpackWithTool(t *testing.T, dir, runID, variant string, tool
 		Refs: schemarunpack.Refs{
 			RunID: runID,
 		},
+		CaptureMode: "raw",
 	})
 	if err != nil {
 		t.Fatalf("write variant runpack: %v", err)

--- a/core/runpack/read_replay_test.go
+++ b/core/runpack/read_replay_test.go
@@ -296,6 +296,15 @@ func TestReplayRealRequiresAllowlist(t *testing.T) {
 	}
 }
 
+func TestReplayRealRejectsReferenceModeRunpack(t *testing.T) {
+	path := writeTestRunpackWithCaptureMode(t, "run_replay_real_reference", buildIntents("intent_1"), buildResults("intent_1"), "reference")
+	if _, err := ReplayReal(path, RealReplayOptions{AllowTools: []string{"tool.demo"}}); err == nil {
+		t.Fatalf("expected replay real to reject reference-mode runpacks")
+	} else if !strings.Contains(err.Error(), "capture_mode=raw") {
+		t.Fatalf("expected raw-capture guidance, got %v", err)
+	}
+}
+
 func TestReplayRealExecutesAllowedToolsAndKeepsRecordedFallback(t *testing.T) {
 	workDir := t.TempDir()
 	outputPath := filepath.Join(workDir, "out.txt")
@@ -474,6 +483,10 @@ func writeTestRunpack(t *testing.T, runID string, intents []schemarunpack.Intent
 }
 
 func writeTestRunpackWithIntents(t *testing.T, runID string, intents []schemarunpack.IntentRecord, results []schemarunpack.ResultRecord) string {
+	return writeTestRunpackWithCaptureMode(t, runID, intents, results, "raw")
+}
+
+func writeTestRunpackWithCaptureMode(t *testing.T, runID string, intents []schemarunpack.IntentRecord, results []schemarunpack.ResultRecord, captureMode string) string {
 	run := schemarunpack.Run{
 		RunID:     runID,
 		CreatedAt: time.Date(2026, time.February, 5, 0, 0, 0, 0, time.UTC),
@@ -490,7 +503,7 @@ func writeTestRunpackWithIntents(t *testing.T, runID string, intents []schemarun
 		Refs: schemarunpack.Refs{
 			RunID: runID,
 		},
-		CaptureMode: "raw",
+		CaptureMode: captureMode,
 	})
 	if err != nil {
 		t.Fatalf("write runpack: %v", err)

--- a/core/runpack/read_replay_test.go
+++ b/core/runpack/read_replay_test.go
@@ -490,6 +490,7 @@ func writeTestRunpackWithIntents(t *testing.T, runID string, intents []schemarun
 		Refs: schemarunpack.Refs{
 			RunID: runID,
 		},
+		CaptureMode: "raw",
 	})
 	if err != nil {
 		t.Fatalf("write runpack: %v", err)

--- a/core/runpack/record.go
+++ b/core/runpack/record.go
@@ -68,6 +68,7 @@ func RecordRun(options RecordOptions) (RecordResult, error) {
 	if captureMode == "" {
 		captureMode = "reference"
 	}
+	intents, results = applyCaptureModePayloadPolicy(intents, results, captureMode)
 
 	runBytes, err := canonicalJSON(run)
 	if err != nil {
@@ -465,4 +466,21 @@ func digestJSONValue(value any) (string, error) {
 		return "", err
 	}
 	return jcs.DigestJCS(raw)
+}
+
+func applyCaptureModePayloadPolicy(
+	intents []schemarunpack.IntentRecord,
+	results []schemarunpack.ResultRecord,
+	captureMode string,
+) ([]schemarunpack.IntentRecord, []schemarunpack.ResultRecord) {
+	if !strings.EqualFold(strings.TrimSpace(captureMode), "reference") {
+		return intents, results
+	}
+	for index := range intents {
+		intents[index].Args = nil
+	}
+	for index := range results {
+		results[index].Result = nil
+	}
+	return intents, results
 }

--- a/core/runpack/record_test.go
+++ b/core/runpack/record_test.go
@@ -334,7 +334,7 @@ func TestRecordRunInvalidIntent(test *testing.T) {
 			Args:       map[string]any{"bad": make(chan int)},
 		},
 	}
-	if _, err := RecordRun(RecordOptions{Run: run, Intents: intents}); err == nil {
+	if _, err := RecordRun(RecordOptions{Run: run, Intents: intents, CaptureMode: "raw"}); err == nil {
 		test.Fatalf("expected error for invalid intent args")
 	}
 }
@@ -409,6 +409,158 @@ func TestRecordRunNormalizesMissingDigestsFromNormalization(test *testing.T) {
 	}
 	if refsDecoded.Receipts[0].ContentDigest != resultsDecoded[0].ResultDigest {
 		test.Fatalf("expected content digest to match normalized result digest")
+	}
+}
+
+func TestRecordRunReferenceModeStripsRawPayloadsAfterDigestNormalization(test *testing.T) {
+	run := schemarunpack.Run{
+		RunID: "run_reference_strip",
+		Env:   schemarunpack.RunEnv{OS: "linux", Arch: "amd64", Runtime: "go"},
+		Timeline: []schemarunpack.TimelineEvt{
+			{Event: "start", TS: time.Date(2026, time.February, 5, 0, 0, 0, 0, time.UTC)},
+		},
+	}
+	secretArg := "ghp_reference_secret_demo_1234567890"
+	secretResult := "sk-reference-result-demo-abcdef"
+	intents := []schemarunpack.IntentRecord{{
+		IntentID: "intent_1",
+		ToolName: "tool.write",
+		Args: map[string]any{
+			"path":   "/tmp/out.txt",
+			"secret": secretArg,
+		},
+	}}
+	results := []schemarunpack.ResultRecord{{
+		IntentID: "intent_1",
+		Status:   "ok",
+		Result: map[string]any{
+			"ok":     true,
+			"secret": secretResult,
+		},
+	}}
+	refs := schemarunpack.Refs{
+		Receipts: []schemarunpack.RefReceipt{{
+			RefID:         "trace_intent_1",
+			SourceType:    "gait.trace",
+			SourceLocator: "trace://trace_intent_1",
+			RetrievedAt:   time.Date(2026, time.February, 5, 0, 0, 1, 0, time.UTC),
+			RedactionMode: "reference",
+		}},
+	}
+	expectedArgsDigest, err := digestJSONValue(intents[0].Args)
+	if err != nil {
+		test.Fatalf("digest args: %v", err)
+	}
+	expectedResultDigest, err := digestJSONValue(results[0].Result)
+	if err != nil {
+		test.Fatalf("digest result: %v", err)
+	}
+
+	result, err := RecordRun(RecordOptions{
+		Run:         run,
+		Intents:     intents,
+		Results:     results,
+		Refs:        refs,
+		CaptureMode: "reference",
+	})
+	if err != nil {
+		test.Fatalf("record run: %v", err)
+	}
+	files := readZipFiles(test, result.ZipBytes)
+	if bytes.Contains(files["intents.jsonl"], []byte(secretArg)) {
+		test.Fatalf("expected stripped reference intents to omit raw secret payload")
+	}
+	if bytes.Contains(files["results.jsonl"], []byte(secretResult)) {
+		test.Fatalf("expected stripped reference results to omit raw secret payload")
+	}
+	if bytes.Contains(result.ZipBytes, []byte(secretArg)) || bytes.Contains(result.ZipBytes, []byte(secretResult)) {
+		test.Fatalf("expected reference zip bytes to omit raw secret payload strings")
+	}
+
+	intentsDecoded, err := decodeJSONL[schemarunpack.IntentRecord](files["intents.jsonl"])
+	if err != nil {
+		test.Fatalf("decode intents: %v", err)
+	}
+	if intentsDecoded[0].Args != nil {
+		test.Fatalf("expected reference-mode intents to strip raw args, got %#v", intentsDecoded[0].Args)
+	}
+	if intentsDecoded[0].ArgsDigest != expectedArgsDigest {
+		test.Fatalf("expected preserved args digest %q got %q", expectedArgsDigest, intentsDecoded[0].ArgsDigest)
+	}
+
+	resultsDecoded, err := decodeJSONL[schemarunpack.ResultRecord](files["results.jsonl"])
+	if err != nil {
+		test.Fatalf("decode results: %v", err)
+	}
+	if resultsDecoded[0].Result != nil {
+		test.Fatalf("expected reference-mode results to strip raw payloads, got %#v", resultsDecoded[0].Result)
+	}
+	if resultsDecoded[0].ResultDigest != expectedResultDigest {
+		test.Fatalf("expected preserved result digest %q got %q", expectedResultDigest, resultsDecoded[0].ResultDigest)
+	}
+
+	var refsDecoded schemarunpack.Refs
+	if err := json.Unmarshal(files["refs.json"], &refsDecoded); err != nil {
+		test.Fatalf("decode refs: %v", err)
+	}
+	if refsDecoded.Receipts[0].QueryDigest == "" || refsDecoded.Receipts[0].ContentDigest == "" {
+		test.Fatalf("expected normalized receipt digests, got %#v", refsDecoded.Receipts[0])
+	}
+	if refsDecoded.Receipts[0].ContentDigest != expectedResultDigest {
+		test.Fatalf("expected preserved content digest %q got %q", expectedResultDigest, refsDecoded.Receipts[0].ContentDigest)
+	}
+}
+
+func TestRecordRunRawModeRetainsRawPayloads(test *testing.T) {
+	run := schemarunpack.Run{
+		RunID: "run_raw_keep",
+		Env:   schemarunpack.RunEnv{OS: "linux", Arch: "amd64", Runtime: "go"},
+		Timeline: []schemarunpack.TimelineEvt{
+			{Event: "start", TS: time.Date(2026, time.February, 5, 0, 0, 0, 0, time.UTC)},
+		},
+	}
+	intents := []schemarunpack.IntentRecord{{
+		IntentID: "intent_1",
+		ToolName: "tool.write",
+		Args: map[string]any{
+			"path":   "/tmp/out.txt",
+			"secret": "raw-intent-secret",
+		},
+	}}
+	results := []schemarunpack.ResultRecord{{
+		IntentID: "intent_1",
+		Status:   "ok",
+		Result: map[string]any{
+			"ok":     true,
+			"secret": "raw-result-secret",
+		},
+	}}
+
+	result, err := RecordRun(RecordOptions{
+		Run:         run,
+		Intents:     intents,
+		Results:     results,
+		CaptureMode: "raw",
+	})
+	if err != nil {
+		test.Fatalf("record run: %v", err)
+	}
+	files := readZipFiles(test, result.ZipBytes)
+
+	intentsDecoded, err := decodeJSONL[schemarunpack.IntentRecord](files["intents.jsonl"])
+	if err != nil {
+		test.Fatalf("decode intents: %v", err)
+	}
+	if intentsDecoded[0].Args == nil || intentsDecoded[0].Args["secret"] != "raw-intent-secret" {
+		test.Fatalf("expected raw-mode intent payload retention, got %#v", intentsDecoded[0].Args)
+	}
+
+	resultsDecoded, err := decodeJSONL[schemarunpack.ResultRecord](files["results.jsonl"])
+	if err != nil {
+		test.Fatalf("decode results: %v", err)
+	}
+	if resultsDecoded[0].Result == nil || resultsDecoded[0].Result["secret"] != "raw-result-secret" {
+		test.Fatalf("expected raw-mode result payload retention, got %#v", resultsDecoded[0].Result)
 	}
 }
 

--- a/core/runpack/replay.go
+++ b/core/runpack/replay.go
@@ -67,6 +67,9 @@ func replay(path string, mode ReplayMode, allowSet map[string]struct{}) (ReplayR
 	if err != nil {
 		return ReplayResult{}, err
 	}
+	if mode == ReplayModeReal && strings.EqualFold(strings.TrimSpace(pack.Manifest.CaptureMode), "reference") {
+		return ReplayResult{}, fmt.Errorf("real replay requires capture_mode=raw; reference-mode runpacks strip raw tool inputs")
+	}
 	seenIntents := make(map[string]struct{}, len(pack.Intents))
 	for _, intent := range pack.Intents {
 		if _, exists := seenIntents[intent.IntentID]; exists {

--- a/docs-site/public/llm/contracts.md
+++ b/docs-site/public/llm/contracts.md
@@ -11,10 +11,12 @@ Stable OSS contracts include:
 - **CLI Meta Contract**: `gait --help` is text-only and exits `0`; machine-readable version discovery uses `gait version --json` or the `--version` / `-v` aliases.
 - **Python SDK Demo Contract**: machine-readable SDK/demo capture consumes `gait demo --json` output only; the human text form is non-contractual.
   - `run_session(...)` delegates digest-bearing runpack fields to `gait run record` in Go rather than hashing them in Python.
+  - `gait run record` defaults to `capture_mode=reference`, strips raw `intents[].args` and `results[].result` after digesting, and warns when explicit raw capture is selected.
   - unsupported `set` values and other non-JSON payloads are rejected deterministically.
   - `sdk/python` version metadata is repo-local dev metadata; release/install verification uses `gait version --json`.
 - **Doctor Install Contract**: `gait doctor --json` is truthful for a clean writable binary-install lane, returning `status=pass|warn` there and only surfacing repo-only checks from a Gait repo checkout.
 - **Repo Policy Contract**: `gait init` writes `.gait.yaml` and returns `detected_signals`, `generated_rules`, and `unknown_signals`; `gait check` reports the live contract with `default_verdict`, `rule_count`, structured `findings`, compatibility `gap_warnings`, and install-safe `next_commands`.
+- **Strict `oss-prod` Policy Contract**: `gait gate eval`, `gait mcp proxy`, and `gait mcp serve` reject policies that set `default_verdict: allow`; strict profiles must use `block` or `require_approval` defaults plus explicit allow rules.
 - **Draft Proposal Migration Contract**: keep the shipped policy DSL (`schema_id`, `schema_version`, `default_verdict`, optional `fail_closed`, optional `mcp_trust`, `rules`); proposal keys like `version`, `name`, `boundaries`, `defaults`, `trust_sources`, and `unknown_server` return deterministic migration guidance instead of enabling a second DSL.
 - **CLI Migration Contract**: use `gait mcp verify` rather than `gait mcp-verify`, and `gait capture --out ...` rather than `gait capture --save-as ...`.
 - **Equal-Priority Policy Semantics**: when multiple rules at the same priority match one intent, Gait evaluates that priority tier and applies the most restrictive verdict rather than depending on rule names.

--- a/docs-site/public/llm/faq.md
+++ b/docs-site/public/llm/faq.md
@@ -44,7 +44,7 @@ For context-required policies, the gate only trusts a verified `--context-envelo
 
 ## How do I know install is valid and high-risk enforcement is production-ready?
 
-Use `gait version --json` as the machine-readable install probe. For `oss-prod`, use the canonical template at `examples/config/oss_prod_template.yaml`: copy it from a repo checkout, or fetch that same file after a binary-only install, then run `gait check --json` and require `gait doctor --production-readiness --json` to return `ok=true` before treating high-risk enforcement as production-ready.
+Use `gait version --json` as the machine-readable install probe. For `oss-prod`, use the canonical template at `examples/config/oss_prod_template.yaml`: copy it from a repo checkout, or fetch that same file after a binary-only install, then run `gait check --json` and require `gait doctor --production-readiness --json` to return `ok=true` before treating high-risk enforcement as production-ready. In that strict profile, policies with `default_verdict: allow` are rejected; use `block` or `require_approval` defaults and express allow paths with explicit rules.
 
 ## Can I replay an agent run without re-executing real API calls?
 

--- a/docs-site/public/llm/quickstart.md
+++ b/docs-site/public/llm/quickstart.md
@@ -48,6 +48,8 @@ For SDKs and wrappers, prefer the JSON form and treat the text form as human-fac
 
 `run_session(...)` and other Python run-capture helpers delegate digest-bearing artifact fields to `gait run record` in Go. Convert `set` values to JSON lists before calling the SDK; unsupported non-JSON payloads are rejected.
 
+`gait run record` defaults to `capture_mode=reference`: it computes digests, keeps receipts deterministic, and strips raw `intents[].args` and `results[].result` from the emitted runpack. Use `--capture-mode raw` only when you explicitly want sensitive payload retention.
+
 For binary discovery and install automation, use `gait version --json` (or `gait --version --json` / `gait -v --json`). `gait --help` is text-only and exits `0`.
 
 Context-required policies must pass `--context-envelope <context_envelope.json>` on `gait gate eval`, `gait mcp proxy`, or `gait mcp serve`; raw intent context claims are not authoritative by themselves.
@@ -79,6 +81,8 @@ curl -fsSL https://raw.githubusercontent.com/Clyra-AI/gait/main/examples/config/
 gait check --json
 gait doctor --production-readiness --json
 ```
+
+In `oss-prod`, policies with `default_verdict: allow` are rejected. Use `block` or `require_approval` as the policy default, then grant allow paths with explicit rules.
 
 Do not treat `oss-prod` enforcement as production-ready until that doctor command reports `ok=true`.
 

--- a/docs-site/public/llm/security.md
+++ b/docs-site/public/llm/security.md
@@ -5,8 +5,10 @@
 - Gate freeze-window rules can deterministically block or approval-gate production-impacting actions using policy-owned IANA timezones and replayable `--evaluation-time` inputs.
 - Gate sandbox posture rules can block high-risk `proc.exec` when network, filesystem, timeout, env exposure, privilege mode, or sandbox evidence metadata is missing or too permissive.
 - Gate generalized kill-switch state can block matching agents, identities, tools, targets, paths, workspaces, and environments with fail-closed behavior when configured state is unavailable in strict profiles.
+- `oss-prod` rejects policies that set `default_verdict: allow`; strict profiles must default to `block` or `require_approval` and use explicit allow rules.
 - Gate explain JSON gives machine-readable missing-state and fail-closed status so blocked or undecidable outcomes are not mistaken for silent success.
 - Provider-style credential broker receipts normalize refs and metadata only; raw secret-bearing broker payloads are rejected.
+- `gait run record` reference mode digests raw args/results and strips them from `intents.jsonl` and `results.jsonl`; raw payload retention is explicit via `--capture-mode raw` and is warned.
 - Approved-script promotion remains bounded by signed digest, explicit scope, and expiry; stale or mismatched entries fall back to normal approval or block behavior.
 - Authorization bundles detect tampered linked evidence even when the outer pack structure is otherwise intact.
 - Out-of-band emergency stop preemption blocks post-stop dispatches and records signed proof events.

--- a/docs-site/public/llms.txt
+++ b/docs-site/public/llms.txt
@@ -40,6 +40,7 @@
 - Input: structured intent payload.
 - Rule: `verdict != allow` means no tool execution.
 - Fast proof (`gait doctor --json`, `gait demo`, `gait regress bootstrap`) is not the same thing as strict inline enforcement.
+- In `oss-prod`, policies with `default_verdict: allow` are rejected at `gait gate eval`, `gait mcp proxy`, and `gait mcp serve`; use `block` or `require_approval` plus explicit allow rules.
 - Context-required policies must receive `--context-envelope <context_envelope.json>` at that boundary; raw context digest/mode/age claims are not authoritative alone.
 - For `gait mcp serve`, same-host callers may use `call.context.context_envelope_path` only when the server explicitly enables `--allow-client-artifact-paths`.
 - Official LangChain lane: middleware with optional callback correlation, not a separate policy engine.
@@ -71,6 +72,7 @@
 - `sdk/python` keeps repo-local dev metadata (`0.0.0.dev0`); release/install automation should use `gait version --json`.
 - Machine-readable wrappers and SDKs use `gait demo --json`; the text form is human-facing only.
 - Python run-session capture delegates digest-bearing artifact fields to `gait run record` in Go; convert `set` values to JSON lists before calling the SDK.
+- `gait run record` defaults to `capture_mode=reference`: it digests raw args/results, emits refs and receipts, strips raw `intents[].args` and `results[].result`, and warns when explicit `--capture-mode raw` retention is selected.
 - `examples/integrations/claude_code/` is a reference adapter; hook/runtime/input errors fail closed by default and `GAIT_CLAUDE_UNSAFE_FAIL_OPEN=1` is an unsafe opt-in override.
 - `gait doctor --json` is install-safe in a clean writable directory: it returns the installed-binary lane with `status=pass|warn` and only adds repo-only checks in a Gait repo checkout.
 - High-risk `oss-prod` claims require the separate readiness gate: `gait doctor --production-readiness --json`.

--- a/docs/contracts/primitive_contract.md
+++ b/docs/contracts/primitive_contract.md
@@ -252,6 +252,8 @@ Producer obligations:
 - MUST generate byte-stable artifacts for identical inputs.
 - MUST use RFC 8785 (JCS) canonicalization for digest-bearing JSON.
 - MUST record `capture_mode` (`reference` default, `raw` explicit).
+- In `reference` capture, MUST compute digest-bearing fields before serialization and MUST omit raw `intents[].args` and `results[].result` from the emitted runpack.
+- In `raw` capture, MAY retain raw `intents[].args` and `results[].result`, but only when the caller explicitly selects raw capture.
 - SDK or wrapper helper inputs MAY omit digest-bearing fields only when a Go-authoritative normalization path computes them before artifact emission.
 
 Consumer obligations:
@@ -300,6 +302,7 @@ Consumer obligations:
   - `--context-envelope <path>`
   - `--context-evidence-mode best_effort|required`
   - `--unsafe-context-raw`
+  - `capture_mode=reference` strips raw intent/result payload objects after digesting; `capture_mode=raw` is explicit and operator-visible
   - additive normalization helpers may be used by thin SDK/wrapper lanes so Go computes digest-bearing record fields before runpack emission
 - `gait regress run`:
   - `--context-conformance`

--- a/docs/policy_authoring.md
+++ b/docs/policy_authoring.md
@@ -104,6 +104,8 @@ Most policies start with these fields:
 - `mcp_trust`: optional local trust-snapshot contract for MCP server admission
 - `rules`: ordered rule list
 
+For `oss-prod`, `default_verdict: allow` is not valid. Strict profiles must use `block` or `require_approval` as the policy default and express allow paths with explicit rules.
+
 Example:
 
 ```yaml
@@ -227,7 +229,7 @@ gait keys verify --private-key ./gait-out/keys/prod_private.key --public-key ./g
 
 ### What happens if no rule matches a tool call?
 
-The default action applies. In fail-closed mode (`oss-prod` profile), the default is block. In standard mode, the default is configurable per policy.
+The policy default applies. In standard mode, that default remains configurable per policy. In `oss-prod`, permissive `default_verdict: allow` policies are rejected, so unmatched actions can only fall back to `block` or `require_approval`.
 
 ### Can I test a policy without affecting production?
 

--- a/examples/policy/README.md
+++ b/examples/policy/README.md
@@ -88,6 +88,7 @@ Expected verdict matrix:
 High-risk note:
 
 - `base_high_risk.yaml` marks write actions with `require_broker_credential: true` for least-privilege brokering.
+- `oss-prod` rejects policies that set `default_verdict: allow`; keep strict profiles on `block` or `require_approval` and grant allow paths with explicit rules.
 - `base_high_risk.yaml` and `baseline-highrisk.yaml` accept scoped, time-bounded
   AWS STS, GitHub OIDC, and Vault-style dynamic credentials for covered
   high-risk write and deploy paths by default.

--- a/internal/e2e/v17_runtime_fail_closed_test.go
+++ b/internal/e2e/v17_runtime_fail_closed_test.go
@@ -69,7 +69,7 @@ func TestCLIV17FailClosedMatrix(t *testing.T) {
 
 	highRiskNoBrokerPolicy := filepath.Join(workDir, "policy_high_risk_no_broker.yaml")
 	if err := os.WriteFile(highRiskNoBrokerPolicy, []byte(strings.Join([]string{
-		"default_verdict: allow",
+		"default_verdict: block",
 		"rules:",
 		"  - name: high-risk-allow-without-broker",
 		"    effect: allow",
@@ -198,7 +198,7 @@ func TestCLIV17FailClosedMatrix(t *testing.T) {
 
 	highRiskWithBrokerPolicy := filepath.Join(workDir, "policy_high_risk_with_broker.yaml")
 	if err := os.WriteFile(highRiskWithBrokerPolicy, []byte(strings.Join([]string{
-		"default_verdict: allow",
+		"default_verdict: block",
 		"rules:",
 		"  - name: high-risk-allow-with-broker",
 		"    effect: allow",

--- a/internal/integration/testdata/record_verify_replay_diff.golden.json
+++ b/internal/integration/testdata/record_verify_replay_diff.golden.json
@@ -9,7 +9,7 @@
     "context_drift_classification": "none"
   },
   "files_checked": 4,
-  "manifest_digest": "d4f0f83b6501b6a17faa089047f92cfd9ebcccbb199f07f05fc5bd5cc4a7efc4",
+  "manifest_digest": "5df30db691a7623bbad16c19ddda77f801ac9aad853a615ca6511c628f21f5d8",
   "replay_mode": "stub",
   "replay_steps": 2,
   "run_id": "run_integration",

--- a/schemas/v1/runpack/intent.schema.json
+++ b/schemas/v1/runpack/intent.schema.json
@@ -22,7 +22,10 @@
     "intent_id": { "type": "string" },
     "tool_name": { "type": "string" },
     "args_digest": { "type": "string", "pattern": "^[a-fA-F0-9]{64}$" },
-    "args": { "type": "object" }
+    "args": {
+      "type": "object",
+      "description": "Raw intent arguments. Present only when capture_mode=raw; reference mode records args_digest and omits args."
+    }
   },
   "additionalProperties": false
 }

--- a/schemas/v1/runpack/manifest.schema.json
+++ b/schemas/v1/runpack/manifest.schema.json
@@ -19,7 +19,11 @@
     "created_at": { "type": "string", "format": "date-time" },
     "producer_version": { "type": "string" },
     "run_id": { "type": "string", "pattern": "^run_[A-Za-z0-9_-]+$" },
-    "capture_mode": { "type": "string", "enum": ["reference", "raw"] },
+    "capture_mode": {
+      "type": "string",
+      "enum": ["reference", "raw"],
+      "description": "reference stores digests and refs without raw intent/result payload objects; raw explicitly retains raw payloads."
+    },
     "files": {
       "type": "array",
       "items": {

--- a/schemas/v1/runpack/result.schema.json
+++ b/schemas/v1/runpack/result.schema.json
@@ -22,7 +22,10 @@
     "intent_id": { "type": "string" },
     "status": { "type": "string", "enum": ["ok", "error"] },
     "result_digest": { "type": "string", "pattern": "^[a-fA-F0-9]{64}$" },
-    "result": { "type": "object" }
+    "result": {
+      "type": "object",
+      "description": "Raw result payload. Present only when capture_mode=raw; reference mode records result_digest and omits result."
+    }
   },
   "additionalProperties": false
 }


### PR DESCRIPTION
## Problem
- `oss-prod` policy evaluation still accepted `default_verdict: allow`, which left room for permissive unmatched tool calls at the Gate and MCP boundary.
- Reference-mode runpack recording still serialized raw intent args and raw result payloads after digesting, weakening the privacy-by-default contract.
- The docs and schema descriptions did not fully describe the stricter `oss-prod` default or the reference-mode payload stripping behavior.

## Changes
- Reject `default_verdict: allow` for `gait gate eval --profile oss-prod` and cover the fail-closed behavior in CLI, MCP, and e2e tests.
- Strip `intents[].args` and `results[].result` from reference-mode runpacks after digesting, and update runpack tests plus the integration golden fixture.
- Align README, policy docs, examples, schema descriptions, and LLM docs with the stricter `oss-prod` and reference-capture behavior.

## Validation
- `make prepush-full`
- Pre-push hook: `make prepush`

## Risks
- Existing strict-profile policies that still set `default_verdict: allow` will now fail fast in `oss-prod` until they move to `block` or `require_approval`.
- Reference-mode consumers that incorrectly expected raw `args` or `result` payloads will now need to rely on digests/refs or opt into `--capture-mode raw`.

## Notes
- No submodule pointer changes.
