### PR TITLE
hotfix: align v1.7 oss-prod acceptance fixtures (r1)

### DIFF
--- a/scripts/test_v1_7_acceptance.sh
+++ b/scripts/test_v1_7_acceptance.sh
@@ -225,7 +225,7 @@ private_key_path="$WORK_DIR/trace_private.key"
 generate_private_key_file "$private_key_path"
 
 cat >"$WORK_DIR/high_risk_no_broker.yaml" <<'YAML'
-default_verdict: allow
+default_verdict: block
 rules:
   - name: high-risk-allow-without-broker
     effect: allow
@@ -277,7 +277,7 @@ if ! grep -q "require_broker_credential" "$WORK_DIR/fail_closed_missing_signals.
 fi
 
 cat >"$WORK_DIR/high_risk_with_broker.yaml" <<'YAML'
-default_verdict: allow
+default_verdict: block
 rules:
   - name: high-risk-allow-with-broker
     effect: allow


### PR DESCRIPTION
## Problem
- The merge of PR #143 landed cleanly, but post-merge monitoring on `main` caught a failing `ci` run for commit `ce1bc42a85b254c6260c02b433782d69e294ba1d`.
- The failure was isolated to job `v1-7-acceptance`, where `scripts/test_v1_7_acceptance.sh` still generated strict-mode fixture policies with `default_verdict: allow`.
- `oss-prod` now correctly rejects permissive defaults, so the acceptance fixture drift caused the default-branch regression rather than the runtime behavior itself.

## Changes
- Update the `high_risk_no_broker.yaml` fixture snippet in `scripts/test_v1_7_acceptance.sh` to use `default_verdict: block`.
- Update the `high_risk_with_broker.yaml` fixture snippet in the same acceptance script to use `default_verdict: block`.

## Validation
- `make test-v1-7-acceptance`
- `make prepush-full`
- Pre-push hook: `make prepush`

## Risks
- Very low: this only aligns acceptance fixtures with the already-landed `oss-prod` contract.
- No runtime code paths, schemas, or docs changed in this hotfix.

## Notes
- Hotfix branch created from merged `main` after post-merge CI failure on run `25764015919`.
