### PR TITLE
test: restore action contract coverage gate

### DIFF
--- a/core/actioncontract/actioncontract_test.go
+++ b/core/actioncontract/actioncontract_test.go
@@ -304,6 +304,24 @@ func TestVerifyActivationEnforcesValidityAtExplicitEvaluationTime(t *testing.T) 
 	}
 }
 
+func TestPublicArtifactAndKeyHelperBranches(t *testing.T) {
+	if got := (&ValidationError{}).Error(); got != "action contract validation failed" {
+		t.Fatalf("unexpected empty validation error: %q", got)
+	}
+	if got := (*ValidationError)(nil).Error(); got != "action contract validation failed" {
+		t.Fatalf("unexpected nil validation error: %q", got)
+	}
+	if _, _, err := ReadActivatedArtifact(""); err == nil {
+		t.Fatal("empty activation path accepted")
+	}
+	if _, _, err := ReadActivatedArtifact(filepath.Join(t.TempDir(), "missing.json")); err == nil {
+		t.Fatal("missing activation path accepted")
+	}
+	if encoded := EncodePrivateKey(mustKey(t)); encoded == "" {
+		t.Fatal("private key encoding is empty")
+	}
+}
+
 func TestSelectionEvidenceRejectsSymlinkOutsideRoot(t *testing.T) {
 	root := t.TempDir()
 	scenarioDir := filepath.Join(root, "scenario")


### PR DESCRIPTION
## Summary
- add focused coverage for public action-contract helper error/key branches
- restore `core/actioncontract` package coverage above the repository’s 75% threshold

## Validation
- `go test -race ./core/actioncontract ./cmd/gait`
- full Go coverage suite passes with only the known sandbox IPv6 bind failure excluded (`core/registry.TestInstallRemoteWithSignatureAndPin`)
- actioncontract coverage: 75.8%

This is test-only and based directly on merged `main` at 0897620. No production behavior or fixture bytes change.