### PR TITLE
fix: unblock nightly gosec scan

### DIFF
--- a/cmd/gait/actioncontract_lifecycle_result.go
+++ b/cmd/gait/actioncontract_lifecycle_result.go
@@ -148,7 +148,7 @@ func runActionContractLifecycleResult(args []string) int {
 		traceDigest = "sha256:" + traceDigest
 	}
 	if strings.TrimSpace(resultPath) != "" {
-		resultRaw, readErr := os.ReadFile(resultPath)
+		resultRaw, readErr := os.ReadFile(resultPath) // #nosec G304 -- explicit local lifecycle result artifact selected by the CLI operator.
 		if readErr != nil {
 			return lifecycleResultOutput(js, nil, readErr, exitInvalidInput)
 		}

--- a/cmd/gait/containment.go
+++ b/cmd/gait/containment.go
@@ -178,7 +178,7 @@ func runContainment(args []string) int {
 		if len(command) == 0 {
 			status = "partial"
 			reasons = append(reasons, "external_revocation_invalid")
-		} else if err := exec.CommandContext(ctx, command[0], command[1:]...).Run(); err != nil {
+		} else if err := exec.CommandContext(ctx, command[0], command[1:]...).Run(); err != nil { // #nosec G204 -- explicit operator-selected adapter command; executed without a shell.
 			status = "partial"
 			reasons = append(reasons, "external_revocation_failed")
 		} else {

--- a/scripts/action_contract_authoritative_bundle_generator/main.go
+++ b/scripts/action_contract_authoritative_bundle_generator/main.go
@@ -124,7 +124,7 @@ func generateBundle(root, out, tag, commit, workflow string) error {
 	if err != nil {
 		return err
 	}
-	activationRaw, err := os.ReadFile(filepath.Join(root, sourceActivation))
+	activationRaw, err := os.ReadFile(filepath.Join(root, sourceActivation)) // #nosec G304 -- release tool reads caller-selected local repository inputs.
 	if err != nil {
 		return err
 	}
@@ -158,7 +158,7 @@ func generateBundle(root, out, tag, commit, workflow string) error {
 	if err != nil {
 		return err
 	}
-	lifecycleRaw, err := os.ReadFile(filepath.Join(root, sourceLifecycle))
+	lifecycleRaw, err := os.ReadFile(filepath.Join(root, sourceLifecycle)) // #nosec G304 -- release tool reads caller-selected local repository inputs.
 	if err != nil {
 		return err
 	}
@@ -222,7 +222,7 @@ func generateBundle(root, out, tag, commit, workflow string) error {
 	}
 	sort.Strings(schemaPaths)
 	for _, schemaPath := range schemaPaths {
-		data, readErr := os.ReadFile(schemaPath)
+		data, readErr := os.ReadFile(schemaPath) // #nosec G304 -- schema paths are local repository files enumerated by this release tool.
 		if readErr != nil {
 			return readErr
 		}
@@ -257,7 +257,7 @@ func generateBundle(root, out, tag, commit, workflow string) error {
 }
 
 func releaseReadiness(path, contractID, policy string, private ed25519.PrivateKey, public ed25519.PublicKey) (actioncontract.ReadinessResult, []byte, error) {
-	raw, err := os.ReadFile(path)
+	raw, err := os.ReadFile(path) // #nosec G304 -- readiness artifact is an explicit local release-tool input.
 	if err != nil {
 		return actioncontract.ReadinessResult{}, nil, err
 	}
@@ -295,7 +295,7 @@ func releaseReadiness(path, contractID, policy string, private ed25519.PrivateKe
 }
 
 func readRuntimeAction(path string) (actioncontract.RuntimeAction, []byte, error) {
-	raw, err := os.ReadFile(path)
+	raw, err := os.ReadFile(path) // #nosec G304 -- runtime action is an explicit local release-tool input.
 	if err != nil {
 		return actioncontract.RuntimeAction{}, nil, err
 	}
@@ -459,7 +459,7 @@ func digestJCS(raw []byte) (string, error) {
 }
 
 func writeZip(path string, files map[string][]byte) error {
-	f, err := os.Create(path)
+	f, err := os.Create(path) // #nosec G304 -- output bundle path is explicitly selected by the local release operator.
 	if err != nil {
 		return err
 	}
@@ -493,7 +493,7 @@ func verifyBundle(path, expectedTag, expectedCommit, checksumsPath string) error
 	if strings.TrimSpace(checksumsPath) == "" {
 		return errors.New("caller-trusted signed checksums anchor is required")
 	}
-	checksumsRaw, err := os.ReadFile(checksumsPath)
+	checksumsRaw, err := os.ReadFile(checksumsPath) // #nosec G304 -- signed checksums anchor is an explicit local release-tool input.
 	if err != nil {
 		return fmt.Errorf("read checksums anchor: %w", err)
 	}
@@ -579,7 +579,7 @@ func verifyBundle(path, expectedTag, expectedCommit, checksumsPath string) error
 			return fmt.Errorf("artifact digest mismatch: %s", entry.Path)
 		}
 	}
-	bundleRaw, err := os.ReadFile(path)
+	bundleRaw, err := os.ReadFile(path) // #nosec G304 -- bundle path is an explicit local release-tool input.
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Problem
Scheduled Linux and Windows nightlies both fail in `make lint` because gosec reports one intentional external-adapter command execution and nine intentional local release/CLI file-path operations.

## Changes
- Document the reviewed operator-controlled command boundary with a narrow G204 suppression.
- Document the reviewed local artifact and release-tool file paths with narrow G304 suppressions.

## Validation
- `GOCACHE=/private/tmp/gait-nightly-gosec-cache-verify make lint`
- `GOCACHE=/private/tmp/gait-nightly-gosec-cache-verify make prepush-full`
- Push hook: `make prepush`

## Risk
Runtime behavior is unchanged. Each suppression records why the input is an explicit local operator or release-tool choice; no scanner findings remain.

## Submodules
No submodule changes; `factory` remains uninitialized and clean.
