### PR TITLE
chore: bump Proof dependency to v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - Added exact trace/proposal/activation digest binding, persistent token revocation checks, cross-process chain-state locking, and fail-closed containment/provider validation.
 
+### Changed
+
+- Updated the pinned `Clyra-AI/proof` dependency and runtime compatibility declaration to `v0.7.0`.
+
 ## [1.6.0] - 2026-08-25
 
 ### Added

--- a/core/actioncontract/runtime.go
+++ b/core/actioncontract/runtime.go
@@ -30,7 +30,7 @@ const (
 	RuntimeReadinessSchemaID           = "https://gait.dev/schemas/v1/runtime-readiness.schema.json"
 	RuntimeLifecycleSchemaID           = "https://gait.dev/schemas/v1/runtime-lifecycle-record.schema.json"
 	RuntimeLifecycleVersion            = "1"
-	ProofCompatibilityVersion          = "0.6.1"
+	ProofCompatibilityVersion          = "0.7.0"
 	CorrelationProfileVersion          = "1.0"
 )
 

--- a/docs/contracts/action_contract_activation.md
+++ b/docs/contracts/action_contract_activation.md
@@ -78,7 +78,7 @@ UTC `--evaluation-time` and policy-bound validator public key(s); a freeform
 validator name or signature string cannot authorize readiness. Evidence must
 be verified, digest-bound, timestamped, fresh within its max age, and carry
 non-empty evidence references. Wrkr declarations, judge/advisory, and
-self-attested results do not satisfy required checks. Proof v0.6.1
+self-attested results do not satisfy required checks. Proof v0.7.0
 digest-bound relationship refs and the correlation profile are retained on
 signed lifecycle records. Callers should use the verified reducer, which
 checks every record signature before reconstructing state without an event

--- a/docs/contracts/compatibility_matrix.md
+++ b/docs/contracts/compatibility_matrix.md
@@ -23,7 +23,7 @@ This matrix defines compatibility between producer and consumer surfaces.
 | --- | --- | --- | --- |
 | Wrkr `proposed_action_contract` `v1.14.0` -> Gait v1.4.0 | 1 | 3 | Gait validates one explicit report-only proposal; the committed activation compatibility pack covers valid scenarios with current-selection evidence; activations are separate signed artifacts and new revisions require reactivation |
 | Gait consumer receipt | 1 | n/a | Direct deterministic JSON receipt; `self_attestation=false`, no execution/effect claim |
-| Gait runtime classification/readiness/lifecycle | 1 | n/a | Additive pre-execution schemas; required readiness evidence is fail-closed, lifecycle records use Proof v0.6.1 relationship refs/correlation, and no surface claims execution/effect |
+| Gait runtime classification/readiness/lifecycle | 1 | n/a | Additive pre-execution schemas; required readiness evidence is fail-closed, lifecycle records use Proof v0.7.0 relationship refs/correlation, and no surface claims execution/effect |
 
 | Effect snapshot / contract / grade | 1.0.0 | 1.0.0 | Bounded before/after evidence with Proof JCS digests; pure `expect`/`forbid`/`invariant` grading is pass, fail, or inconclusive and never executes effects |
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/Clyra-AI/gait
 go 1.26.6
 
 require (
-	github.com/Clyra-AI/proof v0.6.1
+	github.com/Clyra-AI/proof v0.7.0
 	github.com/goccy/go-yaml v1.19.2
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/Clyra-AI/proof v0.6.1 h1:PtkfKoDgBsRT+aVMfucK3ree48vQz2E/JWVWhbBQbpY=
-github.com/Clyra-AI/proof v0.6.1/go.mod h1:oH/QMlmfi4mSlGSkXTjdk/DUIStow5KyxYEPiEamufk=
+github.com/Clyra-AI/proof v0.7.0 h1:jaBG+AjBGKysz3VpXPd1V4xCClz5ZYUUYXRcCR0JG+I=
+github.com/Clyra-AI/proof v0.7.0/go.mod h1:ytCmhLduSeWcVxBCGmZkC5amz6fq6ODB1lgwCK8u9ng=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
## Summary
- update the pinned Clyra-AI/proof module and sums to v0.7.0
- align runtime compatibility declaration, contract docs, and changelog

## Validation
- go test ./...
- go test ./core/actioncontract ./internal/integration ./internal/scenarios ./scripts/action_contract_authoritative_bundle_generator ./scripts/action_contract_fixture_generator -count=1
- make test-scenarios
- make test-docs-consistency
- git diff --check