### PR TITLE
[codex] add plan verify repair wrapper

### DIFF
--- a/.agents/skills/plan-verify-repair/SKILL.md
+++ b/.agents/skills/plan-verify-repair/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: plan-verify-repair
+description: Verify implemented Factory plans against original source requirements, run all required validation lanes, create a repair branch when gaps exist, and fix gaps until all requirements are satisfied.
+disable-model-invocation: true
+---
+
+# Plan Verify Repair
+
+This is a local discovery wrapper for the shared Factory skill at `factory/skills/plan-verify-repair/SKILL.md`.
+
+Before using this skill:
+
+1. Verify `factory/skills/plan-verify-repair/SKILL.md` exists.
+2. If it is missing, stop and ask the user to run:
+
+```bash
+git submodule update --init factory
+```
+
+Then read `factory/skills/plan-verify-repair/SKILL.md` and follow that Factory skill exactly, using the active `gait` repo profile unless the user provides another explicit profile.
+
+Do not treat this wrapper as the source of truth. The Factory skill is authoritative.
+
+Gait repository skill contract:
+
+- When command evidence is needed, prefer `gait doctor --json` or another active-profile `gait ... --json` command from `factory/profiles/gait.yaml`.
+- Require `--json` output for machine-readable command evidence.

--- a/.agents/skills/plan-verify-repair/agents/openai.yaml
+++ b/.agents/skills/plan-verify-repair/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Plan Verify Repair"
+  short_description: "Verify plans and repair all gaps"
+  default_prompt: "Use $plan-verify-repair to verify implemented plans against source requirements, run all required tests, and repair every gap."


### PR DESCRIPTION
## Summary

Adds the local `.agents` discovery wrapper for the shared Factory `plan-verify-repair` skill, including Gait's `gait ... --json` command-evidence contract, and bumps the `factory` submodule to the merged Factory commit that contains the shared skill.

## Validation

- `python3 scripts/validate_repo_skills.py`
- `git push` pre-push hook: `make prepush`
- wrapper metadata/frontmatter scan
- shared skill presence check under `factory/skills/plan-verify-repair/SKILL.md`
- `git diff --check`