### PR TITLE
Bind lifecycle fixtures to merged conformance source

### DIFF
--- a/core/actioncontract/lifecycle_conformance_test.go
+++ b/core/actioncontract/lifecycle_conformance_test.go
@@ -22,6 +22,7 @@ type conformanceFixturePack struct {
 type conformanceFixtureManifest struct {
 	FixtureVersion   string `json:"fixture_version"`
 	FoundationCommit string `json:"foundation_commit"`
+	SourceCommit     string `json:"source_commit"`
 	Producer         struct {
 		Name    string `json:"name"`
 		Version string `json:"version"`
@@ -112,7 +113,7 @@ func TestLifecycleConformanceManifestPinsExactBytes(t *testing.T) {
 	if err := json.Unmarshal(manifestRaw, &manifest); err != nil {
 		t.Fatal(err)
 	}
-	if manifest.FixtureVersion != "1" || manifest.FoundationCommit != "4177f1e575441975b5a8979e6350e988c2f71d70" || manifest.Producer.Name != "gait" || manifest.Producer.Version != "v1.5.0" || !manifest.Signing.FixtureTestOnly || !manifest.Signing.NonAuthoritative || len(manifest.Scenarios) != 9 {
+	if manifest.FixtureVersion != "1" || manifest.FoundationCommit != "4177f1e575441975b5a8979e6350e988c2f71d70" || manifest.SourceCommit != "eb4c599a5c1a24dbb270c39a5a513d78f253506d" || manifest.Producer.Name != "gait" || manifest.Producer.Version != "v1.5.0" || !manifest.Signing.FixtureTestOnly || !manifest.Signing.NonAuthoritative || len(manifest.Scenarios) != 9 {
 		t.Fatalf("unexpected conformance fixture manifest: %+v", manifest)
 	}
 	for _, prefix := range []string{"proposal", "activation", "runtime_action", "runtime_readiness", "runtime_action_source", "runtime_readiness_source"} {

--- a/scripts/action_contract_evidence_fixture_generator/main.go
+++ b/scripts/action_contract_evidence_fixture_generator/main.go
@@ -31,11 +31,13 @@ const (
 	runtimeReadiness = "testdata/runtime-goldens/runtime-readiness.json"
 	seedPhrase       = "gait-action-contract-activation-development-key-v1"
 	foundationCommit = "4177f1e575441975b5a8979e6350e988c2f71d70"
+	sourceCommit     = "eb4c599a5c1a24dbb270c39a5a513d78f253506d"
 )
 
 type manifest struct {
 	FixtureVersion   string `json:"fixture_version"`
 	FoundationCommit string `json:"foundation_commit"`
+	SourceCommit     string `json:"source_commit"`
 	Producer         struct {
 		Name    string `json:"name"`
 		Version string `json:"version"`
@@ -233,7 +235,7 @@ func run(repoRoot string, update bool) error {
 	if err != nil {
 		return err
 	}
-	manifestValue := manifest{FixtureVersion: "1", FoundationCommit: foundationCommit, Bindings: map[string]string{
+	manifestValue := manifest{FixtureVersion: "1", FoundationCommit: foundationCommit, SourceCommit: sourceCommit, Bindings: map[string]string{
 		"proposal_path": sourceProposal, "proposal_sha256": rawDigest(proposalRaw),
 		"activation_path": sourceActivation, "activation_sha256": rawDigest(activationRaw),
 		"runtime_action_path": fixtureRoot + "/runtime-action.json", "runtime_action_sha256": rawDigest(projectedActionRaw),

--- a/testdata/action-contract-evidence/v1/fixture-manifest.json
+++ b/testdata/action-contract-evidence/v1/fixture-manifest.json
@@ -1,6 +1,7 @@
 {
   "fixture_version": "1",
   "foundation_commit": "4177f1e575441975b5a8979e6350e988c2f71d70",
+  "source_commit": "eb4c599a5c1a24dbb270c39a5a513d78f253506d",
   "producer": {
     "name": "gait",
     "version": "v1.5.0"


### PR DESCRIPTION
## Summary

- record the exact merged conformance source commit `eb4c599a5c1a24dbb270c39a5a513d78f253506d` in the v1 lifecycle fixture manifest
- keep the earlier typed-evidence foundation commit separately pinned
- extend the manifest regression to require the exact reachable merged source
- regenerate/check fixture bytes; only the manifest changes

## Validation

- lifecycle fixture generator `--update` then `--check`
- focused manifest and scenario tests green
- diff/check clean

This provenance-only follow-up does not release/tag Gait.