### PR TITLE
Fix macOS gosec path annotations

### DIFF
--- a/cmd/gait/actioncontract_advisory.go
+++ b/cmd/gait/actioncontract_advisory.go
@@ -50,7 +50,7 @@ func runAdvisoryEvaluate(args []string) int {
 	if input == "" || out == "" || key == "" || action == "" {
 		return advisoryOutput(js, nil, "--input, --out, --private-key, and --action-id are required", exitInvalidInput)
 	}
-	raw, e := os.ReadFile(input)
+	raw, e := os.ReadFile(input) // #nosec G304 -- explicit local input path supplied by the operator.
 	if e != nil {
 		return advisoryOutput(js, nil, e.Error(), exitInvalidInput)
 	}
@@ -90,7 +90,7 @@ func runAdvisoryVerify(args []string) int {
 	if err := f.Parse(args); err != nil {
 		return advisoryOutput(js, nil, err.Error(), exitInvalidInput)
 	}
-	raw, e := os.ReadFile(path)
+	raw, e := os.ReadFile(path) // #nosec G304 -- explicit local report path supplied by the operator.
 	if e != nil {
 		return advisoryOutput(js, nil, e.Error(), exitInvalidInput)
 	}

--- a/cmd/gait/regress.go
+++ b/cmd/gait/regress.go
@@ -139,8 +139,8 @@ func runRegressAdd(arguments []string) int {
 			Error: "missing required --from <capture.json|run_id|path>",
 		}, exitInvalidInput)
 	}
-	if rawProbe, e := os.ReadFile(from); e == nil && strings.Contains(string(rawProbe), `"schema_id":"`+actioncontract.LifecycleReceiptSchemaID+`"`) {
-		raw, readErr := os.ReadFile(from)
+	if rawProbe, e := os.ReadFile(from); e == nil && strings.Contains(string(rawProbe), `"schema_id":"`+actioncontract.LifecycleReceiptSchemaID+`"`) { // #nosec G304 -- explicit local source path supplied by the operator.
+		raw, readErr := os.ReadFile(from) // #nosec G304 -- explicit local source path supplied by the operator.
 		if readErr != nil {
 			return writeRegressAddOutput(jsonOutput, regressAddOutput{OK: false, Source: from, Error: readErr.Error()}, exitInvalidInput)
 		}

--- a/core/effects/capture.go
+++ b/core/effects/capture.go
@@ -154,7 +154,7 @@ func captureFilesystem(req CaptureRequest, now time.Time) (CaptureResult, error)
 			if totalBytes > MaxCaptureBytes {
 				return errors.New("capture byte limit exceeded")
 			}
-			content, readErr := os.ReadFile(p)
+			content, readErr := os.ReadFile(p) // #nosec G304 -- p is produced by the bounded, symlink-rejecting filepath.Walk rooted at the explicit capture path.
 			if readErr != nil {
 				return readErr
 			}

--- a/core/gate/token_io.go
+++ b/core/gate/token_io.go
@@ -31,7 +31,7 @@ func readTokenFile(path string) ([]byte, error) {
 	if !i.Mode().IsRegular() || i.Mode()&os.ModeSymlink != 0 {
 		return nil, errors.New("token file invalid")
 	}
-	f, e := os.Open(path)
+	f, e := os.Open(path) // #nosec G304 -- path is explicitly supplied by the caller and was validated with Lstat immediately before opening.
 	if e != nil {
 		return nil, e
 	}

--- a/scripts/action_contract_evidence_fixture_generator/main.go
+++ b/scripts/action_contract_evidence_fixture_generator/main.go
@@ -221,11 +221,11 @@ func run(repoRoot string, update bool) error {
 	validPacks["capability-invalidation"] = base.controlScenario("external_revocation", "attempted", "acknowledged", "capability_invalidation")
 	validPacks["descendant-invalidation"] = base.controlScenario("external_revocation", "attempted", "acknowledged", "descendant_invalidation")
 	files := map[string][]byte{"runtime-action.json": projectedActionRaw, "runtime-readiness.json": projectedReadinessRaw}
-	generatorRaw, err := os.ReadFile(filepath.Join(repoRoot, "scripts/action_contract_evidence_fixture_generator/main.go"))
+	generatorRaw, err := os.ReadFile(filepath.Join(repoRoot, "scripts/action_contract_evidence_fixture_generator/main.go")) // #nosec G304 -- fixed generator-owned source path rooted at repoRoot.
 	if err != nil {
 		return err
 	}
-	schemaRaw, err := os.ReadFile(filepath.Join(repoRoot, "schemas/v1/action-contract/runtime-lifecycle-record.schema.json"))
+	schemaRaw, err := os.ReadFile(filepath.Join(repoRoot, "schemas/v1/action-contract/runtime-lifecycle-record.schema.json")) // #nosec G304 -- fixed schema path rooted at repoRoot.
 	if err != nil {
 		return err
 	}

--- a/scripts/action_contract_gate_fixture_generator/main.go
+++ b/scripts/action_contract_gate_fixture_generator/main.go
@@ -170,7 +170,7 @@ func writeOrCheck(update bool, items map[string]any, codes map[string]string, pu
 				return err
 			}
 		} else {
-			got, err := os.ReadFile(filepath.Join(rootDir, path))
+			got, err := os.ReadFile(filepath.Join(rootDir, path)) // #nosec G304 -- path is derived from the generator's fixed fixture manifest and rooted at rootDir.
 			if err != nil || string(got) != string(raw) {
 				return fmt.Errorf("fixture drift: %s", path)
 			}

--- a/testdata/action-contract-evidence/v1/fixture-manifest.json
+++ b/testdata/action-contract-evidence/v1/fixture-manifest.json
@@ -51,7 +51,7 @@
       "quarantine": true,
       "authoritative": false,
       "base_commit": "eb4c599a5c1a24dbb270c39a5a513d78f253506d",
-      "generator_sha256": "sha256:4d509fca09db65ff715c073fe84b371983d50b7962ea6be5a0061e1ebdfa5e3c",
+      "generator_sha256": "sha256:e48d144298b96c7599eec354b3c2a8f5774491cba17526b0616e17d3414ee145",
       "schema_sha256": "sha256:f7ec8fcba3470024f955b224474bf668380558f8ce92ddf312520585be177b45",
       "producer_version": "unreleased-control-extension"
     },
@@ -76,7 +76,7 @@
       "quarantine": true,
       "authoritative": false,
       "base_commit": "eb4c599a5c1a24dbb270c39a5a513d78f253506d",
-      "generator_sha256": "sha256:4d509fca09db65ff715c073fe84b371983d50b7962ea6be5a0061e1ebdfa5e3c",
+      "generator_sha256": "sha256:e48d144298b96c7599eec354b3c2a8f5774491cba17526b0616e17d3414ee145",
       "schema_sha256": "sha256:f7ec8fcba3470024f955b224474bf668380558f8ce92ddf312520585be177b45",
       "producer_version": "unreleased-control-extension"
     },
@@ -90,7 +90,7 @@
       "quarantine": true,
       "authoritative": false,
       "base_commit": "eb4c599a5c1a24dbb270c39a5a513d78f253506d",
-      "generator_sha256": "sha256:4d509fca09db65ff715c073fe84b371983d50b7962ea6be5a0061e1ebdfa5e3c",
+      "generator_sha256": "sha256:e48d144298b96c7599eec354b3c2a8f5774491cba17526b0616e17d3414ee145",
       "schema_sha256": "sha256:f7ec8fcba3470024f955b224474bf668380558f8ce92ddf312520585be177b45",
       "producer_version": "unreleased-control-extension"
     },
@@ -104,7 +104,7 @@
       "quarantine": true,
       "authoritative": false,
       "base_commit": "eb4c599a5c1a24dbb270c39a5a513d78f253506d",
-      "generator_sha256": "sha256:4d509fca09db65ff715c073fe84b371983d50b7962ea6be5a0061e1ebdfa5e3c",
+      "generator_sha256": "sha256:e48d144298b96c7599eec354b3c2a8f5774491cba17526b0616e17d3414ee145",
       "schema_sha256": "sha256:f7ec8fcba3470024f955b224474bf668380558f8ce92ddf312520585be177b45",
       "producer_version": "unreleased-control-extension"
     },
@@ -128,7 +128,7 @@
       "quarantine": true,
       "authoritative": false,
       "base_commit": "eb4c599a5c1a24dbb270c39a5a513d78f253506d",
-      "generator_sha256": "sha256:4d509fca09db65ff715c073fe84b371983d50b7962ea6be5a0061e1ebdfa5e3c",
+      "generator_sha256": "sha256:e48d144298b96c7599eec354b3c2a8f5774491cba17526b0616e17d3414ee145",
       "schema_sha256": "sha256:f7ec8fcba3470024f955b224474bf668380558f8ce92ddf312520585be177b45",
       "producer_version": "unreleased-control-extension"
     },
@@ -151,7 +151,7 @@
       "quarantine": true,
       "authoritative": false,
       "base_commit": "eb4c599a5c1a24dbb270c39a5a513d78f253506d",
-      "generator_sha256": "sha256:4d509fca09db65ff715c073fe84b371983d50b7962ea6be5a0061e1ebdfa5e3c",
+      "generator_sha256": "sha256:e48d144298b96c7599eec354b3c2a8f5774491cba17526b0616e17d3414ee145",
       "schema_sha256": "sha256:f7ec8fcba3470024f955b224474bf668380558f8ce92ddf312520585be177b45",
       "producer_version": "unreleased-control-extension"
     },
@@ -165,7 +165,7 @@
       "quarantine": true,
       "authoritative": false,
       "base_commit": "eb4c599a5c1a24dbb270c39a5a513d78f253506d",
-      "generator_sha256": "sha256:4d509fca09db65ff715c073fe84b371983d50b7962ea6be5a0061e1ebdfa5e3c",
+      "generator_sha256": "sha256:e48d144298b96c7599eec354b3c2a8f5774491cba17526b0616e17d3414ee145",
       "schema_sha256": "sha256:f7ec8fcba3470024f955b224474bf668380558f8ce92ddf312520585be177b45",
       "producer_version": "unreleased-control-extension"
     },

--- a/testdata/action-contract-gate/v1/fixture-manifest.json
+++ b/testdata/action-contract-gate/v1/fixture-manifest.json
@@ -4,7 +4,7 @@
   "quarantine": true,
   "authoritative": false,
   "base_commit": "eb4c599a5c1a24dbb270c39a5a513d78f253506d",
-  "generator_sha256": "sha256:0601f41490f9e213f5b538f65779b21be920ad57717d7b47a83e23422df7df1e",
+  "generator_sha256": "sha256:cc328ff49b3ccccca27eca0b870b46877225c9a26a6fc0418c6c0454fa09f9f4",
   "approval_schema_sha256": "sha256:d95b9920068d16041e1871eaa5e94163d949a5e0e899a589171e415fb2727118",
   "delegation_schema_sha256": "sha256:ba89960f37fd48a948f6976098fa0b3087772537c8947e061afa1eafe5b87e53",
   "public_key_sha256": "sha256:ecd40e8a5fbcd1e73bfbd4bac1ad7693f1cacc1cb2ef8d51844fa675e61b78ee",


### PR DESCRIPTION
Summary:
- add narrow G304 justifications for explicit operator-provided paths
- document generator-rooted fixed paths and bounded filesystem-walk reads
- preserve existing token-file and capture boundary validation

Validation:
- go test ./core/gate ./core/effects ./core/actioncontract ./core/regress ./cmd/gait

This fixes the macOS-only gosec failure in main workflow run 32889126509.