### PR TITLE
ci: pin download-artifact to v4.1.3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -334,7 +334,7 @@ jobs:
               raise SystemExit("attestation digest mismatch")
           PY
       - name: Download v2.3 metrics snapshot
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@87c55149d96e628cc2ef7e6fc2aab372015aec85 # v4.1.3
         with:
           name: v2-3-metrics-release-${{ github.run_id }}
           path: gait-out

--- a/scripts/check_github_action_runtime_versions.py
+++ b/scripts/check_github_action_runtime_versions.py
@@ -12,6 +12,7 @@ from typing import Iterable
 @dataclass(frozen=True)
 class Rule:
     minimum_major: int
+    immutable_sha: bool = False
 
 
 @dataclass(frozen=True)
@@ -29,12 +30,14 @@ RULES: dict[str, Rule] = {
     "actions/setup-node": Rule(minimum_major=5),
     "github/codeql-action/init": Rule(minimum_major=4),
     "github/codeql-action/analyze": Rule(minimum_major=4),
+    "actions/download-artifact": Rule(minimum_major=4, immutable_sha=True),
 }
 
 USES_PATTERN = re.compile(
     r"uses:\s*['\"]?([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+(?:/[A-Za-z0-9_.-]+)?@[^ \t\r\n#'\"]+)"
 )
 MAJOR_PATTERN = re.compile(r"^v(?P<major>[0-9]+)(?:[._-].*)?$")
+SHA_PATTERN = re.compile(r"^[0-9a-f]{40}$")
 
 
 def parse_args() -> argparse.Namespace:
@@ -82,6 +85,8 @@ def scan_file(path: Path) -> list[Violation]:
             rule = RULES.get(action_name)
             if rule is None:
                 continue
+            if rule.immutable_sha and SHA_PATTERN.fullmatch(version_ref):
+                continue
             major = parse_major(version_ref)
             if major is None:
                 violations.append(
@@ -92,6 +97,7 @@ def scan_file(path: Path) -> list[Violation]:
                         message=(
                             f"unsupported monitored ref format; require {action_name}@v"
                             f"{rule.minimum_major}+"
+                            + (" or a 40-character commit SHA" if rule.immutable_sha else "")
                         ),
                     )
                 )
@@ -105,6 +111,17 @@ def scan_file(path: Path) -> list[Violation]:
                         message=(
                             f"deprecated major v{major}; require {action_name}@v"
                             f"{rule.minimum_major}+"
+                        ),
+                    )
+                )
+            elif rule.immutable_sha:
+                violations.append(
+                    Violation(
+                        path=str(path),
+                        line=line_number,
+                        reference=reference,
+                        message=(
+                            f"mutable ref; require {action_name}@<40-character commit SHA>"
                         ),
                     )
                 )

--- a/scripts/check_github_action_runtime_versions.py
+++ b/scripts/check_github_action_runtime_versions.py
@@ -38,6 +38,11 @@ USES_PATTERN = re.compile(
 )
 MAJOR_PATTERN = re.compile(r"^v(?P<major>[0-9]+)(?:[._-].*)?$")
 SHA_PATTERN = re.compile(r"^[0-9a-f]{40}$")
+APPROVED_IMMUTABLE_REFS: dict[str, frozenset[str]] = {
+    "actions/download-artifact": frozenset(
+        {"87c55149d96e628cc2ef7e6fc2aab372015aec85"}
+    ),
+}
 
 
 def parse_args() -> argparse.Namespace:
@@ -85,8 +90,22 @@ def scan_file(path: Path) -> list[Violation]:
             rule = RULES.get(action_name)
             if rule is None:
                 continue
-            if rule.immutable_sha and SHA_PATTERN.fullmatch(version_ref):
-                continue
+            if rule.immutable_sha:
+                if version_ref in APPROVED_IMMUTABLE_REFS.get(action_name, frozenset()):
+                    continue
+                if SHA_PATTERN.fullmatch(version_ref):
+                    violations.append(
+                        Violation(
+                            path=str(path),
+                            line=line_number,
+                            reference=reference,
+                            message=(
+                                f"unapproved commit SHA; require {action_name}@an approved "
+                                "v4 commit SHA"
+                            ),
+                        )
+                    )
+                    continue
             major = parse_major(version_ref)
             if major is None:
                 violations.append(

--- a/scripts/test_github_action_runtime_versions.sh
+++ b/scripts/test_github_action_runtime_versions.sh
@@ -44,6 +44,7 @@ jobs:
       - uses: actions/setup-node@v5
       - uses: github/codeql-action/init@v4
       - uses: github/codeql-action/analyze@v4
+      - uses: actions/download-artifact@87c55149d96e628cc2ef7e6fc2aab372015aec85 # v4.1.3
 EOF
 cat > "${WORK_DIR}/pass/docs/adopt_in_one_pr.md" <<'EOF'
 ```yaml
@@ -73,6 +74,7 @@ jobs:
       - uses: github/codeql-action/analyze@v3
       - uses: actions/setup-go@v5
       - uses: actions/setup-node@v4
+      - uses: actions/download-artifact@v4
 EOF
 cat > "${WORK_DIR}/fail/docs/adopt_in_one_pr.md" <<'EOF'
 ```yaml
@@ -98,6 +100,7 @@ ${WORK_DIR}/fail/.github/workflows/core.yml:7: actions/checkout@v4: deprecated m
 ${WORK_DIR}/fail/.github/workflows/core.yml:8: github/codeql-action/analyze@v3: deprecated major v3; require github/codeql-action/analyze@v4+
 ${WORK_DIR}/fail/.github/workflows/core.yml:9: actions/setup-go@v5: deprecated major v5; require actions/setup-go@v6+
 ${WORK_DIR}/fail/.github/workflows/core.yml:10: actions/setup-node@v4: deprecated major v4; require actions/setup-node@v5+
+${WORK_DIR}/fail/.github/workflows/core.yml:11: actions/download-artifact@v4: mutable ref; require actions/download-artifact@<40-character commit SHA>
 ${WORK_DIR}/fail/docs/adopt_in_one_pr.md:2: actions/checkout@v4: deprecated major v4; require actions/checkout@v5+
 EOF
 )"

--- a/scripts/test_github_action_runtime_versions.sh
+++ b/scripts/test_github_action_runtime_versions.sh
@@ -75,6 +75,7 @@ jobs:
       - uses: actions/setup-go@v5
       - uses: actions/setup-node@v4
       - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@0000000000000000000000000000000000000000
 EOF
 cat > "${WORK_DIR}/fail/docs/adopt_in_one_pr.md" <<'EOF'
 ```yaml
@@ -101,6 +102,7 @@ ${WORK_DIR}/fail/.github/workflows/core.yml:8: github/codeql-action/analyze@v3: 
 ${WORK_DIR}/fail/.github/workflows/core.yml:9: actions/setup-go@v5: deprecated major v5; require actions/setup-go@v6+
 ${WORK_DIR}/fail/.github/workflows/core.yml:10: actions/setup-node@v4: deprecated major v4; require actions/setup-node@v5+
 ${WORK_DIR}/fail/.github/workflows/core.yml:11: actions/download-artifact@v4: mutable ref; require actions/download-artifact@<40-character commit SHA>
+${WORK_DIR}/fail/.github/workflows/core.yml:12: actions/download-artifact@0000000000000000000000000000000000000000: unapproved commit SHA; require actions/download-artifact@an approved v4 commit SHA
 ${WORK_DIR}/fail/docs/adopt_in_one_pr.md:2: actions/checkout@v4: deprecated major v4; require actions/checkout@v5+
 EOF
 )"


### PR DESCRIPTION
## Summary
- pin the release workflow's `actions/download-artifact` to the immutable official v4.1.3 commit `87c55149d96e628cc2ef7e6fc2aab372015aec85`
- extend the workflow runtime/security guard to require a 40-character SHA for this action
- add deterministic pass/fail coverage for immutable and mutable refs

## Validation
- `scripts/test_github_action_runtime_versions.sh`
- `scripts/check_repo_hygiene.sh`
- docs consistency
- local Syft/Grype scan reports no matches

CI-only security fix; no product release/tag changes.
