### PR TITLE
hotfix: align v2.4 real replay acceptance (r2)

### DIFF
--- a/scripts/test_v2_4_acceptance.sh
+++ b/scripts/test_v2_4_acceptance.sh
@@ -208,7 +208,10 @@ if [[ $BLOCKED_CODE -eq 0 ]]; then
   echo "expected replay with --real-tools only to fail" >&2
   exit 1
 fi
-GAIT_ALLOW_REAL_REPLAY=1 "$BIN_PATH" run replay "$WORK_DIR/gait-out/runpack_run_tck.zip" --real-tools --unsafe-real-tools --allow-tools echo --json > "$WORK_DIR/replay_real.json"
+
+mkdir -p "$WORK_DIR/gait-out-raw"
+"$BIN_PATH" run record --input "$WORK_DIR/run_record_input.json" --out-dir "$WORK_DIR/gait-out-raw" --capture-mode raw --key-mode dev --json > "$WORK_DIR/run_record_raw.json"
+GAIT_ALLOW_REAL_REPLAY=1 "$BIN_PATH" run replay "$WORK_DIR/gait-out-raw/runpack_run_tck.zip" --real-tools --unsafe-real-tools --allow-tools echo --json > "$WORK_DIR/replay_real.json"
 
 python3 - "$WORK_DIR/replay_real.json" <<'PY'
 import json


### PR DESCRIPTION
## Problem
- After hotfix PR #144 fixed the `v1-7-acceptance` default-branch regression, post-merge monitoring on `main` surfaced a second failing `ci` run for commit `5d0b0b3e53d09272ec333f4544b700d774938a03`.
- The failure was isolated to job `v2-4-acceptance`, where `scripts/test_v2_4_acceptance.sh` still expected successful real replay from `run_tck` after recording it with the default reference capture mode.
- The runtime now correctly blocks real replay on reference-mode runpacks, so the acceptance needed a dedicated raw-capture artifact for the explicit unsafe real-replay subsection.

## Changes
- Keep the primary `run_tck` recording on the default reference-capture path for the rest of the `v2.4` acceptance coverage.
- Add a second `run record --capture-mode raw` artifact only for the real-replay subsection and point the explicit unsafe replay call at that raw runpack.

## Validation
- `make test-v2-4-acceptance`
- `make prepush-full`
- Pre-push hook: `make prepush`

## Risks
- Very low: this only narrows the acceptance harness so it uses raw capture where the runtime now requires it.
- No runtime behavior, schemas, or docs changed in this hotfix.

## Notes
- Hotfix branch created from merged `main` after post-merge CI failure on run `25764657177`.
