### PR TITLE
chore: bump Go toolchain to 1.26.4

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-golang 1.26.1
+golang 1.26.4
 python 3.13.7

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Clyra-AI/gait
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/Clyra-AI/proof v0.4.6


### PR DESCRIPTION
## Problem
- Scheduled GitHub Actions runs `26935870692` (`adoption-nightly`) and `26934181573` (`nightly-full-windows`) both failed on `main` at commit `a345cd0854c0e8ea2796562774b5144048d9afe4`.
- The failing step was the repo lint lane's `govulncheck -mode=binary` scan against a binary built with Go `1.26.3`.
- `govulncheck` reported standard-library vulnerabilities fixed in Go `1.26.4`, including `GO-2026-5039` in `net/textproto` and `GO-2026-5037` in `crypto/x509`.

## Changes
- Bump the repo Go toolchain pin in `go.mod` from `1.26.3` to `1.26.4`.
- Keep the fix scoped to the shared toolchain source so all workflows using `actions/setup-go` via `go-version-file: go.mod` pick up the patched release.

## Validation
- `make prepush-full`
- Repo pre-push hook `make prepush`
- Confirmed the previously failing path now passes: `go build -o ./gait ./cmd/gait && go run golang.org/x/vuln/cmd/govulncheck@v1.1.4 -mode=binary ./gait`

## Risks
- Low risk patch bump only; no product code or workflow logic changes.
- The repo hook configuration needed the standard local setup step `make hooks` before validation on this machine.

## Submodule Notes
- No submodule pointer updates.
