### PR TITLE
test: restore action contract coverage margin

### DIFF
--- a/cmd/gait/actioncontract_test.go
+++ b/cmd/gait/actioncontract_test.go
@@ -4,6 +4,7 @@ import (
 	"crypto/ed25519"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
@@ -99,6 +100,174 @@ func TestActionContractValidateRejectsMalformedEvaluationTime(t *testing.T) {
 	}
 }
 
+func TestActionContractValidateAndConsumeSuccess(t *testing.T) {
+	proposalPath := filepath.Join("..", "..", "testdata", "action-contract-interop", "v1", "expected", "customer-data-to-egress", "pac-6dcee5a6d9a65e8c.json")
+	selectionPath := filepath.Join("..", "..", "testdata", "action-contract-interop", "v1", "expected", "fixture-manifest.json")
+	output, code := captureActionContractOutput(t, func() int {
+		return runActionContractValidate([]string{"--proposal", proposalPath, "--evaluation-time", "2026-07-19T00:00:00Z", "--json"})
+	})
+	if code != exitOK || !strings.Contains(output, `"operation":"validate"`) || !strings.Contains(output, `"ok":true`) {
+		t.Fatalf("valid proposal validation should pass: code=%d output=%s", code, output)
+	}
+
+	output, code = captureActionContractOutput(t, func() int {
+		return runActionContractConsume([]string{proposalPath, "--selection", selectionPath, "--scenario-id", "customer-data-to-egress"})
+	})
+	if code != exitOK || !strings.Contains(output, `"status":"pass"`) || !strings.Contains(output, `"self_attestation":false`) {
+		t.Fatalf("valid proposal consumer should pass: code=%d output=%s", code, output)
+	}
+	output, code = captureActionContractOutput(t, func() int {
+		return runActionContractConsume([]string{"--artifact", proposalPath, "--selection", selectionPath})
+	})
+	if code != exitOK || !strings.Contains(output, `"status":"pass"`) || !strings.Contains(output, `"scenario_id":"customer-data-to-egress"`) {
+		t.Fatalf("inferred scenario consumer should pass: code=%d output=%s", code, output)
+	}
+	output, code = captureActionContractOutput(t, func() int {
+		return runActionContractConsume([]string{"--artifact", proposalPath, "--selection", filepath.Join(t.TempDir(), "missing.json")})
+	})
+	if code != exitVerifyFailed || !strings.Contains(output, actioncontract.ReasonSelectionEvidenceRequired) {
+		t.Fatalf("invalid consumer selection must fail verification: code=%d output=%s", code, output)
+	}
+}
+
+func TestActionContractKeyAndHelperBranches(t *testing.T) {
+	keyPair, err := proofsign.GenerateKeyPair()
+	if err != nil {
+		t.Fatal(err)
+	}
+	directory := t.TempDir()
+	privatePath := filepath.Join(directory, "private.key")
+	publicPath := filepath.Join(directory, "public.key")
+	if err := os.WriteFile(privatePath, []byte(base64.StdEncoding.EncodeToString(keyPair.Private)), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(publicPath, []byte(base64.StdEncoding.EncodeToString(keyPair.Public)), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if privateKey, err := loadActionContractPrivateKey(privatePath, ""); err != nil || len(privateKey) != ed25519.PrivateKeySize {
+		t.Fatalf("private key file branch: len=%d err=%v", len(privateKey), err)
+	}
+	if publicKey, err := loadActionContractPublicKey(publicPath, ""); err != nil || len(publicKey) != ed25519.PublicKeySize {
+		t.Fatalf("public key file branch: len=%d err=%v", len(publicKey), err)
+	}
+	privateEnv, publicEnv := "GAIT_TEST_PRIVATE_KEY", "GAIT_TEST_PUBLIC_KEY"
+	t.Setenv(privateEnv, base64.StdEncoding.EncodeToString(keyPair.Private))
+	t.Setenv(publicEnv, base64.StdEncoding.EncodeToString(keyPair.Public))
+	if privateKey, err := loadActionContractPrivateKey("", privateEnv); err != nil || len(privateKey) != ed25519.PrivateKeySize {
+		t.Fatalf("private key environment branch: len=%d err=%v", len(privateKey), err)
+	}
+	if publicKey, err := loadActionContractPublicKey("", publicEnv); err != nil || len(publicKey) != ed25519.PublicKeySize {
+		t.Fatalf("public key environment branch: len=%d err=%v", len(publicKey), err)
+	}
+	for _, test := range []struct {
+		name string
+		fn   func() error
+	}{
+		{name: "private both", fn: func() error { _, err := loadActionContractPrivateKey(privatePath, privateEnv); return err }},
+		{name: "public both", fn: func() error { _, err := loadActionContractPublicKey(publicPath, publicEnv); return err }},
+		{name: "private missing env", fn: func() error { _, err := loadActionContractPrivateKey("", "GAIT_MISSING_PRIVATE"); return err }},
+		{name: "public missing env", fn: func() error { _, err := loadActionContractPublicKey("", "GAIT_MISSING_PUBLIC"); return err }},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if err := test.fn(); err == nil {
+				t.Fatal("invalid key source accepted")
+			}
+		})
+	}
+	if got := parseActionContractCSV(" one, ,two,, three "); strings.Join(got, "|") != "one|two|three" {
+		t.Fatalf("CSV normalization: %v", got)
+	}
+	if _, err := parseEvaluationTime("2026-07-19T00:00:00Z"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := parseEvaluationTime("not-a-time"); err == nil {
+		t.Fatal("invalid evaluation time accepted")
+	}
+	if got := errorString(nil, "fallback"); got != "fallback" {
+		t.Fatalf("nil error fallback: %q", got)
+	}
+	if got := errorString(errors.New("boom"), "fallback"); got != "boom" {
+		t.Fatalf("error string: %q", got)
+	}
+}
+
+func TestActionContractOutputAndSelectorHelpers(t *testing.T) {
+	output, code := captureActionContractOutput(t, func() int {
+		return writeActionContractOutput(false, actionContractOutput{Operation: "validate", OK: true}, exitOK)
+	})
+	if code != exitOK || !strings.Contains(output, "contract validate: ok=true") {
+		t.Fatalf("text output branch: code=%d output=%q", code, output)
+	}
+	receipt := normalizeActionContractReceipt(actionContractReceipt{})
+	if receipt.Consumer != "gait" || receipt.Version == "" || receipt.ScenarioID != "unknown" || receipt.ArtifactSHA256 == "" || receipt.SchemaVersions.Artifact == "" || receipt.SchemaVersions.Contract == "" || receipt.SelfAttestation {
+		t.Fatalf("receipt defaults not normalized: %+v", receipt)
+	}
+	validationErr := &actioncontract.ValidationError{Reasons: []string{"one", "two"}}
+	if got := actionContractReasonCodes(validationErr); strings.Join(got, "|") != "one|two" {
+		t.Fatalf("validation reason extraction: %v", got)
+	}
+	if got := actionContractReasonCodes(errors.New("ordinary")); got != nil {
+		t.Fatalf("ordinary errors should not have reason codes: %v", got)
+	}
+	if got := actionContractNamedFlagCount([]string{"--activation=x", "--activation", "--proposal", "--json"}, "--activation", "--proposal"); got != 3 {
+		t.Fatalf("named flag count: %d", got)
+	}
+	if got := actionContractSelectionFlagCount([]string{"--proposal=x", "--artifact=y", "--from=z"}); got != 3 {
+		t.Fatalf("selection flag count: %d", got)
+	}
+	for _, test := range []struct {
+		name string
+		fn   func() int
+		want string
+	}{
+		{name: "validate help", fn: func() int { return runActionContractValidate([]string{"--help"}) }, want: "Usage: gait contract validate"},
+		{name: "verify help", fn: func() int { return runActionContractVerify([]string{"--help"}) }, want: "Usage: gait contract verify"},
+		{name: "consume help", fn: func() int { return runActionContractConsume([]string{"--help"}) }, want: "Usage: gait contract consume"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got, gotCode := captureActionContractOutput(t, test.fn)
+			if gotCode != exitOK || !strings.Contains(got, test.want) {
+				t.Fatalf("help branch code=%d output=%s", gotCode, got)
+			}
+		})
+	}
+}
+
+func TestActionContractRejectsInvalidCLISelections(t *testing.T) {
+	proposalPath := filepath.Join("..", "..", "testdata", "action-contract-interop", "v1", "expected", "customer-data-to-egress", "pac-6dcee5a6d9a65e8c.json")
+	missingPath := filepath.Join(t.TempDir(), "missing.json")
+	cases := []struct {
+		name string
+		fn   func() int
+		code int
+		want string
+	}{
+		{name: "validate parser", fn: func() int { return runActionContractValidate([]string{"--unknown"}) }, code: exitInvalidInput, want: "contract validate error"},
+		{name: "validate ambiguous", fn: func() int {
+			return runActionContractValidate([]string{"--proposal", proposalPath, "--artifact", proposalPath, "--json"})
+		}, code: exitInvalidInput, want: actioncontract.ReasonAmbiguousSelection},
+		{name: "validate missing", fn: func() int { return runActionContractValidate([]string{"--json"}) }, code: exitInvalidInput, want: actioncontract.ReasonSelectionRequired},
+		{name: "validate read", fn: func() int { return runActionContractValidate([]string{"--proposal", missingPath, "--json"}) }, code: exitInvalidInput, want: `"operation":"validate"`},
+		{name: "verify parser", fn: func() int { return runActionContractVerify([]string{"--unknown"}) }, code: exitInvalidInput, want: "contract verify error"},
+		{name: "verify missing", fn: func() int { return runActionContractVerify([]string{"--json"}) }, code: exitInvalidInput, want: actioncontract.ReasonSelectionRequired},
+		{name: "consume parser", fn: func() int { return runActionContractConsume([]string{"--unknown"}) }, code: exitInvalidInput, want: actioncontract.ReasonMalformedArtifact},
+		{name: "consume ambiguous", fn: func() int { return runActionContractConsume([]string{"--artifact", proposalPath, proposalPath}) }, code: exitInvalidInput, want: actioncontract.ReasonAmbiguousSelection},
+		{name: "consume read", fn: func() int { return runActionContractConsume([]string{"--artifact", missingPath}) }, code: exitVerifyFailed, want: `"status":"reject"`},
+	}
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			output, code := captureActionContractOutput(t, test.fn)
+			if code != test.code || !strings.Contains(output, test.want) {
+				t.Fatalf("invalid CLI branch code=%d output=%s", code, output)
+			}
+		})
+	}
+	output, code := captureActionContractOutput(t, func() int { return runActionContract([]string{"--explain"}) })
+	if code != exitOK || !strings.Contains(output, "explicitly selected Wrkr") {
+		t.Fatalf("explain branch code=%d output=%s", code, output)
+	}
+}
+
 func TestActionContractRejectReceiptHasRequiredFields(t *testing.T) {
 	output, code := captureActionContractOutput(t, func() int {
 		return runActionContractConsume([]string{"--json"})
@@ -132,6 +301,58 @@ func TestActionContractVerifyRejectsConflictingActivationSelectors(t *testing.T)
 	})
 	if code != exitInvalidInput || !strings.Contains(output, actioncontract.ReasonAmbiguousSelection) {
 		t.Fatalf("conflicting activation selectors must fail as invalid input: code=%d output=%s", code, output)
+	}
+}
+
+func TestActionContractActivateAndDispatchBranches(t *testing.T) {
+	proposalPath := filepath.Join("..", "..", "testdata", "action-contract-interop", "v1", "expected", "customer-data-to-egress", "pac-6dcee5a6d9a65e8c.json")
+	selectionPath := filepath.Join("..", "..", "testdata", "action-contract-interop", "v1", "expected", "fixture-manifest.json")
+	base := []string{
+		"--proposal", proposalPath,
+		"--selection", selectionPath,
+		"--policy-digest", "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+		"--principal", "principal:owner",
+		"--authority-ref", "approval:owner",
+		"--target", "target:deploy",
+		"--environment", "development",
+		"--mode", "context_only",
+		"--valid-from", "2026-07-19T00:00:00Z",
+		"--allow-development-signing",
+		"--json",
+	}
+	output, code := captureActionContractOutput(t, func() int {
+		return runActionContractActivate(base)
+	})
+	if code != exitOK || !strings.Contains(output, `"operation":"activate"`) || !strings.Contains(output, `"ok":true`) {
+		t.Fatalf("valid activation CLI should pass: code=%d output=%s", code, output)
+	}
+
+	for _, test := range []struct {
+		name string
+		args []string
+		code int
+		want string
+	}{
+		{name: "help", args: []string{"--help"}, code: exitOK, want: "Usage: gait contract activate"},
+		{name: "ambiguous proposal", args: []string{"--proposal", proposalPath, "--artifact", proposalPath, "--json"}, code: exitInvalidInput, want: actioncontract.ReasonAmbiguousSelection},
+		{name: "missing proposal", args: []string{"--json"}, code: exitInvalidInput, want: actioncontract.ReasonSelectionRequired},
+		{name: "missing selection", args: []string{"--proposal", proposalPath, "--json"}, code: exitVerifyFailed, want: actioncontract.ReasonSelectionEvidenceRequired},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got, gotCode := captureActionContractOutput(t, func() int {
+				return runActionContractActivate(test.args)
+			})
+			if gotCode != test.code || !strings.Contains(got, test.want) {
+				t.Fatalf("activation branch code=%d output=%s", gotCode, got)
+			}
+		})
+	}
+
+	for _, test := range [][]string{{}, {"unknown"}} {
+		output, code := captureActionContractOutput(t, func() int { return runActionContract(test) })
+		if code != exitInvalidInput || !strings.Contains(output, "gait contract validate") {
+			t.Fatalf("dispatch branch code=%d output=%s", code, output)
+		}
 	}
 }
 

--- a/core/actioncontract/actioncontract_test.go
+++ b/core/actioncontract/actioncontract_test.go
@@ -90,6 +90,49 @@ func TestValidationRejectsTamperedDigestAndVersion(t *testing.T) {
 	}
 }
 
+func TestValidateArtifactRejectsMalformedAndUnsupportedFields(t *testing.T) {
+	result := ValidateArtifact(Artifact{}, ValidationOptions{Now: mustTime("2026-07-19T00:00:00Z")})
+	for _, reason := range []string{ReasonSchemaValidationFailed, ReasonUnsupportedArtifactSchema, ReasonUnsupportedProducer, ReasonUnsupportedContractSchema, ReasonReportOnlyRequired, ReasonArtifactIdentityMismatch, ReasonMissingContractID, ReasonMissingFamilyID, ReasonRevisionInvalid, ReasonMissingSourceRefs, ReasonMissingCompositionRef, ReasonMissingEvidenceRefs, ReasonMalformedArtifact} {
+		if !contains(result.Reasons, reason) {
+			t.Fatalf("empty artifact missing %q: %+v", reason, result.Reasons)
+		}
+	}
+
+	artifact := fixtureArtifact(t, "customer-data-to-egress")
+	artifact.Revision = 2
+	artifact.ResolutionKey = "resolution:top"
+	artifact.Contract["contract_id"] = "pac-other"
+	artifact.Contract["contract_family_id"] = "pacf-other"
+	artifact.Contract["revision"] = 1
+	artifact.Contract["contract_version"] = "2"
+	artifact.Contract["contract_kind"] = "other"
+	artifact.Contract["report_only"] = false
+	artifact.Contract["composition_ref"] = "composition:missing"
+	artifact.Contract["resolution_key"] = "resolution:contract"
+	artifact.Contract["target_constraints"] = []any{map[string]any{"key": "unsupported"}}
+	artifact.Contract["preconditions"] = []any{map[string]any{"kind": "unsupported"}}
+	artifact.Contract["authority_requirements"] = []any{map[string]any{"kind": "unsupported"}}
+	artifact.Contract["expires_at"] = "not-a-time"
+	artifact.Contract["readiness_state"] = "blocked_by_contradiction"
+	artifact.Contract["authority_readiness_state"] = "blocked_by_contradiction"
+	result = ValidateArtifact(artifact, ValidationOptions{ExpectedContractID: "pac-expected", ExpectedFamilyID: "pacf-expected", ExpectedRevision: 3, Now: mustTime("2026-07-19T00:00:00Z")})
+	for _, reason := range []string{ReasonRevisionIdentityMismatch, ReasonContractIdentityMismatch, ReasonRevisionReactivationRequired, ReasonContractDigestMismatch, ReasonContradictoryProposal, ReasonMalformedArtifact} {
+		if !contains(result.Reasons, reason) {
+			t.Fatalf("mutated artifact missing %q: %+v", reason, result.Reasons)
+		}
+	}
+	unsupported := false
+	for _, reason := range result.Reasons {
+		if strings.HasPrefix(reason, ReasonUnsupportedConstraint+":") {
+			unsupported = true
+			break
+		}
+	}
+	if !unsupported {
+		t.Fatalf("unsupported constraint was not reported: %+v", result.Reasons)
+	}
+}
+
 func TestDuplicateJSONKeysAndNestedSchemaDriftReject(t *testing.T) {
 	path := filepath.Join("..", "..", "testdata", "action-contract-interop", "v1", "expected", "customer-data-to-egress", "pac-6dcee5a6d9a65e8c.json")
 	raw, err := os.ReadFile(path)


### PR DESCRIPTION
## Summary
- add focused action-contract CLI tests for validation, activation, verification, consumer, key-source, selector, help, and receipt branches
- add the malformed/unsupported artifact validation matrix needed by the exact aggregate Go coverage gate

## Validation
- `go test -race ./core/actioncontract ./cmd/gait`
- `cmd/gait` coverage: 85.8%
- aggregate Go coverage checker: 85.0% (required 85.0%)
- full local suite is green except the proven sandbox-only IPv6 bind restriction in `core/registry.TestInstallRemoteWithSignatureAndPin`

Test-only; no production behavior, fixtures, or dependency/toolchain changes.