### PR TITLE
ci: enforce Go coverage contract before merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,28 +186,7 @@ jobs:
       - name: Go tests with coverage
         shell: bash
         run: |
-          set +e
-          go_test_packages=()
-          while IFS= read -r package; do
-            package=${package%$'\r'}
-            [[ -n "${package}" ]] || continue
-            go_test_packages+=("$package")
-          done < <(python scripts/list_go_test_packages.py)
-          go test "${go_test_packages[@]}" -cover > coverage-go-packages.out 2>&1
-          package_test_status=$?
-          set -e
-          cat coverage-go-packages.out
-          if [[ "${package_test_status}" -ne 0 ]]; then
-            echo "go test filtered packages with coverage failed"
-            exit "${package_test_status}"
-          fi
-          python scripts/check_go_package_coverage.py coverage-go-packages.out 75
-          go test ./core/... ./cmd/gait -coverprofile=coverage-go.out
-          if [[ "$RUNNER_OS" == "Linux" ]]; then
-            python scripts/check_go_coverage.py coverage-go.out 85
-          else
-            go tool cover -func=coverage-go.out | tail -n 1
-          fi
+          bash scripts/test_go_coverage_contract.sh 75 85
       - name: Python tests with coverage
         env:
           PYTHONPATH: .

--- a/.github/workflows/pr-fast.yml
+++ b/.github/workflows/pr-fast.yml
@@ -54,6 +54,9 @@ jobs:
           PYTHONPATH: .
         run: |
           make test-fast
+      - name: Go coverage contract
+        run: |
+          bash scripts/test_go_coverage_contract.sh 75 85
       - name: CLI contract tests
         run: |
           go test ./cmd/gait -count=1

--- a/scripts/action_contract_fixture_generator/main_test.go
+++ b/scripts/action_contract_fixture_generator/main_test.go
@@ -132,6 +132,121 @@ func TestRunRejectsScenarioPathTraversalAndSymlinkActivation(t *testing.T) {
 	}
 }
 
+func TestFixturePathHelpersAndCopyRejectUnsafeDestinations(t *testing.T) {
+	root := t.TempDir()
+	expectedRoot := filepath.Join(root, "expected")
+	if err := os.MkdirAll(expectedRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := safeFixturePath(expectedRoot, "../escape"); err == nil {
+		t.Fatal("safeFixturePath accepted traversal")
+	}
+	if _, err := safeFixturePath(expectedRoot, filepath.Join(root, "absolute")); err == nil {
+		t.Fatal("safeFixturePath accepted an absolute path")
+	}
+	if err := rejectSymlinkAncestors(expectedRoot, filepath.Join(expectedRoot, "missing", "file")); err != nil {
+		t.Fatal(err)
+	}
+	outside := filepath.Join(root, "outside")
+	if err := os.WriteFile(outside, []byte("outside\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	symlinkRoot := filepath.Join(root, "symlink-root")
+	if err := os.Symlink(expectedRoot, symlinkRoot); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	if err := rejectSymlinkAncestors(symlinkRoot, filepath.Join(symlinkRoot, "file")); err == nil {
+		t.Fatal("rejectSymlinkAncestors accepted a symlink root")
+	}
+
+	source := filepath.Join(root, "source.json")
+	if err := os.WriteFile(source, []byte("generated\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	regularDestination := filepath.Join(expectedRoot, "regular.json")
+	if err := compareOrCopy(source, regularDestination, false); err != nil {
+		t.Fatal(err)
+	}
+	if err := compareOrCopy(source, regularDestination, true); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(filepath.Join(expectedRoot, "directory"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := compareOrCopy(source, filepath.Join(expectedRoot, "directory"), false); err == nil {
+		t.Fatal("compareOrCopy accepted a directory destination")
+	}
+	stale := filepath.Join(expectedRoot, "stale.json")
+	if err := os.WriteFile(stale, []byte("old\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := compareOrCopy(source, stale, true); err == nil {
+		t.Fatal("--check accepted stale fixture bytes")
+	}
+	if err := compareOrCopy(filepath.Join(root, "missing-source.json"), regularDestination, false); err == nil {
+		t.Fatal("compareOrCopy accepted a missing source")
+	}
+	symlinkDestination := filepath.Join(expectedRoot, "symlink.json")
+	if err := os.Symlink(outside, symlinkDestination); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	if err := compareOrCopy(source, symlinkDestination, false); err == nil {
+		t.Fatal("compareOrCopy accepted a symlink destination")
+	}
+	if got, err := os.ReadFile(outside); err != nil || string(got) != "outside\n" {
+		t.Fatalf("outside file changed: %q %v", got, err)
+	}
+}
+
+func TestCollectActivationFilesRejectsInvalidRootAndNonRegularActivation(t *testing.T) {
+	root := t.TempDir()
+	if _, err := collectActivationFiles(filepath.Join(root, "missing")); err == nil {
+		t.Fatal("collectActivationFiles accepted a missing root")
+	}
+	fileRoot := filepath.Join(root, "file-root")
+	if err := os.WriteFile(fileRoot, []byte("not a directory\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := collectActivationFiles(fileRoot); err == nil {
+		t.Fatal("collectActivationFiles accepted a regular-file root")
+	}
+	fixtureRoot := filepath.Join(root, "fixture-root")
+	if err := os.MkdirAll(filepath.Join(fixtureRoot, "scenario"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(filepath.Join(fixtureRoot, "scenario", activationName), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := collectActivationFiles(fixtureRoot); err == nil {
+		t.Fatal("collectActivationFiles accepted a directory activation fixture")
+	}
+}
+
+func TestRunRejectsInvalidSourceManifestInputs(t *testing.T) {
+	if err := run(t.TempDir(), false); err == nil {
+		t.Fatal("run accepted a repository without the pinned source manifest")
+	}
+
+	root := copyFixtureRepo(t)
+	manifestPath := filepath.Join(root, manifestRel)
+	manifest := readJSON(t, manifestPath)
+	manifest["producer"].(map[string]any)["version"] = "v9.9.9"
+	writeJSON(t, manifestPath, manifest)
+	if err := run(root, false); err == nil {
+		t.Fatal("run accepted an unsupported source producer version")
+	}
+
+	root = copyFixtureRepo(t)
+	manifestPath = filepath.Join(root, manifestRel)
+	manifest = readJSON(t, manifestPath)
+	scenarios := manifest["scenarios"].([]any)
+	scenarios[1].(map[string]any)["scenario_id"] = scenarios[0].(map[string]any)["scenario_id"]
+	writeJSON(t, manifestPath, manifest)
+	if err := run(root, false); err == nil {
+		t.Fatal("run accepted duplicate source scenario IDs")
+	}
+}
+
 func copyFixtureRepo(t *testing.T) string {
 	t.Helper()
 	root := t.TempDir()

--- a/scripts/test_docs_consistency.sh
+++ b/scripts/test_docs_consistency.sh
@@ -97,6 +97,13 @@ require_pattern "${REPO_ROOT}/cmd/gait/verify.go" "gait contract activate .*--va
 require_pattern "${REPO_ROOT}/schemas/v1/action-contract/README.md" "artifact schema \x601\x60(?:,|$)" "Action Contract artifact schema version missing or malformed"
 require_pattern "${REPO_ROOT}/schemas/v1/action-contract/README.md" "contract schema \x603\x60(?:[.,]|$)" "Action Contract contract schema version missing or malformed"
 
+# Main and PR-fast CI must enforce the same Go package/aggregate coverage contract.
+for workflow in \
+  "${REPO_ROOT}/.github/workflows/ci.yml" \
+  "${REPO_ROOT}/.github/workflows/pr-fast.yml"; do
+  require_pattern "${workflow}" "scripts/test_go_coverage_contract\.sh 75 85" "Go coverage contract missing from workflow"
+done
+
 # Required onboarding sections.
 require_readme_intro_heading_near_top \
   "${REPO_ROOT}/README.md" \

--- a/scripts/test_go_coverage_contract.sh
+++ b/scripts/test_go_coverage_contract.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+PACKAGE_THRESHOLD="${1:-75}"
+AGGREGATE_THRESHOLD="${2:-85}"
+PYTHON="${PYTHON:-python3}"
+
+cd "$REPO_ROOT"
+
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+go_test_packages=()
+while IFS= read -r package; do
+  package=${package%$'\r'}
+  [[ -n "$package" ]] || continue
+  go_test_packages+=("$package")
+done < <("$PYTHON" scripts/list_go_test_packages.py)
+
+if [[ "${#go_test_packages[@]}" -eq 0 ]]; then
+  echo "no Go test packages discovered" >&2
+  exit 1
+fi
+
+set +e
+go test "${go_test_packages[@]}" -cover > "$WORK_DIR/coverage-go-packages.out" 2>&1
+package_test_status=$?
+set -e
+cat "$WORK_DIR/coverage-go-packages.out"
+if [[ "$package_test_status" -ne 0 ]]; then
+  echo "go test filtered packages with coverage failed" >&2
+  exit "$package_test_status"
+fi
+"$PYTHON" scripts/check_go_package_coverage.py "$WORK_DIR/coverage-go-packages.out" "$PACKAGE_THRESHOLD"
+
+go test ./core/... ./cmd/gait -coverprofile="$WORK_DIR/coverage-go.out"
+if [[ "${RUNNER_OS:-Linux}" == "Linux" ]]; then
+  "$PYTHON" scripts/check_go_coverage.py "$WORK_DIR/coverage-go.out" "$AGGREGATE_THRESHOLD"
+else
+  go tool cover -func="$WORK_DIR/coverage-go.out" | tail -n 1
+fi


### PR DESCRIPTION
## Summary
- raise action-contract fixture generator package coverage above the 75% CI gate with focused safety/error-path tests
- centralize the existing Go package (75%) and Linux aggregate (85%) coverage contract
- run the same coverage contract in `ci` and `pr-fast`, with docs consistency guarding workflow wiring

## Validation
- generator package coverage: 76.1%
- focused race tests, version tests, vet, docs consistency, and generator checks pass
- full local coverage run reaches all packages; the registry test is sandbox-blocked locally by restricted loopback binding

This is a post-merge CI hotfix; no release/tag changes.
