### PR TITLE
Prepare Gait v1.5.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [1.5.0] - 2026-08-24
+
 ### Added
 
 - [semver:minor] Added deterministic pre-execution runtime action/boundary/outcome classification, typed contract readiness evaluation, and signed lifecycle records with pure reduction. These surfaces never execute tools or claim observed effects.


### PR DESCRIPTION
## Summary

- move the completed runtime/effect/execution/containment/conformance changes from Unreleased into `1.5.0` dated 2026-08-24
- leave Unreleased open for subsequent work

## Validation

- docs consistency green
- CLI version/release tests green
- activation, effects, and lifecycle-conformance fixture generators `--check` green

This PR does not create the tag; tagging occurs only after merge and green protected CI.